### PR TITLE
fix(pagespeed_check): KeyError 'audit_details' — missing init in run_pagespeed result dict

### DIFF
--- a/scripts/pagespeed_check.py
+++ b/scripts/pagespeed_check.py
@@ -98,6 +98,7 @@ def run_pagespeed(
         "passed_audits_count": 0,
         "seo_audits": [],
         "accessibility_audits": [],
+        "audit_details": {},
         "analysis_timestamp": None,
         "error": None,
     }


### PR DESCRIPTION
## Bug

`scripts/pagespeed_check.py` raises `KeyError: 'audit_details'` on every PSI run (verified on v1.8.2 and v1.9.6 — same code path, untouched between releases).

The `result` dict is initialized at line 89 of `run_pagespeed()` without an `audit_details` key, but line 290 then assigns to `result["audit_details"][audit_id]` — failing on the first audit with both `details.items` and `details.headings` (typically `unused-javascript` or `render-blocking-resources`).

## Reproduce

```bash
python3 scripts/pagespeed_check.py https://example.com --strategy mobile --json
```

```
Traceback (most recent call last):
  File "scripts/pagespeed_check.py", line 649, in <module>
    main()
  File "scripts/pagespeed_check.py", line 524, in main
    result = combined_check(args.url, api_key=api_key, strategy=args.strategy)
  File "scripts/pagespeed_check.py", line 452, in combined_check
    psi_result = run_pagespeed(url, strategy=strat, api_key=api_key)
  File "scripts/pagespeed_check.py", line 290, in run_pagespeed
    result["audit_details"][audit_id] = {
KeyError: 'audit_details'
```

## Fix

One-line addition to the `result` init in `run_pagespeed()`:

```diff
         "passed_audits_count": 0,
         "seo_audits": [],
         "accessibility_audits": [],
+        "audit_details": {},
         "analysis_timestamp": None,
         "error": None,
     }
```

After the fix, the previously-broken `audit_details` block (lines 270-295) populates as designed — capturing the top items per audit (e.g., which specific resources are flagged in `unused-javascript`, `unsized-images`, `largest-contentful-paint-element`).

## Verification

Confirmed working on both `--strategy mobile` and `--strategy desktop` against `https://furoma.online`. Sample output post-patch (mobile):

```json
{
  "psi": {
    "mobile": {
      "lighthouse_scores": {"performance": 45, "seo": 100, "accessibility": 92, "best-practices": 92},
      "audit_details": {  // ← previously crashed; now populated with 33 audit-detail blocks
        "unused-javascript": {"title": "Reduce unused JavaScript", "headings": [...], "items": [...]},
        ...
      }
    }
  }
}
```

## Environment

- Reproduced on plugin v1.8.2 and v1.9.6
- Python 3.9.6 (macOS system)

Single-file change. Happy to add a test if there's a test harness convention you'd like to follow.