### PR TITLE
fix(install.ps1): handle git clone stderr on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -82,7 +82,16 @@ $keepTemp = ($env:CLAUDE_SEO_KEEP_TEMP -eq '1')
 
 try {
     Write-Host "↓ Downloading Claude SEO..." -ForegroundColor Yellow
-    $clone = Invoke-External -Exe 'git' -Args @('clone','--depth','1',$RepoUrl,$TempDir) -Quiet
+    # Git writes progress to stderr; with ErrorActionPreference=Stop this can be
+    # treated as a terminating error in Windows PowerShell. Run clone under
+    # Continue and restore the original preference immediately after.
+    $prevErrorAction = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $clone = Invoke-External -Exe 'git' -Args @('clone','--depth','1',$RepoUrl,$TempDir) -Quiet
+    } finally {
+        $ErrorActionPreference = $prevErrorAction
+    }
     if ($clone.ExitCode -ne 0) {
         throw "git clone failed. Output:`n$($clone.Output -join "`n")"
     }


### PR DESCRIPTION
Temporarily set ErrorActionPreference to Continue for the git clone call so PowerShell does not terminate on git progress written to stderr.

Made-with: Cursor