### PR TITLE
fix: pin MCP server package versions in extension install scripts

### DIFF
--- a/extensions/banana/install.sh
+++ b/extensions/banana/install.sh
@@ -110,7 +110,7 @@ if 'mcpServers' not in settings:
 # Add nanobanana-mcp server config
 settings['mcpServers']['nanobanana-mcp'] = {
     'command': 'npx',
-    'args': ['-y', '@ycse/nanobanana-mcp@latest'],
+    'args': ['-y', '@ycse/nanobanana-mcp@1.1.1'],
     'env': {
         'GOOGLE_AI_API_KEY': '''${GOOGLE_AI_API_KEY}'''
     }
@@ -148,7 +148,7 @@ print('  ✓ nanobanana-mcp configured in settings.json')
 
     # Pre-warm npm package without starting the MCP server binary.
     echo "→ Pre-downloading nanobanana-mcp..."
-    npx --yes --package=@ycse/nanobanana-mcp@latest -- node -e "" >/dev/null 2>&1 || true
+    npx --yes --package=@ycse/nanobanana-mcp@1.1.1 -- node -e "" >/dev/null 2>&1 || true
 
     echo ""
     echo "✓ Banana Image Generation extension installed successfully!"

--- a/extensions/dataforseo/install.sh
+++ b/extensions/dataforseo/install.sh
@@ -118,7 +118,7 @@ if 'mcpServers' not in settings:
 # Add DataForSEO server config
 settings['mcpServers']['dataforseo'] = {
     'command': 'npx',
-    'args': ['-y', 'dataforseo-mcp-server'],
+    'args': ['-y', 'dataforseo-mcp-server@2.8.10'],
     'env': {
         'DATAFORSEO_USERNAME': username,
         'DATAFORSEO_PASSWORD': password,
@@ -141,7 +141,7 @@ print('  ✓ MCP server configured in settings.json')
 
     # Pre-warm npm package without starting the MCP server binary.
     echo "→ Pre-downloading dataforseo-mcp-server..."
-    npx --yes --package=dataforseo-mcp-server -- node -e "" >/dev/null 2>&1 || true
+    npx --yes --package=dataforseo-mcp-server@2.8.10 -- node -e "" >/dev/null 2>&1 || true
 
     echo ""
     echo "✓ DataForSEO extension installed successfully!"

--- a/extensions/firecrawl/install.sh
+++ b/extensions/firecrawl/install.sh
@@ -101,7 +101,7 @@ if 'mcpServers' not in settings:
 # Add Firecrawl server config
 settings['mcpServers']['firecrawl-mcp'] = {
     'command': 'npx',
-    'args': ['-y', 'firecrawl-mcp'],
+    'args': ['-y', 'firecrawl-mcp@3.11.0'],
     'env': {
         'FIRECRAWL_API_KEY': api_key
     }
@@ -121,7 +121,7 @@ print('  v MCP server configured in settings.json')
 
     # Pre-warm npm package without starting the MCP server binary.
     echo "-> Pre-downloading firecrawl-mcp..."
-    npx --yes --package=firecrawl-mcp -- node -e "" >/dev/null 2>&1 || true
+    npx --yes --package=firecrawl-mcp@3.11.0 -- node -e "" >/dev/null 2>&1 || true
 
     echo ""
     echo "v Firecrawl extension installed successfully!"


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

All three extension install scripts use floating/unpinned npm package references. When these packages are fetched at install time, they download whatever version happens to be current — with no integrity verification.

| File | Package | Previous reference | Pinned to |
|------|---------|--------------------|-----------|
| `extensions/banana/install.sh` | `@ycse/nanobanana-mcp` | `@latest` | `1.1.1` |
| `extensions/dataforseo/install.sh` | `dataforseo-mcp-server` | *(no version)* | `2.8.10` |
| `extensions/firecrawl/install.sh` | `firecrawl-mcp` | *(no version)* | `3.11.0` |

## Risk

Unpinned `npx --yes` invocations are a supply chain attack surface: a compromised or typosquatted package would execute silently on every new install. They also cause non-reproducible installs — users can get different behaviour depending on when they run the installer.

## Fix

Each package is pinned to its current latest stable version. The `args` array in the MCP server config block and the pre-warm `npx` invocation are both updated so the configured version and the cached version stay in sync.

When you want to upgrade to a newer version, update the version string in both the `args` array and the pre-warm line.

## Versions pinned (current as of 2026-04-22)

- `@ycse/nanobanana-mcp@1.1.1` (was `@latest`)
- `dataforseo-mcp-server@2.8.10` (was unpinned)
- `firecrawl-mcp@3.11.0` (was unpinned)