### PR TITLE
fix: resolve script paths for cross-directory execution and macOS SSL

### DIFF
--- a/agents/seo-content.md
+++ b/agents/seo-content.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Write, Grep
 
 You are a Content Quality specialist following Google's September 2025 Quality Rater Guidelines.
 
-When given content to analyze:
+When given content to analyze, always fetch pages with `fetch_page.py --extract` to get compact SEO-relevant text (meta tags, schema, headings, body content, images, links). Only use raw HTML when you need full markup context.
 
 1. Assess E-E-A-T signals (Experience, Expertise, Authoritativeness, Trustworthiness)
 2. Check word count against page type minimums

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -8,7 +8,7 @@ tools: Read, Bash, WebFetch, Glob, Grep
 
 You are a Generative Engine Optimization (GEO) specialist. When given a URL:
 
-1. Fetch the page and check robots.txt for AI crawler rules
+1. Fetch the page with `fetch_page.py --extract` for content/citability analysis. Use raw HTML only for robots.txt and AI crawler header checks.
 2. Check for `/llms.txt` and RSL 1.0 licensing
 3. Analyze content citability (passage length, structure, directness)
 4. Evaluate authority signals (authorship, dates, citations, entity presence)

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -8,7 +8,10 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 
 You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 
-1. Check credentials: `python scripts/google_auth.py --check --json`
+**Python:** `~/.claude/skills/seo/.venv/bin/python`
+**Scripts:** `~/.claude/skills/seo/scripts/`
+
+1. Check credentials: `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/google_auth.py --check --json`
 2. Determine tier (0 = API key, 1 = + service account, 2 = + GA4)
 3. Execute tier-appropriate analysis
 4. Format output to match claude-seo conventions
@@ -16,20 +19,20 @@ You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 ## Tier-Based Workflow
 
 ### Tier 0 (API Key Only)
-- Run PSI + CrUX on homepage: `python scripts/pagespeed_check.py <url> --json`
-- Run CrUX History for origin: `python scripts/crux_history.py <origin> --origin --json`
+- Run PSI + CrUX on homepage: `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/pagespeed_check.py <url> --json`
+- Run CrUX History for origin: `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/crux_history.py <origin> --origin --json`
 - Report CWV field data with traffic-light ratings
 
 ### Tier 1 (+ Service Account)
 - All Tier 0 checks
-- GSC top queries/pages (28 days): `python scripts/gsc_query.py --property <prop> --json`
-- URL Inspection on homepage + key pages: `python scripts/gsc_inspect.py <url> --json`
-- GSC sitemap status: `python scripts/gsc_query.py sitemaps --property <prop> --json`
+- GSC top queries/pages (28 days): `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/gsc_query.py --property <prop> --json`
+- URL Inspection on homepage + key pages: `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/gsc_inspect.py <url> --json`
+- GSC sitemap status: `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/gsc_query.py sitemaps --property <prop> --json`
 
 ### Tier 2 (Full)
 - All Tier 1 checks
-- GA4 organic traffic (28 days): `python scripts/ga4_report.py --property <id> --json`
-- Top organic landing pages: `python scripts/ga4_report.py --property <id> --report top-pages --json`
+- GA4 organic traffic (28 days): `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/ga4_report.py --property <id> --json`
+- Top organic landing pages: `~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/ga4_report.py --property <id> --report top-pages --json`
 
 ## Core Web Vitals Thresholds
 
@@ -56,7 +59,7 @@ After completing data collection at any tier, ALWAYS offer to generate a PDF rep
 The report uses the enterprise template: white cover, navy accents, Times New Roman, charts at 85% width, Google logo on title page. No page-break-inside: avoid (causes white gaps).
 
 ```bash
-python scripts/google_report.py --type full --data data.json --domain DOMAIN --format pdf --json
+~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/google_report.py --type full --data data.json --domain DOMAIN --format pdf --json
 ```
 Report types: `cwv-audit`, `gsc-performance`, `indexation`, `full`.
 Before presenting: verify `"review": {"status": "PASS"}` in the JSON output.

--- a/agents/seo-local.md
+++ b/agents/seo-local.md
@@ -8,7 +8,7 @@ tools: Read, Bash, WebFetch, Glob, Grep, Write
 
 You are a Local SEO specialist. When given a URL:
 
-1. Fetch the page and detect business type (brick-and-mortar, SAB, or hybrid) from address visibility, service area language, and Maps embeds
+1. Fetch the page with `fetch_page.py --extract` for compact analysis (meta tags, schema, headings, content, images, links). Use raw HTML only for Maps embed detection or specific markup inspection. (brick-and-mortar, SAB, or hybrid) from address visibility, service area language, and Maps embeds
 2. Detect industry vertical (restaurant, healthcare, legal, home services, real estate, automotive) from page content signals
 3. Extract NAP (Name, Address, Phone) from visible HTML, JSON-LD schema, and meta tags -- flag any discrepancies between sources
 4. Validate LocalBusiness schema: correct industry subtype, required properties (name, address), recommended properties (geo with 5 decimal precision, openingHoursSpecification, telephone, url)

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -25,7 +25,7 @@ Google evaluates the **75th percentile** of page visits, 75% of visits must meet
 ## When Analyzing Performance
 
 1. Use PageSpeed Insights API if available
-2. Otherwise, analyze HTML source for common issues
+2. Otherwise, analyze HTML source for common issues (use raw `fetch_page.py` without `--extract` for performance analysis — you need full markup to detect render-blocking resources, script loading patterns, and image optimization)
 3. Provide specific, actionable optimization recommendations
 4. Prioritize by expected impact
 

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -75,8 +75,8 @@ npx lighthouse URL --output json
 
 If Google API credentials are configured, prefer CrUX field data over Lighthouse lab data for CWV assessment:
 ```bash
-python scripts/pagespeed_check.py URL --json
-python scripts/crux_history.py URL --json
+~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/pagespeed_check.py URL --json
+~/.claude/skills/seo/.venv/bin/python ~/.claude/skills/seo/scripts/crux_history.py URL --json
 ```
 Field data (28-day Chrome user average) is more representative than lab data (single Lighthouse run). Use lab data as fallback when CrUX returns 404 (insufficient traffic).
 

--- a/agents/seo-schema.md
+++ b/agents/seo-schema.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Write
 
 You are a Schema.org markup specialist.
 
-When analyzing pages:
+When analyzing pages, use `fetch_page.py --extract` which includes all JSON-LD blocks in the `=== SCHEMA JSON-LD ===` section. Use raw HTML only when checking for Microdata/RDFa attributes.
 
 1. Detect all existing schema (JSON-LD, Microdata, RDFa)
 2. Validate against Google's supported rich result types

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 
 You are a Technical SEO specialist. When given a URL or set of URLs:
 
-1. Fetch the page(s) and analyze HTML source
+1. Fetch the page(s) using `fetch_page.py --extract` for content analysis. Use raw HTML (without `--extract`) only when checking `<head>` elements like render-blocking resources, security headers, or prerender detection.
 2. Check robots.txt and sitemap availability
 3. Analyze meta tags, canonical tags, and security headers
 4. Evaluate URL structure and redirect chains

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ playwright>=1.56.0,<2.0.0         # CVE-2025-59288 fix (macOS)
 Pillow>=12.1.0,<13.0.0            # CVE-2025-48379 fix
 urllib3>=2.6.3,<3.0.0             # CRITICAL: CVE-2026-21441 (CVSS 8.9), CVE-2025-66418
 validators>=0.22.0,<1.0.0         # No known CVEs
+pip-system-certs>=5.0,<6.0.0     # Use OS cert store (fixes macOS SSL with Homebrew Python)
 
 # Report generation (for seo-google PDF/Excel reports)
 matplotlib>=3.8.0,<4.0.0              # No known CVEs

--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -5,14 +5,18 @@ Fetch a web page with proper headers and error handling.
 Usage:
     python fetch_page.py https://example.com
     python fetch_page.py https://example.com --output page.html
+    python fetch_page.py https://example.com --extract
+    python fetch_page.py https://example.com --extract -o extracted.txt
 """
 
 import argparse
 import ipaddress
+import json
+import re
 import socket
 import sys
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 
 try:
     import requests
@@ -141,6 +145,153 @@ def fetch_page(
     return result
 
 
+def extract_seo_content(html: str, url: str) -> str:
+    """
+    Extract SEO-relevant content from raw HTML.
+
+    Strips ~95% of bloat (scripts, styles, WordPress markup) while preserving
+    all data needed for SEO analysis: meta tags, schema, headings, body text,
+    images, and internal links.
+    """
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError:
+        return "Error: beautifulsoup4 required for --extract. Install with: pip install beautifulsoup4"
+
+    soup = BeautifulSoup(html, "html.parser")
+    parsed_url = urlparse(url)
+    base_domain = parsed_url.netloc
+    sections = []
+
+    # --- 1. Meta Tags ---
+    meta_lines = []
+    title_tag = soup.find("title")
+    if title_tag and title_tag.string:
+        meta_lines.append(f"  title: {title_tag.string.strip()}")
+
+    html_tag = soup.find("html")
+    if html_tag and html_tag.get("lang"):
+        meta_lines.append(f"  lang: {html_tag['lang']}")
+
+    meta_names = ["description", "robots", "viewport", "author", "generator"]
+    for name in meta_names:
+        tag = soup.find("meta", attrs={"name": name})
+        if tag and tag.get("content"):
+            meta_lines.append(f"  {name}: {tag['content']}")
+
+    canonical = soup.find("link", attrs={"rel": "canonical"})
+    if canonical and canonical.get("href"):
+        meta_lines.append(f"  canonical: {canonical['href']}")
+
+    # OG tags
+    for og in soup.find_all("meta", attrs={"property": re.compile(r"^og:")}):
+        if og.get("content"):
+            meta_lines.append(f"  {og['property']}: {og['content']}")
+
+    # Twitter cards
+    for tw in soup.find_all("meta", attrs={"name": re.compile(r"^twitter:")}):
+        if tw.get("content"):
+            meta_lines.append(f"  {tw['name']}: {tw['content']}")
+
+    # Hreflang
+    for hl in soup.find_all("link", attrs={"rel": "alternate", "hreflang": True}):
+        meta_lines.append(f"  hreflang[{hl['hreflang']}]: {hl.get('href', '')}")
+
+    if meta_lines:
+        sections.append("=== META TAGS ===\n" + "\n".join(meta_lines))
+
+    # --- 2. Schema JSON-LD ---
+    schema_blocks = []
+    for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        if script.string:
+            try:
+                data = json.loads(script.string)
+                schema_blocks.append(json.dumps(data, indent=2, ensure_ascii=False))
+            except json.JSONDecodeError:
+                schema_blocks.append(script.string.strip())
+    if schema_blocks:
+        sections.append("=== SCHEMA JSON-LD ===\n" + "\n---\n".join(schema_blocks))
+
+    # --- Remove noise before content extraction ---
+    for tag in soup.find_all(["script", "style", "noscript", "svg", "iframe"]):
+        tag.decompose()
+
+    # --- 3. Heading Structure ---
+    heading_lines = []
+    for level in range(1, 7):
+        for h in soup.find_all(f"h{level}"):
+            text = h.get_text(separator=" ", strip=True)
+            if text:
+                indent = "  " * (level - 1)
+                heading_lines.append(f"{indent}h{level}: {text}")
+    if heading_lines:
+        sections.append("=== HEADINGS ===\n" + "\n".join(heading_lines))
+
+    # --- 4. Body Content ---
+    content_container = (
+        soup.find("main")
+        or soup.find("article")
+        or soup.find(id="content")
+        or soup.find(class_="content")
+        or soup.find("body")
+    )
+    content_lines = []
+    if content_container:
+        for el in content_container.find_all(
+            ["p", "li", "td", "blockquote", "figcaption"]
+        ):
+            text = el.get_text(separator=" ", strip=True)
+            if len(text) >= 20:
+                content_lines.append(text)
+    if content_lines:
+        sections.append("=== BODY CONTENT ===\n" + "\n".join(content_lines))
+
+    # --- 5. Images ---
+    seen_srcs = set()
+    image_lines = []
+    for img in soup.find_all("img"):
+        src = img.get("src") or img.get("data-src") or ""
+        if not src or src in seen_srcs:
+            continue
+        seen_srcs.add(src)
+        parts = [f"src={src}"]
+        alt = img.get("alt", "")
+        parts.append(f'alt="{alt}"')
+        for attr in ("width", "height", "loading"):
+            val = img.get(attr)
+            if val:
+                parts.append(f"{attr}={val}")
+        image_lines.append("  " + " | ".join(parts))
+    if image_lines:
+        sections.append("=== IMAGES ===\n" + "\n".join(image_lines))
+
+    # --- 6. Internal Links ---
+    seen_hrefs = set()
+    link_lines = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        # Resolve relative URLs
+        full_url = urljoin(url, href)
+        parsed_link = urlparse(full_url)
+        # Only internal links
+        if parsed_link.netloc and parsed_link.netloc != base_domain:
+            continue
+        # Normalize
+        normalized = parsed_link.path.rstrip("/") or "/"
+        if normalized in seen_hrefs:
+            continue
+        seen_hrefs.add(normalized)
+        anchor = a.get_text(separator=" ", strip=True)
+        if anchor:
+            link_lines.append(f"  {anchor} -> {normalized}")
+        else:
+            link_lines.append(f"  [no text] -> {normalized}")
+    if link_lines:
+        sections.append("=== INTERNAL LINKS ===\n" + "\n".join(link_lines))
+
+    return "\n\n".join(sections)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Fetch a web page for SEO analysis")
     parser.add_argument("url", help="URL to fetch")
@@ -154,6 +305,15 @@ def main():
         help=(
             "Use Googlebot UA to detect dynamic rendering / prerender services. "
             "Compare response size with default UA to identify SPA prerender configuration."
+        ),
+    )
+    parser.add_argument(
+        "--extract",
+        action="store_true",
+        help=(
+            "Extract SEO-relevant content instead of raw HTML. "
+            "Returns meta tags, schema JSON-LD, headings, body text, images, "
+            "and internal links. ~95%% size reduction."
         ),
     )
 
@@ -174,12 +334,16 @@ def main():
         print(f"Error: {result['error']}", file=sys.stderr)
         sys.exit(1)
 
+    output = result["content"]
+    if args.extract:
+        output = extract_seo_content(result["content"], result["url"])
+
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
-            f.write(result["content"])
-        print(f"Saved to {args.output}")
+            f.write(output)
+        print(f"Saved to {args.output}", file=sys.stderr)
     else:
-        print(result["content"])
+        print(output)
 
     # Print metadata to stderr
     print(f"\nURL: {result['url']}", file=sys.stderr)

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 
 ## Process
 
-1. **Fetch homepage**: use `scripts/fetch_page.py` to retrieve HTML
+1. **Fetch homepage**: use `${CLAUDE_SKILL_DIR}/../seo/scripts/fetch_page.py` to retrieve HTML
 2. **Detect business type**: analyze homepage signals per seo orchestrator
 3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt
 4. **Delegate to subagents** (if available, otherwise run inline sequentially):
@@ -31,7 +31,7 @@ metadata:
    - `seo-geo` -- AI crawler access, llms.txt, citability, brand mention signals
    - `seo-local` -- GBP signals, NAP consistency, reviews, local schema, industry-specific local factors (spawn when Local Service industry detected: brick-and-mortar, SAB, or hybrid business type)
    - `seo-maps` -- Geo-grid rank tracking, GBP audit, review intelligence, competitor radius mapping (spawn when Local Service detected AND DataForSEO MCP available)
-   - `seo-google` -- CWV field data (CrUX), URL indexation (GSC), organic traffic (GA4) (spawn when Google API credentials detected via `python scripts/google_auth.py --check`)
+   - `seo-google` -- CWV field data (CrUX), URL indexation (GSC), organic traffic (GA4) (spawn when Google API credentials detected via `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_auth.py --check`)
 5. **Score** -- aggregate into SEO Health Score (0-100)
 6. **Report** -- generate prioritized action plan
 
@@ -51,7 +51,7 @@ Delay between requests: 1 second
 - `FULL-AUDIT-REPORT.md`: Comprehensive findings
 - `ACTION-PLAN.md`: Prioritized recommendations (Critical > High > Medium > Low)
 - `screenshots/`: Desktop + mobile captures (if Playwright available)
-- **PDF Report** (recommended): Generate a professional A4 PDF using `scripts/google_report.py --type full`. This produces a white-cover enterprise report with TOC, executive summary, charts (Lighthouse gauges, query bars, index donut), metric cards, threshold tables, prioritized recommendations with effort estimates, and implementation roadmap. Always offer PDF generation after completing an audit.
+- **PDF Report** (recommended): Generate a professional A4 PDF using `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_report.py --type full`. This produces a white-cover enterprise report with TOC, executive summary, charts (Lighthouse gauges, query bars, index donut), metric cards, threshold tables, prioritized recommendations with effort estimates, and implementation roadmap. Always offer PDF generation after completing an audit.
 
 ## Scoring Weights
 
@@ -124,7 +124,7 @@ If DataForSEO MCP tools are available, spawn the `seo-dataforseo` agent alongsid
 
 ## Google API Integration (Optional)
 
-If Google API credentials are configured (`python scripts/google_auth.py --check`), spawn the `seo-google` agent to enrich the audit with real Google field data: CrUX Core Web Vitals (replaces lab-only estimates), GSC URL indexation status, search performance (clicks, impressions, CTR), and GA4 organic traffic trends. The Performance (CWV) category score benefits most from field data.
+If Google API credentials are configured (`${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_auth.py --check`), spawn the `seo-google` agent to enrich the audit with real Google field data: CrUX Core Web Vitals (replaces lab-only estimates), GSC URL indexation status, search performance (clicks, impressions, CTR), and GA4 organic traffic trends. The Performance (CWV) category score benefits most from field data.
 
 ## Error Handling
 

--- a/skills/seo-google/SKILL.md
+++ b/skills/seo-google/SKILL.md
@@ -27,11 +27,17 @@ Chrome user metrics, real indexation status, search performance, and organic tra
 All APIs are free. Setup requires a Google Cloud project with API key and/or
 service account -- run `/seo google setup` for step-by-step instructions.
 
+## Script Execution
+
+Scripts and venv live in the parent `seo` skill directory. All script commands use:
+- **Python:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python`
+- **Scripts:** `${CLAUDE_SKILL_DIR}/../seo/scripts/`
+
 ## Prerequisites
 
 Before executing any command, check credentials:
 ```bash
-python scripts/google_auth.py --check --json
+${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_auth.py --check --json
 ```
 
 Config file: `~/.config/claude-seo/google-api.json`
@@ -91,7 +97,7 @@ Always communicate the detected tier before running commands.
 
 Combined Lighthouse lab data + CrUX field data.
 
-**Script:** `python scripts/pagespeed_check.py <url> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/pagespeed_check.py <url> --json`
 **Reference:** `references/pagespeed-crux-api.md`
 **Default:** Both mobile + desktop strategies, all Lighthouse categories.
 
@@ -102,13 +108,13 @@ Chrome user metrics). CrUX tries URL-level first, falls back to origin-level.
 
 CrUX field data only (no Lighthouse run). Faster.
 
-**Script:** `python scripts/pagespeed_check.py <url> --crux-only --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/pagespeed_check.py <url> --crux-only --json`
 
 ### `/seo google crux-history <url>`
 
 25-week CrUX History trends. Shows whether CWV metrics are improving, stable, or degrading.
 
-**Script:** `python scripts/crux_history.py <url> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/crux_history.py <url> --json`
 **Reference:** `references/pagespeed-crux-api.md`
 
 Output includes per-metric trend direction, percentage change, and weekly p75 values.
@@ -121,7 +127,7 @@ Output includes per-metric trend direction, percentage change, and weekly p75 va
 
 Search Analytics: clicks, impressions, CTR, position for last 28 days.
 
-**Script:** `python scripts/gsc_query.py --property <property> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/gsc_query.py --property <property> --json`
 **Reference:** `references/search-console-api.md`
 **Default:** 28 days, dimensions=query,page, type=web, limit=1000.
 
@@ -131,7 +137,7 @@ Includes quick-win detection: queries at position 4-10 with high impressions.
 
 URL Inspection: real indexation status from Google.
 
-**Script:** `python scripts/gsc_inspect.py <url> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/gsc_inspect.py <url> --json`
 
 Returns: verdict (PASS/FAIL), coverage state, robots.txt status, indexing state,
 page fetch state, canonical selection, mobile usability, rich results.
@@ -140,13 +146,13 @@ page fetch state, canonical selection, mobile usability, rich results.
 
 Batch inspection from a file (one URL per line). Rate limited to 2,000/day per site.
 
-**Script:** `python scripts/gsc_inspect.py --batch <file> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/gsc_inspect.py --batch <file> --json`
 
 ### `/seo google sitemaps <property>`
 
 List submitted sitemaps with status, errors, warnings.
 
-**Script:** `python scripts/gsc_query.py sitemaps --property <property> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/gsc_query.py sitemaps --property <property> --json`
 
 ---
 
@@ -156,7 +162,7 @@ List submitted sitemaps with status, errors, warnings.
 
 Notify Google of a URL update.
 
-**Script:** `python scripts/indexing_notify.py <url> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/indexing_notify.py <url> --json`
 **Reference:** `references/indexing-api.md`
 
 The Indexing API is officially for JobPosting and BroadcastEvent/VideoObject pages.
@@ -166,7 +172,7 @@ Always inform the user of this restriction. Daily quota: 200 publish requests.
 
 Batch submit URLs from a file. Tracks quota usage.
 
-**Script:** `python scripts/indexing_notify.py --batch <file> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/indexing_notify.py --batch <file> --json`
 
 ---
 
@@ -176,7 +182,7 @@ Batch submit URLs from a file. Tracks quota usage.
 
 Organic traffic report: daily sessions, users, pageviews, bounce rate, engagement.
 
-**Script:** `python scripts/ga4_report.py --property <id> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/ga4_report.py --property <id> --json`
 **Reference:** `references/ga4-data-api.md`
 **Default:** 28 days, filtered to Organic Search channel group.
 
@@ -184,7 +190,7 @@ Organic traffic report: daily sessions, users, pageviews, bounce rate, engagemen
 
 Top organic landing pages ranked by sessions.
 
-**Script:** `python scripts/ga4_report.py --property <id> --report top-pages --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/ga4_report.py --property <id> --report top-pages --json`
 
 ---
 
@@ -196,7 +202,7 @@ YouTube mentions have the strongest AI visibility correlation (0.737). Free, API
 
 Search YouTube for videos. Returns title, channel, views, likes, duration.
 
-**Script:** `python scripts/youtube_search.py search "<query>" --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/youtube_search.py search "<query>" --json`
 **Reference:** `references/youtube-api.md`
 **Quota:** 100 units per search (10,000 units/day free).
 
@@ -204,7 +210,7 @@ Search YouTube for videos. Returns title, channel, views, likes, duration.
 
 Detailed video info + tags + top 10 comments.
 
-**Script:** `python scripts/youtube_search.py video <video_id> --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/youtube_search.py video <video_id> --json`
 **Quota:** 2 units (video details + comments).
 
 ---
@@ -217,7 +223,7 @@ Google's own entity/sentiment analysis. Enhances E-E-A-T scoring.
 
 Full NLP analysis: entities, sentiment, content classification.
 
-**Script:** `python scripts/nlp_analyze.py --url <url> --json` or `--text "..."`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/nlp_analyze.py --url <url> --json` or `--text "..."`
 **Reference:** `references/nlp-api.md`
 **Free tier:** 5,000 units/month. Requires billing enabled on GCP project.
 
@@ -225,7 +231,7 @@ Full NLP analysis: entities, sentiment, content classification.
 
 Entity extraction only (faster, less quota).
 
-**Script:** `python scripts/nlp_analyze.py --url <url> --features entities --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/nlp_analyze.py --url <url> --features entities --json`
 
 ---
 
@@ -237,7 +243,7 @@ Gold-standard keyword volume data. Requires Google Ads account.
 
 Generate keyword ideas from seed terms.
 
-**Script:** `python scripts/keyword_planner.py ideas "<seed>" --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/keyword_planner.py ideas "<seed>" --json`
 **Reference:** `references/keyword-planner-api.md`
 **Requires:** Ads developer token + customer ID in config (Tier 3).
 
@@ -245,7 +251,7 @@ Generate keyword ideas from seed terms.
 
 Search volume for specific keywords (comma-separated).
 
-**Script:** `python scripts/keyword_planner.py volume "<kw1>,<kw2>" --json`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/keyword_planner.py volume "<kw1>,<kw2>" --json`
 
 ---
 
@@ -278,7 +284,7 @@ After any analysis command, offer to generate a PDF/HTML report.
 
 Generate a professional PDF report with charts and analytics.
 
-**Script:** `python scripts/google_report.py --type <type> --data <json> --domain <domain> --format pdf`
+**Script:** `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_report.py --type <type> --data <json> --domain <domain> --format pdf`
 
 | Type | Input | Output |
 |------|-------|--------|
@@ -289,8 +295,8 @@ Generate a professional PDF report with charts and analytics.
 
 **Workflow:**
 1. Run data collection commands (pagespeed, gsc, inspect-batch, etc.)
-2. Save JSON output to file: `python scripts/pagespeed_check.py <url> --json > data.json`
-3. Generate report: `python scripts/google_report.py --type cwv-audit --data data.json --domain <domain>`
+2. Save JSON output to file: `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/pagespeed_check.py <url> --json > data.json`
+3. Generate report: `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_report.py --type cwv-audit --data data.json --domain <domain>`
 
 **Convention:** After completing analysis, suggest: "Generate a report? Use `/seo google report <type>`"
 

--- a/skills/seo-google/references/auth-setup.md
+++ b/skills/seo-google/references/auth-setup.md
@@ -106,7 +106,7 @@ Save to `~/.config/claude-seo/google-api.json`:
 ## Step 8: Verify Setup
 
 ```bash
-python scripts/google_auth.py --check
+${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/google_auth.py --check
 ```
 
 Expected output at Tier 2 (full):

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -161,7 +161,7 @@ If DataForSEO MCP tools are available, use `on_page_instant_pages` for real page
 
 ## Google API Integration (Optional)
 
-If Google API credentials are configured, use `python scripts/pagespeed_check.py <url> --json` for real PSI + CrUX field data (replaces lab-only CWV estimates), `python scripts/crux_history.py <url> --json` for 25-week CWV trends, and `python scripts/gsc_inspect.py <url> --json` for real indexation status per URL.
+If Google API credentials are configured, use `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/pagespeed_check.py <url> --json` for real PSI + CrUX field data (replaces lab-only CWV estimates), `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/crux_history.py <url> --json` for 25-week CWV trends, and `${CLAUDE_SKILL_DIR}/../seo/.venv/bin/python ${CLAUDE_SKILL_DIR}/../seo/scripts/gsc_inspect.py <url> --json` for real indexation status per URL.
 
 ## Error Handling
 

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -25,7 +25,8 @@ metadata:
 
 **Invocation:** `/seo $1 $2` where `$1` is the command and `$2` is the URL or argument.
 
-**Scripts:** Located at the plugin root `scripts/` directory.
+**Scripts:** `${CLAUDE_SKILL_DIR}/scripts/`
+**Python:** `${CLAUDE_SKILL_DIR}/.venv/bin/python`
 
 Comprehensive SEO analysis across all industries (SaaS, local services,
 e-commerce, publishers, agencies). Orchestrates 15 specialized sub-skills and 10 subagents
@@ -60,7 +61,7 @@ e-commerce, publishers, agencies). Orchestrates 15 specialized sub-skills and 10
 When the user invokes `/seo audit`, delegate to subagents in parallel:
 1. Detect business type (SaaS, local, ecommerce, publisher, agency, other)
 2. Spawn subagents: seo-technical, seo-content, seo-schema, seo-sitemap, seo-performance, seo-visual, seo-geo
-3. If Google API credentials detected (`python scripts/google_auth.py --check`), also spawn seo-google agent
+3. If Google API credentials detected (`${CLAUDE_SKILL_DIR}/.venv/bin/python ${CLAUDE_SKILL_DIR}/scripts/google_auth.py --check`), also spawn seo-google agent
 4. If local business detected, also spawn seo-local agent
 5. If local business detected AND DataForSEO MCP available, also spawn seo-maps agent
 6. If Firecrawl MCP available, use `firecrawl_map` to discover all site URLs before analysis
@@ -69,7 +70,7 @@ When the user invokes `/seo audit`, delegate to subagents in parallel:
 8. **Offer PDF report**: "Generate a professional PDF report? Use `/seo google report full`"
 
 For individual commands, load the relevant sub-skill directly.
-After any analysis command completes, offer to generate a PDF report via `scripts/google_report.py`.
+After any analysis command completes, offer to generate a PDF report via `${CLAUDE_SKILL_DIR}/scripts/google_report.py`.
 
 ## Industry Detection
 


### PR DESCRIPTION
## Summary
- **Script path resolution**: All SKILL.md and agent files referenced scripts with relative paths (`python scripts/X.py`) which broke when running from any working directory other than the skill root. SKILL.md files now use `${CLAUDE_SKILL_DIR}` (Claude Code built-in variable) for path resolution; agent files use absolute `~/.claude/skills/seo/` paths since agents don't support variable substitution.
- **macOS SSL fix**: Added `pip-system-certs` to requirements.txt to fix SSL certificate verification failures with `requests`/`urllib3` on macOS Homebrew Python 3.14, where `certifi`'s bundled CA store lags behind the system store.
- **`--extract` flag for fetch_page.py**: Subagents were consuming entire context windows on raw WordPress HTML (~300KB per page, ~40K tokens). New `--extract` flag strips HTML to structured SEO-relevant text (~95% reduction): meta tags, schema JSON-LD, headings, body content, images, internal links. Updated 6 agent prompts to default to `--extract`.

## Files changed

### Commit 1: Script paths + SSL
- `skills/seo/SKILL.md` — use `${CLAUDE_SKILL_DIR}` for script/python paths
- `skills/seo-google/SKILL.md` — use `${CLAUDE_SKILL_DIR}/../seo/` for cross-skill references (21 occurrences)
- `skills/seo-audit/SKILL.md` — same pattern (4 occurrences)
- `skills/seo-technical/SKILL.md` — same pattern (1 occurrence)
- `skills/seo-google/references/auth-setup.md` — same pattern (1 occurrence)
- `agents/seo-google.md` — absolute paths with definition block at top (10 occurrences)
- `agents/seo-performance.md` — absolute paths (2 occurrences)
- `requirements.txt` — add `pip-system-certs>=5.0,<6.0.0`

### Commit 2: --extract flag
- `scripts/fetch_page.py` — new `extract_seo_content()` function + `--extract` CLI flag
- `agents/seo-technical.md` — default to `--extract`, raw HTML for render-blocking/headers
- `agents/seo-content.md` — default to `--extract`
- `agents/seo-schema.md` — default to `--extract`, raw HTML for Microdata/RDFa
- `agents/seo-geo.md` — default to `--extract`, raw HTML for robots.txt/crawler checks
- `agents/seo-local.md` — default to `--extract`, raw HTML for Maps embed detection
- `agents/seo-performance.md` — explicitly uses raw HTML (needs full markup)

## Test plan
- [x] Ran `install.sh` — installs successfully
- [x] Verified venv python + script paths work from `/tmp` (different working directory)
- [x] Verified `${CLAUDE_SKILL_DIR}` expands correctly when skill activated via `/seo google`
- [x] Verified `requests.get()` works after `pip-system-certs` install
- [x] `--extract` tested: ~95% size reduction, all 6 sections present

🤖 Generated with [Claude Code](https://claude.com/claude-code)