### PR TITLE
fix: sync extensions/banana seo-image-gen skill with core v1.9.0

### DIFF
--- a/extensions/banana/skills/seo-image-gen/SKILL.md
+++ b/extensions/banana/skills/seo-image-gen/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Requires nanobanana MCP server"
 metadata:
   author: AgriciDaniel
-  version: "1.6.1"
+  version: "1.9.0"
   category: seo
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`extensions/banana/skills/seo-image-gen/SKILL.md` was at **v1.6.1** while the canonical `skills/seo-image-gen/SKILL.md` had been updated to **v1.9.0**.

Because `extensions/banana/install.sh` copies the extension SKILL.md to `~/.claude/skills/seo-image-gen/`, a user who installs the banana extension *after* the main SEO plugin would have their skill silently downgraded from v1.9.0 back to v1.6.1.

## Fix

Updated the version field in `extensions/banana/skills/seo-image-gen/SKILL.md` to match the core version (v1.9.0). This is a one-line sync — the skills are otherwise near-identical, and the core is the source of truth.

## Why it matters

Install order should not produce different outcomes. The extension skill copy should always be at least as current as the core version it overrides.

A longer-term fix would be for `install.sh` to skip copying the skill if the core version is already at the same or higher version number, but that is a structural improvement beyond this bug fix.