### PR TITLE
fix: add missing marketplace registration step to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Comprehensive SEO analysis skill for Claude Code. Covers technical SEO, on-page 
 ### Plugin Install (Claude Code 1.0.33+)
 
 ```bash
+claude plugin marketplace add AgriciDaniel/claude-seo
 claude plugin install claude-seo@claude-seo-marketplace
 ```
 


### PR DESCRIPTION
## Summary

The plugin install instructions in README.md were missing the prerequisite `claude plugin marketplace add` step. Without first registering the marketplace, `claude plugin install claude-seo@claude-seo-marketplace` fails with "Plugin not found in marketplace" (see #42).

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)