### PR TITLE
Fix URL normalization in Playwright helper scripts

### DIFF
--- a/scripts/analyze_visual.py
+++ b/scripts/analyze_visual.py
@@ -11,13 +11,28 @@ import ipaddress
 import json
 import socket
 import sys
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 try:
     from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
 except ImportError:
     print("Error: playwright required. Install with: pip install playwright && playwright install chromium")
     sys.exit(1)
+
+
+def normalize_url(url: str) -> tuple[str, ParseResult]:
+    """Normalize URL and return (url, parsed_url)."""
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"https://{url}"
+        parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Invalid URL scheme: {parsed.scheme}")
+    if not parsed.hostname:
+        raise ValueError("Invalid URL: missing hostname")
+
+    return url, parsed
 
 
 def analyze_visual(url: str, timeout: int = 30000) -> dict:
@@ -54,15 +69,21 @@ def analyze_visual(url: str, timeout: int = 30000) -> dict:
         "error": None,
     }
 
+    try:
+        url, parsed = normalize_url(url)
+        result["url"] = url
+    except ValueError as e:
+        result["error"] = str(e)
+        return result
+
     # SSRF prevention: block private/internal IPs
     try:
-        parsed = urlparse(url)
         resolved_ip = socket.gethostbyname(parsed.hostname)
         ip = ipaddress.ip_address(resolved_ip)
         if ip.is_private or ip.is_loopback or ip.is_reserved:
             result["error"] = f"Blocked: URL resolves to private/internal IP ({resolved_ip})"
             return result
-    except (socket.gaierror, ValueError):
+    except socket.gaierror:
         pass
 
     try:
@@ -138,13 +159,15 @@ def analyze_visual(url: str, timeout: int = 30000) -> dict:
             result["mobile"]["horizontal_scroll"] = scroll_width > viewport_width
 
             # Check font size
-            base_font_size = page.evaluate("""
+            base_font_size = page.evaluate(
+                """
                 () => {
                     const body = document.body;
                     const style = window.getComputedStyle(body);
                     return parseFloat(style.fontSize);
                 }
-            """)
+            """
+            )
             result["fonts"]["base_size"] = base_font_size
             result["fonts"]["readable"] = base_font_size >= 16
 

--- a/scripts/capture_screenshot.py
+++ b/scripts/capture_screenshot.py
@@ -13,7 +13,7 @@ import ipaddress
 import os
 import socket
 import sys
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 try:
     from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
@@ -28,6 +28,21 @@ VIEWPORTS = {
     "tablet": {"width": 768, "height": 1024},
     "mobile": {"width": 375, "height": 812},
 }
+
+
+def normalize_url(url: str) -> tuple[str, ParseResult]:
+    """Normalize URL and return (url, parsed_url)."""
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"https://{url}"
+        parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Invalid URL scheme: {parsed.scheme}")
+    if not parsed.hostname:
+        raise ValueError("Invalid URL: missing hostname")
+
+    return url, parsed
 
 
 def capture_screenshot(
@@ -62,15 +77,21 @@ def capture_screenshot(
         result["error"] = f"Invalid viewport: {viewport}. Choose from: {list(VIEWPORTS.keys())}"
         return result
 
+    try:
+        url, parsed = normalize_url(url)
+        result["url"] = url
+    except ValueError as e:
+        result["error"] = str(e)
+        return result
+
     # SSRF prevention: block private/internal IPs
     try:
-        parsed = urlparse(url)
         resolved_ip = socket.gethostbyname(parsed.hostname)
         ip = ipaddress.ip_address(resolved_ip)
         if ip.is_private or ip.is_loopback or ip.is_reserved:
             result["error"] = f"Blocked: URL resolves to private/internal IP ({resolved_ip})"
             return result
-    except (socket.gaierror, ValueError):
+    except socket.gaierror:
         pass
 
     vp = VIEWPORTS[viewport]
@@ -126,9 +147,14 @@ def main():
     # Create output directory
     os.makedirs(args.output, exist_ok=True)
 
+    try:
+        normalized_url, parsed_url = normalize_url(args.url)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
     # Generate filename from URL
-    parsed = urlparse(args.url)
-    base_name = parsed.netloc.replace(".", "_")
+    base_name = parsed_url.netloc.replace(".", "_")
 
     viewports = VIEWPORTS.keys() if args.all else [args.viewport]
 
@@ -138,7 +164,7 @@ def main():
 
         print(f"Capturing {viewport} screenshot...")
         result = capture_screenshot(
-            args.url,
+            normalized_url,
             output_path,
             viewport=viewport,
             full_page=args.full,


### PR DESCRIPTION
## What changed
- Added URL normalization in `scripts/capture_screenshot.py` and `scripts/analyze_visual.py` so inputs like `example.com` are treated as `https://example.com`.
- Added explicit URL validation (scheme + hostname) with clear error messages for invalid inputs.
- Updated screenshot filename generation to use the normalized URL host, preventing empty/invalid output names when the scheme is omitted.

## Why
- Both Playwright helper scripts previously assumed the input URL already included a scheme.
- Passing a bare domain could fail early in hostname resolution or produce poor output behavior.
- This makes the CLI tools more robust for common usage while keeping behavior unchanged for valid `http(s)` URLs.

## Testing
- `scripts/clone_and_test.sh AgriciDaniel/claude-seo`
- Tests: not run (no tests found)
- `.venv/bin/python - <<'PY' ...` (smoke-checked `normalize_url` for bare-domain and invalid-scheme inputs)
