### PR TITLE
fix: update README.md install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Comprehensive SEO analysis skill for Claude Code. 21 core sub-skills covering te
 /plugin marketplace add AgriciDaniel/claude-seo
 
 # Install plugin
-/plugin install claude-seo@AgriciDaniel-claude-seo
+/plugin install claude-seo@agricidaniel-seo
 ```
 
 ### Manual Install (Unix/macOS/Linux)


### PR DESCRIPTION
## Summary
The /plugin install claude-seo@AgriciDaniel-claude-seo command fails with the "Marketplace "AgriciDaniel-claude-seo" not found" error. 
Updated documentation with the right command.
<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [skipped] CHANGELOG.md updated with the change
