### PR TITLE
Add seo-content-brief skill

### DIFF
--- a/skills/seo-content-brief/LICENSE.txt
+++ b/skills/seo-content-brief/LICENSE.txt
@@ -1,4 +1,4 @@
 MIT License - see repository root LICENSE file for complete terms.
 
-Copyright (c) 2026 pjawale
+Copyright (c) 2026 puneetindersingh
 https://github.com/AgriciDaniel/claude-seo

--- a/skills/seo-content-brief/LICENSE.txt
+++ b/skills/seo-content-brief/LICENSE.txt
@@ -1,0 +1,4 @@
+MIT License - see repository root LICENSE file for complete terms.
+
+Copyright (c) 2026 pjawale
+https://github.com/AgriciDaniel/claude-seo

--- a/skills/seo-content-brief/SKILL.md
+++ b/skills/seo-content-brief/SKILL.md
@@ -11,8 +11,8 @@ user-invokable: true
 argument-hint: "[url-or-keyword] [page-type]"
 license: MIT
 metadata:
-  author: pjawale
-  original_author: pjawale
+  author: puneetindersingh
+  original_author: puneetindersingh
   version: "1.0.0"
   category: seo
 ---

--- a/skills/seo-content-brief/SKILL.md
+++ b/skills/seo-content-brief/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: seo-content-brief
+description: >
+  Generate competitive SEO content briefs with per-section word counts,
+  competitor scoring, keyword density guidance, and page-type templates.
+  Supports both new page briefs and improve-existing-page briefs.
+  Use when user says "content brief", "write a brief", "content outline",
+  "blog brief", "service page brief", "brief for", "writing brief",
+  "content plan", or "outline for".
+user-invokable: true
+argument-hint: "[url-or-keyword] [page-type]"
+license: MIT
+metadata:
+  author: pjawale
+  original_author: pjawale
+  version: "1.0.0"
+  category: seo
+---
+
+# SEO Content Brief Generator
+
+Generate research-backed content briefs that help writers produce pages capable of outranking current top results. Briefs include competitor analysis with gap scoring, per-section word count breakdowns, keyword placement rules, and page-type-specific templates.
+
+## Process
+
+### 1. Determine Brief Mode
+
+**Improve mode** (existing page URL provided):
+- Fetch the existing page content and structure
+- Identify what is already strong (keep it)
+- Identify missing, thin, or outdated sections
+- Distinguish "keep/strengthen" vs "add new" sections in the outline
+- Do not recommend a full rewrite when targeted improvements will win
+
+**New page mode** (keyword or topic provided, no existing page):
+- Use the target site's homepage or sitemap for business context only
+- Build the brief from scratch for a new page
+- Focus on competitive gaps the new page can fill
+
+### 2. Fetch Context
+
+- Fetch the target URL or homepage to understand the business
+- Fetch the sitemap to discover all existing pages, categories, and services
+- This context is critical for the Website Relevance Rule (see below)
+
+### 3. Analyse SERPs
+
+- Identify the top 5 ranking pages for the target keyword
+- Filter out non-competitors (Wikipedia, Reddit, Pinterest, Amazon, YouTube, government sites, SEO tool pages, job boards, directories, news aggregators, social platforms). See `references/excluded-domains.md` for the full list.
+- Score each real competitor: Depth (1-10), Formatting (1-10), SEO (1-10), UX (1-10)
+- Identify three gap types:
+  - **Topic gaps:** subtopics competitors miss entirely
+  - **Depth gaps:** topics covered but shallow
+  - **Quality gaps:** outdated info, no expert perspective, poor formatting
+- Calculate gap priority: `Impact x Competitive Advantage / Effort`
+
+### 4. Classify Search Intent
+
+- **Informational:** user wants to learn (guides, how-tos, definitions)
+- **Commercial:** user is researching before buying (comparisons, reviews, "best X")
+- **Transactional:** user is ready to act (buy, book, enquire, sign up)
+- **Navigational:** user is looking for a specific site or page
+
+Identify what SERP format Google rewards for this query: long-form guide, listicle, comparison table, landing page, FAQ, video, local pack.
+
+### 5. Build the Brief
+
+Apply the page-type template from `references/page-type-templates.md`, then customise based on competitor gaps and search intent.
+
+## Critical Rules
+
+### Website Relevance Rule
+
+Every heading, subtopic, keyword, and FAQ you suggest MUST be something the target website can credibly write about based on its actual services or products.
+
+- Read the site's homepage and sitemap to understand what it does
+- Do not borrow competitor structure if those sections cover things this site does not offer
+- Before each suggestion, ask: "Can this website actually deliver on this content?" If no, remove it.
+
+### Site Structure Coverage Rule
+
+When briefing a hub, overview, category, or "types of" page:
+- The outline MUST reference every relevant product category, service, or sub-page that exists on the site
+- Do not invent categories that don't exist, do not leave out categories that do exist
+- Each category should appear as its own section with an internal link suggestion
+- This ensures the page acts as a proper hub linking to all child pages
+
+For non-hub pages (single service page, blog post), use site structure to suggest relevant internal links but do not force every category into the outline.
+
+### Output Language Rules
+
+- Never mention researcher names, framework names, or tool names in the output (no "Ben Goodey method", "Frase.io formula", "Princeton GEO", "Clearscope", "Backlinko")
+- These are internal thinking tools only. The output must read as plain, professional advice.
+- Write for a business owner or content writer, not an SEO academic
+
+## Keyword Density and Placement
+
+Read `references/keyword-density.md` for the full rules. Summary:
+
+**Primary keyword density:** 0.5% to 2.0% of total word count.
+- Above 2% requires review. Above 3% risks keyword stuffing penalties.
+- First 1-2 mentions carry the most SEO weight. Diminishing returns after.
+- For a 1,000-word article at 1-2%: roughly 10-20 total appearances including headings, body, and alt text.
+
+**Primary keyword MUST appear in:**
+1. Title tag (near the front)
+2. H1 tag (near the front)
+3. URL slug
+4. Meta description
+5. First paragraph / first 100 words
+6. At least one image alt text
+
+**Primary keyword does NOT need to appear in:**
+- Every H2 or H3 (subtopics carry context naturally if H1 covers it)
+- Every paragraph or section
+
+**Secondary keywords:**
+- 5-8 closely related supporting terms distributed through body content
+- 10-15 broader semantic terms covering related concepts
+- Use in H2-H6 subheadings where natural
+- Synonyms improve readability and do NOT count toward keyword density
+
+**Per-section keyword guidance:** For each section in the outline, specify:
+- Which keyword (primary or secondary) belongs in the heading
+- Whether the body should include the primary keyword or a variation
+- Example: "Use secondary keyword 'structural drafting services' in H2. Body: mention primary keyword once."
+
+**Distribution:** Spread the primary keyword evenly. Do not front-load or cluster in one section.
+
+## Meta Tag Rules
+
+**Title tag:**
+- 50-60 characters (never under 50, never over 60)
+- Primary keyword first, brand name last
+- Separate brand with a pipe or dash (match the site's existing pattern)
+- Lead with outcomes, numbers, or specifics when possible
+
+**Meta description:**
+- 130-150 characters (never under 130, never over 150)
+- Active voice, expand on the title with USPs and specifics
+- End with a call to action
+- No brand name at the end (it's already in the title)
+- No quotes (Google truncates at quotes)
+
+## Information Gain (non-negotiable)
+
+Every brief must specify EXACTLY what new value this content adds that no current ranking page provides. Must be specific:
+- Proprietary data or original research
+- Case studies with real outcomes
+- Expert quotes or first-hand experience
+- Original synthesis or unique framework
+- NOT "more detail" or "better formatting"
+
+## E-E-A-T Requirements
+
+List the exact trust signals this content needs:
+- Author credentials and bio relevant to the topic
+- Expert quotes or citations from authoritative sources
+- Cited studies, data, or statistics with dates
+- Last updated date
+- Especially critical for YMYL topics (health, finance, legal, safety)
+
+## Internal Linking
+
+- Suggest 3-5 specific internal link opportunities with anchor text
+- Specify whether the page is a hub (links out to cluster pages) or spoke (links to pillar page)
+- Use the site structure from the sitemap to find real link targets
+
+## Output Format
+
+Always output in this exact structure:
+
+```
+## Content Brief: [Primary Keyword]
+
+### Search Intent
+[Intent type, SERP format rewarded, target audience and knowledge level. 3-4 lines.]
+
+### Competitor Analysis
+| # | URL | Key H2 Sections | Est. Words | Score | Main Gap |
+|---|-----|-----------------|------------|-------|----------|
+| 1 | ... | ...             | ...        | X/40  | ...      |
+
+### Content Gaps and Opportunities
+[Bullet list: topic gaps, depth gaps, quality gaps with specifics]
+
+### Winning Outline
+
+**H1:** [H1 with primary keyword]
+**URL Slug:** /[slug]
+**Target Word Count:** ~[X] words (competitor avg: ~[X] words)
+
+[Full H2/H3 outline with:
+- Word count per section
+- Content format notes (bullet list, table, definition box, etc.)
+- Featured Snippet targets marked with "FS target"
+- Per-section keyword guidance]
+
+### Recommended Meta Tags
+
+**Title**
+[title, 60 chars max]
+
+**Meta Description**
+[description, 150 chars max]
+
+### Unique Angle and Information Gain
+[Specific paragraph: what exact new value this piece adds]
+
+### E-E-A-T Requirements
+[Bullet list of exact trust signals needed]
+
+### Internal Linking Opportunities
+[3-5 suggestions with anchor text and target URL]
+```
+
+## Outline-Only Mode
+
+When the user asks for "just an outline" or "content outline" instead of a full brief, skip the Competitor Analysis table, Content Gaps section, Information Gain section, and E-E-A-T section. Output only:
+
+```
+## Content Outline: [Primary Keyword]
+
+**H1:** [H1 with primary keyword]
+**URL Slug:** /[slug]
+**Target Word Count:** ~[X] words (competitor avg: ~[X] words)
+
+[Full H2/H3 outline with word counts, format notes, FS targets, keyword guidance, and a 1-2 sentence writing note per section]
+```
+
+## DataForSEO Integration (Optional)
+
+If DataForSEO MCP tools are available, use `serp_google_organic_live_advanced` for real SERP data and competitor analysis, `kw_data_google_ads_search_volume` for keyword volume, `dataforseo_labs_bulk_keyword_difficulty` for difficulty scores, `dataforseo_labs_search_intent` for intent classification, and `on_page_content_parsing_live` for competitor content extraction.
+
+## Ahrefs Integration (Optional)
+
+If Ahrefs MCP tools are available, use `keywords-explorer-overview` for keyword volume and difficulty, `serp-overview` for SERP analysis, `site-explorer-organic-keywords` for existing keyword rankings, and `site-explorer-top-pages` for competitor page performance.
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| Target URL unreachable | Report the error. Do not guess page content. Ask the user to verify the URL. |
+| No competitors found after filtering | Broaden the search to include partial-match competitors. Note the thin competitive landscape in the brief. |
+| Sitemap not found | Proceed without site structure context. Note that internal linking suggestions may be incomplete. |
+| Page type not specified | Auto-detect from the keyword intent and SERP format. State the detected type in the brief. |
+| Target word count not specified | Use competitor average as the baseline. Note this in the outline. |

--- a/skills/seo-content-brief/references/excluded-domains.md
+++ b/skills/seo-content-brief/references/excluded-domains.md
@@ -1,0 +1,65 @@
+<!-- Updated: 2026-04-17 -->
+# Excluded Competitor Domains
+
+When analysing SERPs for competitor scoring, filter out these domains. They are not real business competitors even when they rank for the target keyword.
+
+## Encyclopedias and Reference Sites
+- wikipedia.org, britannica.com, investopedia.com, dictionary.com, merriam-webster.com, webmd.com, healthline.com, mayoclinic.org
+
+## Social Media Platforms
+- facebook.com, instagram.com, twitter.com, x.com, linkedin.com, pinterest.com, tiktok.com, youtube.com, reddit.com, quora.com, threads.net
+
+## Content Platforms and Blogging
+- medium.com, substack.com, blogger.com, wordpress.com, wix.com, squarespace.com, hubpages.com, tumblr.com
+
+## Search Engines
+- google.com, bing.com, yahoo.com, duckduckgo.com, baidu.com
+
+## Marketplaces and E-Commerce Aggregators
+- amazon.com, amazon.com.au, amazon.co.uk, ebay.com, ebay.com.au, etsy.com, shopify.com, alibaba.com, gumtree.com.au, kogan.com
+
+## Forums and Q&A
+- stackoverflow.com, stackexchange.com, whirlpool.net.au, superuser.com, serverfault.com
+
+## News and Media
+- bbc.com, bbc.co.uk, cnn.com, news.com.au, abc.net.au, theguardian.com, forbes.com, techcrunch.com, theverge.com, mashable.com, huffpost.com, nytimes.com, washingtonpost.com
+
+## Data and Research Platforms
+- statista.com, ibisworld.com, similarweb.com
+
+## Directories, Reviews, and Listings
+- maps.google.com, tripadvisor.com, yelp.com, trustpilot.com, yellowpages.com.au, bark.com, thumbtack.com, angi.com, homeadvisor.com, truelocal.com.au, hotfrog.com.au, productreview.com.au
+
+## Comparison and Aggregator Sites
+- finder.com.au, canstar.com.au, iselect.com.au, mozo.com.au, comparethemarket.com.au, cmsmarket.com
+
+## Job Boards
+- seek.com.au, indeed.com, glassdoor.com, jora.com, linkedin.com/jobs
+
+## SEO and Marketing Tool Pages
+- semrush.com, ahrefs.com, moz.com, neilpatel.com, backlinko.com, searchengineland.com, searchenginejournal.com, yoast.com, screaming frog.co.uk, majestic.com
+
+## AI Platforms
+- chat.openai.com, chatgpt.com, claude.ai, perplexity.ai, gemini.google.com, copilot.microsoft.com
+
+## Government Domains
+- Any domain ending in .gov, .gov.au, .gov.uk, .gov.nz, .gc.ca
+
+## Academic Domains
+- Any domain ending in .edu, .edu.au, .ac.uk, .ac.nz
+
+## URL Path Patterns to Exclude
+
+Even on otherwise valid competitor domains, exclude URLs containing:
+- `/tag/`, `/tags/`, `/author/`, `/category/`, `/archive/`
+- `/feed/`, `/rss/`, `/wp-json/`, `/wp-admin/`
+- `/login`, `/signup`, `/register`, `/cart`, `/checkout`
+- `/terms`, `/privacy`, `/cookie-policy`, `/disclaimer`
+- `/sitemap`, `/robots.txt`
+
+## How to Use This List
+
+1. After fetching SERP results, check each URL against these domains
+2. Remove any matches before scoring competitors
+3. If fewer than 3 real competitors remain, note the thin competitive landscape
+4. Never count a filtered domain in the competitor analysis table

--- a/skills/seo-content-brief/references/keyword-density.md
+++ b/skills/seo-content-brief/references/keyword-density.md
@@ -1,0 +1,60 @@
+<!-- Updated: 2026-04-17 -->
+# Keyword Density and Placement Rules
+
+Based on published research from Semrush, Ahrefs, Yoast, and Google's own guidance on keyword usage.
+
+## Primary Keyword Density
+
+**Safe range:** 0.5% to 2.0% of total word count.
+
+| Density | Assessment |
+|---------|-----------|
+| Below 0.5% | Under-optimised. Likely missing from key locations. |
+| 0.5% - 2.0% | Optimal range. Natural reading, clear topic signal. |
+| 2.0% - 3.0% | Review required. May read unnaturally. |
+| Above 3.0% | Keyword stuffing risk. Likely to trigger penalties. |
+
+**Practical example:** For a 1,000-word article at 1-2%, the primary keyword should appear roughly 10-20 times total. This includes headings, body text, and image alt text.
+
+**Diminishing returns:** The first 1-2 mentions of the primary keyword carry the most SEO weight. After that, each additional mention provides less ranking benefit. Prioritise placement quality over quantity.
+
+## Required Placement Locations
+
+The primary keyword MUST appear in all of these:
+
+1. **Title tag** (near the front, not buried at the end)
+2. **H1 tag** (near the front)
+3. **URL slug** (lowercase, hyphenated)
+4. **Meta description** (naturally integrated)
+5. **First paragraph / first 100 words** (establishes topic immediately)
+6. **At least one image alt text** (reinforces topic for image search)
+
+## Locations Where It Is NOT Required
+
+- Every H2 or H3 (if the H1 covers the keyword, subheadings carry context naturally through semantic relationship)
+- Every paragraph or section (clustering looks unnatural)
+- Anchor text of every internal link (vary the anchor text)
+
+## Secondary and Semantic Keywords
+
+| Type | Count | Usage |
+|------|-------|-------|
+| Closely related terms | 5-8 | Distribute through body content and H2-H6 headings |
+| Broader semantic terms | 10-15 | Cover related concepts and user intent variations |
+| Synonyms | As natural | Improve readability. Do NOT count toward primary density. |
+
+## Distribution Rules
+
+- **Spread evenly** throughout the content. Do not front-load all mentions into the introduction or cluster in one section.
+- **Per-section guidance in briefs:** For each section in a content brief, specify:
+  - Which keyword (primary or secondary) should appear in the heading
+  - Whether the section body should include the primary keyword or a variation
+  - Format: "Use secondary keyword '[term]' in H2. Body: mention primary keyword once."
+
+## Common Mistakes
+
+1. **Exact-match obsession:** Using the exact phrase every time instead of natural variations. Google understands synonyms and related terms.
+2. **Heading stuffing:** Putting the primary keyword in every H2 and H3. One H1 mention plus 1-2 H2 mentions is sufficient.
+3. **Ignoring first 100 words:** The opening paragraph is the highest-value placement after the title and H1.
+4. **Forgetting image alt text:** A free placement opportunity that also helps image search rankings.
+5. **Counting synonyms as density:** "Web design", "website design", and "site design" are different strings. Only count exact-match appearances toward density.

--- a/skills/seo-content-brief/references/page-type-templates.md
+++ b/skills/seo-content-brief/references/page-type-templates.md
@@ -1,0 +1,153 @@
+<!-- Updated: 2026-04-17 -->
+# Content Brief Templates by Page Type
+
+Select the template that matches the page type. Adapt sections based on the specific business and competitive landscape. Not every section applies to every page.
+
+## Service Page
+
+**Goal:** Convert visitors into enquiries or bookings.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| What is [service] | Define the service clearly | Definition box, 80-120 words |
+| Who needs it | Qualify the reader | Bullet list of scenarios |
+| How it works | Reduce friction, set expectations | Numbered steps |
+| Costs/pricing/fees | Address the #1 question | Table or range, not exact if variable |
+| Outcomes/results | Prove value | Stats, case study snippets, before/after |
+| Why choose [brand] | Differentiate | 3-5 bullet points with specifics |
+| FAQ | Capture PAA traffic | 5-8 questions, 40-60 words each, FS target |
+| CTA | Convert | Clear action, reduce risk (free consult, no obligation) |
+
+**Schema:** Service + FAQPage + LocalBusiness (if location-specific)
+**Primary keyword placement:** H1, first 100 words, one H2, URL slug, meta title
+
+## Blog Post
+
+**Goal:** Rank for informational queries, drive readers to service pages.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| Direct answer | Win Featured Snippet | Answer-first paragraph, 40-60 words, FS target |
+| Background/context | Set the scene | 1-2 paragraphs |
+| [3-5 H2 subtopics] | Cover depth from PAA/gaps | Mix of paragraphs, lists, tables |
+| Common mistakes | Add unique value | Numbered list with explanations |
+| FAQ | Capture long-tail traffic | 5 questions from gap analysis |
+| CTA to relevant service | Convert intent | Contextual link, not hard sell |
+
+**Schema:** Article + FAQPage
+**Primary keyword placement:** H1, first 100 words, URL slug, meta title, one image alt text
+
+## Case Study
+
+**Goal:** Build trust, demonstrate real outcomes.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| Outcome summary | Lead with the result | Bold stat or outcome in first line |
+| Client situation | Context | 1-2 paragraphs, anonymise if needed |
+| The challenge | Problem framing | What was at stake |
+| Our approach | Show expertise | Step-by-step or narrative |
+| The result | Prove value | Specific figures, percentages, timelines |
+| Key takeaways | Reusable insight | 3-5 bullet points |
+| Related services CTA | Cross-sell | Link to the relevant service page |
+
+**Schema:** Article (with subject and outcome in description)
+**Primary keyword:** The outcome or matter type, in H1 and title
+
+## Category Page
+
+**Goal:** Rank for broad topic terms, funnel visitors to sub-pages.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| What this area covers | Define scope | Overview paragraph |
+| Sub-services/products (linked) | Hub linking | One H2 or H3 per sub-page with description and link |
+| Who we help | Qualify audience | Bullet list of personas |
+| Process overview | Set expectations | Numbered steps |
+| FAQ | Capture variations | 5-8 questions |
+| CTA | Convert | Clear next step |
+
+**Schema:** Service + BreadcrumbList + FAQPage
+**Primary keyword:** Category name, in H1, title, URL, first paragraph
+**Site Structure Rule:** MUST include every relevant sub-page from the sitemap.
+
+## Landing Page
+
+**Goal:** Single conversion action, minimal distractions.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| Hero (offer + CTA) | Convert above fold | Headline + subheadline + button |
+| Problem statement | Agitate pain | 2-3 sentences |
+| Solution/benefits | Present the fix | 3-5 benefit bullets |
+| Social proof | Build trust | Testimonials, logos, stats |
+| How it works | Reduce friction | 3-step process |
+| Objection handling / FAQ | Remove doubts | 4-6 common objections answered |
+| Final CTA | Convert | Repeat the offer |
+
+**Schema:** WebPage + FAQPage
+**Primary keyword:** Offer or outcome, in H1, title, hero subheading
+
+## FAQ Page
+
+**Goal:** Capture PAA and Featured Snippet traffic.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| 8-15 questions | Grouped by subtopic | Each answered in 40-60 words, FS target for each |
+| CTA after last question | Convert | Contextual next step |
+
+**Schema:** FAQPage (every Q&A as mainEntity, critical for rich results)
+**Primary keyword:** In H1 as "[Topic]: Frequently Asked Questions", in first answer
+
+## Location Page
+
+**Goal:** Rank for [service] + [city] queries.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| What we do in [city] | Local relevance | Overview with city name naturally included |
+| Local areas/courts/landmarks | Hyper-local signals | List of suburbs, jurisdictions, or landmarks served |
+| Service areas | Geographic scope | List or embedded map |
+| Why local matters | Justify the page | 1-2 paragraphs on local expertise |
+| Team in [city] | E-E-A-T | Brief bios of local staff |
+| Local reviews/testimonials | Trust | 2-3 reviews mentioning the location |
+| FAQ | Local variations | 5 location-specific questions |
+| CTA | Convert | Local phone number, address, booking link |
+
+**Schema:** Service + LocalBusiness (with address, phone, geo coordinates)
+**Primary keyword:** [Service] [City], in H1, title, URL, first paragraph, LocalBusiness schema
+
+## About Page
+
+**Goal:** Build trust, support E-E-A-T across the site.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| Who we are | Brand positioning | 2-3 paragraphs |
+| Our story/founding | Humanise | Narrative with founding date |
+| Our team | E-E-A-T | Individual bios with credentials, photos |
+| Our values | Differentiate | 3-5 values with brief explanations |
+| Awards/recognition | Authority | List with dates |
+| Media mentions | Authority | Links to press coverage |
+| CTA | Convert | Contact or services link |
+
+**Schema:** Organization + Person (per team member)
+**Primary keyword:** Brand name or "[Brand] [industry]", in H1 and title
+
+## Homepage
+
+**Goal:** Establish brand authority, funnel to service and location pages.
+
+| Section | Purpose | Format |
+|---------|---------|--------|
+| Hero (value prop + CTA) | First impression | Headline + subheadline + primary button |
+| Services overview | Show scope | Card grid or linked list to service pages |
+| Why us (differentiators) | Stand out | 3-5 unique selling points |
+| Social proof | Trust | Testimonials, client logos, review stars |
+| Location/service area | Local relevance | Map or area list |
+| FAQ (for GEO) | AI search visibility | 4-6 broad business questions |
+| CTA | Convert | Repeat primary action |
+
+**Schema:** Organization + WebSite + Service
+**Primary keyword:** Primary service + city, in H1, title, first paragraph


### PR DESCRIPTION
## Summary

- Adds a new `seo-content-brief` skill that generates research-backed SEO content briefs
- Fills a gap in the current toolkit: skills can audit and analyse content, but none generate content briefs with competitive analysis and actionable outlines
- Built from patterns tested in production across multiple client sites

## What the skill does

**Two modes:**
- **New page brief:** builds from scratch based on keyword, SERP analysis, and site context
- **Improve existing page:** identifies what's already strong vs what's missing/thin

**Core features:**
- Competitor scoring matrix (Depth / Formatting / SEO / UX, scored out of 40)
- Gap priority formula: `Impact x Competitive Advantage / Effort`
- Per-section word count breakdowns (not just totals)
- Featured Snippet targeting markers
- Keyword density guidance with placement rules (0.5-2% safe range)
- 9 page-type templates (service, blog, case study, category, landing, FAQ, location, about, homepage)
- Website relevance rule: never suggests content outside what the site actually offers
- Site structure coverage rule: hub pages must link to all child pages from sitemap
- Information gain requirement: every brief must specify unique value vs existing results
- 100+ excluded competitor domains (Wikipedia, Reddit, Pinterest, Amazon, directories, etc.)
- Optional DataForSEO and Ahrefs MCP integration

**Reference files (all under 200 lines):**
- `references/page-type-templates.md` — section-by-section templates for 9 page types
- `references/keyword-density.md` — placement rules and safe density ranges
- `references/excluded-domains.md` — non-competitor domains to filter from SERP analysis

## Files

```
skills/seo-content-brief/
  SKILL.md              (247 lines)
  LICENSE.txt
  references/
    page-type-templates.md   (153 lines)
    keyword-density.md       (60 lines)
    excluded-domains.md      (65 lines)
```

## Compliance

- SKILL.md under 500 lines
- All reference files under 200 lines
- kebab-case naming
- MIT license
- `original_author` in metadata
- No scripts (prompt-only skill)
- No credentials or sensitive data

## Test plan

- [ ] Install skill and invoke with `/seo-content-brief [url]`
- [ ] Test new page mode with a keyword only
- [ ] Test improve mode with an existing page URL
- [ ] Test outline-only mode with "just an outline" phrasing
- [ ] Verify competitor filtering excludes Wikipedia, Reddit, etc.
- [ ] Verify page-type auto-detection from keyword intent
- [ ] Test with DataForSEO available and without

🤖 Generated with [Claude Code](https://claude.com/claude-code)