### PR TITLE
Update README to remove blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ Comprehensive SEO analysis skill for Claude Code. Covers technical SEO, on-page 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Version](https://img.shields.io/github/v/release/AgriciDaniel/claude-seo)](https://github.com/AgriciDaniel/claude-seo/releases)
 
-> **Blog:** [Full breakdown of the Claude Code SEO stack](https://agricidaniel.com/blog/claude-code-seo-stack) | [v1.7.2 release: Firecrawl backlink analysis](https://agricidaniel.com/blog/claude-seo-172-firecrawl-backlink-analysis)
-
 ## Table of Contents
 
 - [Installation](#installation)


### PR DESCRIPTION
Removed blog link for v1.7.2 release from README.

## Summary

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change
