### PR TITLE
fix stuck extension install

### DIFF
--- a/extensions/banana/install.sh
+++ b/extensions/banana/install.sh
@@ -146,9 +146,9 @@ print('  ✓ nanobanana-mcp configured in settings.json')
     cp "${SOURCE_DIR}/scripts/"*.py "${SKILL_DIR}/scripts/"
     cp "${SOURCE_DIR}/references/"*.md "${SKILL_DIR}/references/"
 
-    # Pre-warm npx package
+    # Pre-warm npm package without starting the MCP server binary.
     echo "→ Pre-downloading nanobanana-mcp..."
-    npx -y @ycse/nanobanana-mcp@latest --help >/dev/null 2>&1 || true
+    npx --yes --package=@ycse/nanobanana-mcp@latest -- node -e "" >/dev/null 2>&1 || true
 
     echo ""
     echo "✓ Banana Image Generation extension installed successfully!"

--- a/extensions/dataforseo/install.sh
+++ b/extensions/dataforseo/install.sh
@@ -139,9 +139,9 @@ print('  ✓ MCP server configured in settings.json')
         echo "  See: extensions/dataforseo/docs/DATAFORSEO-SETUP.md"
     }
 
-    # Pre-warm npx package
+    # Pre-warm npm package without starting the MCP server binary.
     echo "→ Pre-downloading dataforseo-mcp-server..."
-    npx -y dataforseo-mcp-server --help >/dev/null 2>&1 || true
+    npx --yes --package=dataforseo-mcp-server -- node -e "" >/dev/null 2>&1 || true
 
     echo ""
     echo "✓ DataForSEO extension installed successfully!"

--- a/extensions/firecrawl/install.sh
+++ b/extensions/firecrawl/install.sh
@@ -119,9 +119,9 @@ print('  v MCP server configured in settings.json')
         echo "  See: extensions/firecrawl/docs/FIRECRAWL-SETUP.md"
     }
 
-    # Pre-warm npx package
+    # Pre-warm npm package without starting the MCP server binary.
     echo "-> Pre-downloading firecrawl-mcp..."
-    npx -y firecrawl-mcp --help >/dev/null 2>&1 || true
+    npx --yes --package=firecrawl-mcp -- node -e "" >/dev/null 2>&1 || true
 
     echo ""
     echo "v Firecrawl extension installed successfully!"


### PR DESCRIPTION
## Summary
Avoid getting stuck at this step:
→ Installing DataForSEO skill...
→ Installing DataForSEO agent...
→ Installing field config...
→ Configuring MCP server...
  ✓ MCP server configured in settings.json
→ Pre-downloading dataforseo-mcp-server...

## Type of Change

- [X] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [X] Tested with a real URL before submitting
- [X] SKILL.md files stay under 500 lines (if modified)
- [X] Python scripts output JSON (if modified)
- [X] Reference files stay under 200 lines (if modified)
- [X] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change
