### PR TITLE
fix: detect marketplace plugin installation in dataforseo extension installer

### DIFF
--- a/extensions/dataforseo/install.sh
+++ b/extensions/dataforseo/install.sh
@@ -16,6 +16,19 @@ main() {
     echo "════════════════════════════════════════"
     echo ""
 
+    # Support both traditional (curl|bash → ~/.claude/skills/seo) and marketplace
+    # (plugin install → ~/.claude/plugins/cache/.../skills/seo) installations.
+    # Resolve early using BASH_SOURCE so it works even when run from the plugin cache.
+    _EARLY_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    _PLUGIN_SEO_DIR="$(cd "${_EARLY_SCRIPT_DIR}/../.." 2>/dev/null && pwd)/skills/seo"
+    if [ ! -d "${SEO_SKILL_DIR}" ] && [ -d "${_PLUGIN_SEO_DIR}" ]; then
+        SEO_SKILL_DIR="${_PLUGIN_SEO_DIR}"
+    fi
+    if [ ! -d "${SEO_SKILL_DIR}" ]; then
+        _GLOB_MATCH=$(ls -d "${HOME}/.claude/plugins/cache/agricidaniel-seo/claude-seo/"*/skills/seo 2>/dev/null | tail -n1 || true)
+        [ -n "${_GLOB_MATCH}" ] && [ -d "${_GLOB_MATCH}" ] && SEO_SKILL_DIR="${_GLOB_MATCH}"
+    fi
+
     # Check prerequisites
     if [ ! -d "${SEO_SKILL_DIR}" ]; then
         echo "✗ Claude SEO is not installed."


### PR DESCRIPTION
## What

Fix `extensions/dataforseo/install.sh` to detect claude-seo when it was installed via the Claude Code marketplace plugin system, not just via the traditional `curl | bash` method.

## Why

Fixes #66

Users who install claude-seo through the marketplace (`/plugin install claude-seo@AgriciDaniel-claude-seo`) have files stored at:

```
~/.claude/plugins/cache/agricidaniel-seo/claude-seo/<version>/
```

The dataforseo extension installer only checked `~/.claude/skills/seo` (the traditional install path), so marketplace users always hit:

```
✗ Claude SEO is not installed.
```

even with claude-seo fully installed and working.

## How

Added two-stage fallback detection before the prerequisite check, using `BASH_SOURCE[0]` to resolve the script's own location at runtime:

1. **Relative path check** — navigate two directory levels up from `extensions/dataforseo/` to the plugin root and look for `skills/seo` there. This handles running the script directly from the plugin cache path.

2. **Glob fallback** — search `~/.claude/plugins/cache/agricidaniel-seo/claude-seo/*/skills/seo` for any cached version. Guards against edge cases where the script is run from an unrelated directory.

Traditional `~/.claude/skills/seo` installs are checked first and are completely unaffected.

The `|| true` on the glob line makes it safe under `set -euo pipefail` when no matches exist.

## Scope

- **Included:** detection logic for marketplace-installed claude-seo in the dataforseo extension installer
- **NOT included:** changes to the firecrawl or banana extension installers (they have the same structure and could benefit from a similar fix, but that is a separate concern)

## Verification

Manual simulation covering all three scenarios (results below):

```bash
# Scenario 1: traditional install
Traditional install → SEO_SKILL_DIR=/tmp/test_trad/.claude/skills/seo
✓ Detection passed

# Scenario 2: marketplace install (no traditional path)
Marketplace install → SEO_SKILL_DIR=.../.claude/plugins/cache/agricidaniel-seo/claude-seo/1.9.0/skills/seo
✓ Detection passed

# Scenario 3: not installed at all
Not installed → SEO_SKILL_DIR=/tmp/test_none/.claude/skills/seo
✓ Correctly reports not installed
```

Bash syntax check: `bash -n extensions/dataforseo/install.sh` → OK

## AI Disclosure

AI-assisted implementation (Claude Code), manually reviewed, logic verified with bash simulation tests, and tested against all three installation scenarios before submission.