### PR TITLE
fix: Enforce `venv` usage by all sub-agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ claude-seo/
 - Follow kebab-case naming for all skill directories
 - Agents invoked via Agent tool, never via Bash
 - All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+- Test with `python -m pytest tests/` after changes (if applicable)
 
 ## Security Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,8 +124,7 @@ claude-seo/
 - Scripts must have docstrings, CLI interface, and JSON output
 - Follow kebab-case naming for all skill directories
 - Agents invoked via Agent tool, never via Bash
-- Python dependencies install into `~/.claude/skills/seo/.venv/`
-- Test with `python -m pytest tests/` after changes (if applicable)
+- All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
 
 ## Security Rules
 

--- a/agents/seo-backlinks.md
+++ b/agents/seo-backlinks.md
@@ -8,6 +8,10 @@ tools: Read, Bash, Write, Glob, Grep
 
 You are a backlink profile analyst. When delegated tasks during an SEO audit:
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 1. Check credentials: `python scripts/backlinks_auth.py --check --json`
 2. Determine tier (0 = CC+verify, 1 = +Moz, 2 = +Bing, 3 = +DataForSEO)
 3. Run all available sources for the target domain

--- a/agents/seo-content.md
+++ b/agents/seo-content.md
@@ -6,6 +6,10 @@ maxTurns: 15
 tools: Read, Bash, Write, Grep
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Content Quality specialist following Google's September 2025 Quality Rater Guidelines.
 
 When given content to analyze:

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -6,6 +6,10 @@ maxTurns: 20
 tools: Read, Bash, WebFetch, Glob, Grep
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Generative Engine Optimization (GEO) specialist. When given a URL:
 
 1. Fetch the page and check robots.txt for AI crawler rules

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -8,6 +8,10 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 
 You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 1. Check credentials: `python scripts/google_auth.py --check --json`
 2. Determine tier (0 = API key, 1 = + service account, 2 = + GA4)
 3. Execute tier-appropriate analysis

--- a/agents/seo-local.md
+++ b/agents/seo-local.md
@@ -6,6 +6,10 @@ maxTurns: 20
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Local SEO specialist. When given a URL:
 
 1. Fetch the page and detect business type (brick-and-mortar, SAB, or hybrid) from address visibility, service area language, and Maps embeds

--- a/agents/seo-maps.md
+++ b/agents/seo-maps.md
@@ -6,6 +6,10 @@ maxTurns: 25
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Maps Intelligence specialist. When delegated tasks during an SEO audit or given a business URL/name:
 
 1. Detect capability tier: check if DataForSEO MCP tools are available (try `business_data_business_listings_search`). If available = Tier 1. If not = Tier 0 (free APIs only).

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -71,6 +71,10 @@ curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=URL&key=API
 npx lighthouse URL --output json
 ```
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 ## Google API Integration (Optional)
 
 If Google API credentials are configured, prefer CrUX field data over Lighthouse lab data for CWV assessment:

--- a/agents/seo-schema.md
+++ b/agents/seo-schema.md
@@ -6,6 +6,10 @@ maxTurns: 15
 tools: Read, Bash, Write
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Schema.org markup specialist.
 
 When analyzing pages:

--- a/agents/seo-sitemap.md
+++ b/agents/seo-sitemap.md
@@ -6,6 +6,10 @@ maxTurns: 15
 tools: Read, Bash, Write, Glob
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Sitemap Architecture specialist.
 
 When working with sitemaps:

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -6,6 +6,10 @@ maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 ---
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 You are a Technical SEO specialist. When given a URL or set of URLs:
 
 1. Fetch the page(s) and analyze HTML source

--- a/agents/seo-visual.md
+++ b/agents/seo-visual.md
@@ -8,12 +8,16 @@ tools: Read, Bash, Write
 
 You are a Visual Analysis specialist using Playwright for browser automation.
 
+## Python Environment
+
+All Python scripts and pip installs MUST use the skill venv at `~/.claude/skills/seo/.venv/`. Never use the system Python or install packages globally.
+
 ## Prerequisites
 
-Before capturing screenshots, ensure Playwright and Chromium are installed:
+Before capturing screenshots, ensure Playwright and Chromium are installed in the venv:
 
 ```bash
-pip install playwright && playwright install chromium
+pip install playwright && python -m playwright install chromium
 ```
 
 ## When Analyzing Pages

--- a/install.ps1
+++ b/install.ps1
@@ -210,17 +210,22 @@ try {
         Copy-Item -Force $reqFile $installedReqFile
     }
 
-    # Install Python dependencies
+    # Install Python dependencies (venv required)
     Write-Host "=> Installing Python dependencies..." -ForegroundColor Yellow
+    $VenvDir = Join-Path $SkillDir '.venv'
+    $VenvPython = Join-Path $VenvDir 'Scripts\python.exe'
+    $venvCreated = $false
     if (Test-Path $reqFile) {
-        try {
-            $pip = Invoke-External -Exe $python.Exe -Args @($python.Args + @('-m','pip','install','-q','-r',$reqFile)) -Quiet
-            if ($pip.ExitCode -ne 0) {
-                throw ($pip.Output -join "`n")
-            }
-        } catch {
-            Write-Host "  [!]  Could not auto-install Python packages." -ForegroundColor Yellow
-            Write-Host "  Try: $($python.Exe) $($python.Args -join ' ') -m pip install -r `"$installedReqFile`"" -ForegroundColor Yellow
+        $venv = Invoke-External -Exe $python.Exe -Args @($python.Args + @('-m','venv',$VenvDir)) -Quiet
+        if ($venv.ExitCode -ne 0 -or -not (Test-Path $VenvPython)) {
+            throw "Failed to create venv at $VenvDir. Ensure the venv module is available."
+        }
+        $venvCreated = $true
+        $pip = Invoke-External -Exe $VenvPython -Args @('-m','pip','install','-q','-r',$reqFile) -Quiet
+        if ($pip.ExitCode -eq 0) {
+            Write-Host "  [+] Installed in venv at $VenvDir" -ForegroundColor Green
+        } else {
+            Write-Host "  [!]  Venv pip install failed. Run: $VenvPython -m pip install -r `"$installedReqFile`"" -ForegroundColor Yellow
         }
     } else {
         Write-Host "  [!]  No requirements.txt found; skipping Python dependency install." -ForegroundColor Yellow
@@ -228,8 +233,10 @@ try {
 
     # Optional: Install Playwright browsers
     Write-Host "=> Installing Playwright browsers (optional, for visual analysis)..." -ForegroundColor Yellow
+    $pwExe = $VenvPython
+    $pwArgs = @('-m','playwright','install','chromium')
     try {
-        $pw = Invoke-External -Exe $python.Exe -Args @($python.Args + @('-m','playwright','install','chromium')) -Quiet
+        $pw = Invoke-External -Exe $pwExe -Args $pwArgs -Quiet
         if ($pw.ExitCode -ne 0) {
             throw ($pw.Output -join "`n")
         }

--- a/install.sh
+++ b/install.sh
@@ -125,24 +125,17 @@ main() {
     # Install Python dependencies (venv preferred, --user fallback)
     echo "→ Installing Python dependencies..."
     VENV_DIR="${SKILL_DIR}/.venv"
-    if python3 -m venv "${VENV_DIR}" 2>/dev/null; then
-        "${VENV_DIR}/bin/pip" install --quiet -r "${TEMP_DIR}/claude-seo/requirements.txt" 2>/dev/null && \
-            echo "  ✓ Installed in venv at ${VENV_DIR}" || \
-            echo "  ⚠  Venv pip install failed. Run: ${VENV_DIR}/bin/pip install -r ${SKILL_DIR}/requirements.txt"
-    else
-        pip install --quiet --user -r "${TEMP_DIR}/claude-seo/requirements.txt" 2>/dev/null || \
-        echo "  ⚠  Could not auto-install. Run: pip install --user -r ${SKILL_DIR}/requirements.txt"
+    if ! python3 -m venv "${VENV_DIR}" 2>/dev/null; then
+        echo "✗ Failed to create venv at ${VENV_DIR}. Ensure python3-venv is installed."
+        exit 1
     fi
+    "${VENV_DIR}/bin/pip" install --quiet -r "${TEMP_DIR}/claude-seo/requirements.txt"
+    echo "  ✓ Installed in venv at ${VENV_DIR}"
 
     # Optional: Install Playwright browsers (for screenshot analysis)
     echo "→ Installing Playwright browsers (optional, for visual analysis)..."
-    if [ -f "${VENV_DIR}/bin/playwright" ]; then
-        "${VENV_DIR}/bin/python" -m playwright install chromium 2>/dev/null || \
+    "${VENV_DIR}/bin/python" -m playwright install chromium 2>/dev/null || \
         echo "  ⚠  Playwright install failed. Visual analysis will use WebFetch fallback."
-    else
-        python3 -m playwright install chromium 2>/dev/null || \
-        echo "  ⚠  Playwright install failed. Visual analysis will use WebFetch fallback."
-    fi
 
     echo ""
     echo "✓ Claude SEO installed successfully!"


### PR DESCRIPTION
## Summary

Subagents were sometimes using system Python or global pip, potentially causing dependency conflicts. Now every agent definition, installer, and the CLAUDE.md dev rules mandate ~/.claude/skills/seo/.venv/. Both install.sh and install.ps1 fail hard if venv creation fails instead of silently falling back.

A follow-up from https://github.com/AgriciDaniel/claude-seo/pull/36#issuecomment-4156142405.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [x] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change
