### PR TITLE
Correct sub-skills count in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Direct integration with Google's SEO data:
 
 ```
 ~/.claude/skills/seo/         # Main orchestrator skill
-~/.claude/skills/seo-*/       # Sub-skills (15 + 2 extensions)
+~/.claude/skills/seo-*/       # Sub-skills (16 + 2 extensions)
 ~/.claude/agents/seo-*.md     # Subagents (10 + 2 extensions)
 ```
 


### PR DESCRIPTION
If I counted correctly, there are 18 total (probably 16+2) seo-* sub skills

## Summary

Correct sub-skills count in README

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [✓] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [✓] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [✓] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [skipped] CHANGELOG.md updated with the change
