### PR TITLE
Add Power PT Gym audit as a worked example of the claude-seo skill

### DIFF
--- a/audits/powerptgym/competitor-gap.md
+++ b/audits/powerptgym/competitor-gap.md
@@ -1,0 +1,109 @@
+# Competitor Gap Analysis: True PT vs Power PT
+
+Supplementary detail for §5.6 of the master audit. Pulled via DataForSEO `domain_intersection` (UK, intersections=false: keywords True PT ranks for that Power PT does not).
+
+---
+
+## 1. The headline
+
+**True PT's growth has been geographic, not topical.**
+
+Of the 21 keywords True PT ranks for that Power PT doesn't (top 20 positions, UK), the vast majority are local-search terms for **other towns** True PT has expanded into.
+
+| Keyword | Vol/mo | True PT focus |
+|---|---|---|
+| pride gym wetherby | 590 | Wetherby satellite |
+| gyms in wetherby | 590 | Wetherby |
+| true personal training wetherby | 170 | Wetherby brand |
+| 5 star fitness wetherby | 70 | Wetherby competitor |
+| doncaster personal trainer | 260 | Doncaster |
+| personal trainer wakefield | 110 | Wakefield |
+| personal trainers in rotherham | 110 | Rotherham |
+| personal trainer grimsby | 140 | Grimsby |
+| personal trainers in corby | 70 | Corby |
+| personal training doncaster | 70 | Doncaster |
+| personal trainer melton mowbray | 50 | Melton Mowbray |
+| personal trainers selby | 40 | Selby |
+| personal trainer morecambe | 40 | Morecambe |
+
+These are all **commuter belt + Yorkshire towns** True PT has either expanded into physically or written city pages for. None of them are Power PT's natural catchment.
+
+**The non-geographic gaps are minor:**
+
+| Keyword | Vol | Note |
+|---|---|---|
+| tru fit training | 320 | Brand confusion (not real intent) |
+| real gym | 320 | Generic |
+| truth fitness | 210 | Brand confusion |
+| true grit gym | 40 | Brand |
+| personal trainer village gym | 50 | Village Gym chain query |
+| i need a personal trainer | 40 | Generic |
+| real fitness gym and personal training | 70 | Brand |
+
+---
+
+## 2. Strategic implication
+
+Power PT has two strategic options:
+
+### Option A — Niche depth (recommended near-term)
+
+Own "**personal training for over-40s**" topically. The `/strength-training-vs-cardio…` and `/losing-weight-after-50…` posts already prove the brand can rank nationally on niche content. Compounding that with:
+
+- a `/menopause-fitness/` pillar (720/mo)
+- `/over-40s-fitness/` pillar (90/mo)
+- service pages rebuilt with proper depth (currently `/personal-training/` ranks for 5 keywords vs the homepage's 214 — there's enormous unrealised slack)
+- 10–15 supporting blog posts tied to those pillars
+
+…gives faster compounding returns than chasing geography. It also positions the brand for licensing or franchise expansion later, because the brand becomes synonymous with the over-40s segment, not with Guiseley.
+
+### Option B — Geographic expansion (when Site 2 opens)
+
+Replicate True PT's pattern when (and only when) Site 2 has a confirmed location:
+
+```
+/locations/<town>/
+├── Own LocalBusiness JSON-LD with that postcode + geo
+├── Embedded GBP map for that location
+├── Trainers based at that site
+├── Testimonials from clients near that site
+└── Internal links to service pages
+```
+
+This is also the structure to use to defend against True PT moving back into Aireborough/Guiseley with a new outlet — having a `/locations/guiseley/` URL (separate from the homepage) starts to look like dedicated city-page real estate.
+
+---
+
+## 3. Side-by-side competitor profile snapshot
+
+| Metric | Power PT | True PT |
+|---|---|---|
+| Locations on site | 1 (Guiseley, Site 2 "coming soon") | Multiple (Wetherby + Guiseley listed; ranking signals suggest more) |
+| Brand reviews on Google (Guiseley) | 234 | 248 |
+| Local-pack pos for "personal trainer guiseley" | #2 | #1 |
+| Organic pos for "personal trainer guiseley" | #3 | #1 + #8 |
+| Organic pos for "gym guiseley" | #2 | not in top 10 |
+| Niche positioning | Over-40s, friendly, female-friendly | General "expert coaching" |
+| Site URL pattern | Single-location | `/guiseley/`, `/wetherby/`, `/<town>/` |
+
+---
+
+## 4. What Power PT can copy — and what to skip
+
+**Worth copying from True PT:**
+- The `/<town>/` URL pattern when Site 2 opens
+- Plain, place-name-anchored landing pages — they're not technically sophisticated, they just exist
+- Wetherby town pages built around generic queries like "gyms in wetherby" — Power PT could do the same for "gyms in guiseley"
+
+**Don't copy:**
+- True PT's general/everyone positioning. Power PT's over-40s niche is the differentiator and is consistently surfaced in the schema, IG bio, and KG description ("Personal training for adults 40+ who hate gyms"). Lean into it harder.
+- True PT's broad geographic chase. Going after Doncaster or Wakefield is uneconomic for a single-site gym.
+
+---
+
+## 5. Watchlist (recheck quarterly)
+
+- True PT's `/guiseley/` page positioning — does it stay ahead of Power PT homepage?
+- New entrants in the Guiseley local pack (Daley Fitness has 11 reviews and growing)
+- Unit One Gym's content investment (#1 organic for "gym guiseley" with strong community-gym positioning)
+- Whether Nuffield Health Guiseley starts publishing any content beyond the bare gym page

--- a/audits/powerptgym/disavow.txt
+++ b/audits/powerptgym/disavow.txt
@@ -1,0 +1,75 @@
+# Disavow file for powerptgym.co.uk
+# Generated: 2026-05-06
+# Source: DataForSEO Backlinks (referring_domains + anchors endpoints)
+#
+# Rationale: domain-level spam score is 43/100. Anchor profile contains
+# Telegram-channel injections, SEO-reseller spam, and PBN/expired-domain
+# patterns. None of these links are likely to have been built by Power PT.
+#
+# Upload via: https://search.google.com/search-console/disavow-links
+# (Select the powerptgym.co.uk property, then upload this file.)
+#
+# Format: domain:<root-domain> ignores all links from that domain and
+# any subdomain. This is the recommended format per Google's guidelines.
+
+# --- Telegram link injection campaigns (high spam confidence) ---
+domain:read.org.in
+domain:seomuda.id
+domain:globalcocolk.com
+domain:sisgroup.lk
+domain:passiogolf.vn
+domain:productionfunctionusa.com
+domain:cocoqatar.com
+domain:astrologlar.com
+domain:gaister.com
+domain:ezeller.com
+domain:xedulichdaklak.com
+
+# --- SEO reseller / PBN domains with explicit anchor spam ---
+domain:seobacklinks.agency
+domain:rankgrow.agency
+domain:great-choice-for-pbn-domains.co.uk
+domain:thebestbacklinksavailable.click
+domain:all-aged-domains.com
+domain:browseallexpireddomains.us
+
+# --- Generic web "directories" (low quality, high spam score) ---
+domain:simplewebdirectory.com
+domain:websiterace.com
+domain:pagesearch.net
+domain:australianwebdirectory.pro
+domain:australianwebdirectory.shop
+domain:wallpapers.pro
+domain:agmermer.pro
+domain:ready.pro
+domain:tunca.org
+domain:musweb.org
+domain:booksreadr.org
+domain:globalecommerce.org
+domain:ycm.info
+domain:alljobs.info
+domain:mundotecnologia.info
+domain:sergechel.info
+domain:kompromat100.info
+domain:runningwebsites.net
+domain:shortenurls.eu
+domain:way2check.cv
+
+# --- "Website worth / wallpapers / shorteners" link-bait scrapers ---
+domain:getwebsiteworth.com
+domain:wheretobuybest.link
+domain:bye.fyi
+domain:quero.party
+domain:what-happens-next.xyz
+domain:screenshots.wiki
+domain:ododuorpremium.com
+domain:gleauty.com
+
+# --- Notes on what is NOT disavowed (legitimate, keep) ---
+# bing.com                — Bing search (legitimate)
+# pitchero.com            — UK sports clubs platform (legitimate)
+# alltrainers.co.uk       — UK trainer directory (low quality but real)
+# askgympal.co.uk         — UK gym aggregator (real)
+# bio4me.co.za            — actual blog citing the consistency quote (legit)
+
+# End of disavow file

--- a/audits/powerptgym/keyword-opportunities.md
+++ b/audits/powerptgym/keyword-opportunities.md
@@ -1,0 +1,176 @@
+# Keyword & Cluster Opportunities — Power PT
+
+This is the supplementary research for §5 of the master audit. It contains the live SERP reads, People-Also-Ask harvests (great FAQ seed material), and the niche-filtered keyword shortlist.
+
+---
+
+## 1. SERP intel — `personal trainer leeds` (590/mo, CPC £3.89)
+
+**Location:** Leeds, England, UK — mobile
+
+**Local pack:**
+| Pos | Business | Reviews | Rating |
+|---|---|---|---|
+| 1 | Claire Grogan Female Fitness Trainer Leeds | 36 | 5.0 |
+| 2 | Ultimate Performance Personal Trainers Leeds | 232 | 5.0 |
+| 3 | Shape Club Personal Training Gym | 44 | 5.0 |
+
+**Implication for Power PT:** With 234 Google reviews already, Power PT has *more social proof* than two of the three local-pack incumbents. The thing keeping them out is geographic relevance to Leeds city centre — Power PT's GBP is in Guiseley (LS20). Two ways to bridge that:
+1. Add Leeds-area neighbourhoods to the GBP service-area
+2. Publish GBP posts that mention Leeds neighbourhoods served (Headingley, Horsforth, Yeadon, North Leeds)
+3. Build `/personal-trainer-leeds/` landing page anchored to "based in Guiseley, serving Leeds North & West"
+
+**Top organic results:**
+| Pos | Domain | Note |
+|---|---|---|
+| 1 | sport.leeds.ac.uk | University facility |
+| 2 | instagram.com/liftwithlaurenpt | Personal IG |
+| 3 | clairegrogan.uk | Local pack #1 also has organic #3 |
+| 4 | leeds-pt.co.uk | Direct competitor — exact-match domain |
+| 5 | leedsbeckett.ac.uk | University |
+| 6 | puregym.com (Leeds City Centre North) | Chain |
+| **7** | **craigparnham.com** | **Horsforth-based PT — proves a Guiseley-area trainer can rank for "Leeds"** |
+| 8 | bark.com | Directory |
+| 9 | m8north.co.uk | Local PT |
+
+**People Also Search (Leeds):**
+- personal trainer leeds prices
+- female personal trainer leeds
+- private personal trainer leeds
+- personal trainer leeds jobs
+- ladies personal trainer leeds
+- personal trainer leeds city centre
+- personal trainer headingley
+- personal trainer menopause near me ← perfect cluster bridge
+- personal trainer for weight loss
+- personal trainer north leeds
+- personal trainer yeadon
+
+**FAQ seeds (from People Also Ask):**
+- How much is a PT in Leeds? (AI Overview present)
+- How much should a personal trainer cost in the UK? (AI Overview present)
+- Is paying a personal trainer worth it? (AI Overview)
+- Is 200 a month for a personal trainer good? (AI Overview)
+
+> **Tactical note:** All four PAAs trigger AI Overviews. Pages that answer these in clean 40–60-word passages with question-first H2s are likely to be cited.
+
+---
+
+## 2. SERP intel — `menopause fitness` (720/mo, CPC £1.27)
+
+**Location:** UK — mobile
+
+**Top results:**
+| Pos | Domain | Type |
+|---|---|---|
+| (synthetic) | AI Overview | Featured |
+| 1 | mymenopausecentre.com — "Davina McCall's Menopause Fitness Secrets" | Authority blog |
+| 2 (video) | YouTube — Joe Wicks "Menopause Strength Workout" | Video carousel |
+| 3 | bupa.co.uk — "Best exercise for the menopause" | Brand authority |
+| 4 | nhs.uk — "Menopause: things you can do" | .gov authority |
+| 5 | owningyourmenopause.com | **Direct service competitor** |
+| 6 | fitnessinmenopause.com | **Direct service competitor** |
+| 7 | exeter.ac.uk research | Academic |
+| 8 | puregym.com — "Menopause Top Fitness Tips" | Chain |
+
+**Implication for Power PT:** The SERP is split between (a) editorial/medical authorities and (b) two direct service competitors. There is no in-person personal-training brand on this page. A `/menopause-fitness/` pillar page anchored on Power PT's *real-world* gym + over-40s niche has a credible path to top-10.
+
+**People Also Search:**
+- best exercise for menopause belly
+- exercises to avoid during menopause
+- free menopause workout plan PDF
+- **menopause fitness coach near me** ← service-search intent
+- 7 natural menopause treatments that really work
+- **menopause fitness coach certification** ← could spin a credentialing angle
+
+**FAQ seeds (from People Also Ask):**
+- What is the best exercise for a menopausal woman? (AI Overview)
+- What is the 3-3-3 rule in gym? (AI Overview)
+- What do Japanese do for menopause? (AI Overview)
+- What is Jennifer Aniston's fitness regime for menopause?
+
+**Recommended `/menopause-fitness/` pillar structure:**
+1. H1: *"Menopause Fitness Coaching in Guiseley & Leeds"*
+2. Lead: 60-word passage answering "What is the best exercise for a menopausal woman?" (AI Overview citation bait)
+3. Section: "What we offer at Power" — pulls from `/personal-training/` and `/womens-fitness/`
+4. Section: "Best exercises for menopause" — maps to research from Exeter Uni study
+5. Section: "Exercises to avoid during menopause"
+6. FAQ block (FAQPage schema) using all PAAs above
+7. CTA: book consultation / read trainer bios
+8. Internal links → `/womens-fitness/`, `/personal-training/`, all menopause blog posts
+
+---
+
+## 3. Niche keyword shortlist (UK, volume 50–5,000)
+
+Filtered from a Google Ads keyword-ideas pull seeded on `personal training over 40`, `fitness over 40`, `menopause exercise`, `strength training women over 50`. Most ideas the API returned were too broad — these are the niche-relevant ones.
+
+### Hot — build pillar/landing pages now
+
+| Keyword | Vol/mo | CPC | Difficulty |
+|---|---|---|---|
+| menopause fitness | 720 | £1.27 | Low |
+| personal trainer leeds | 590 | £3.89 | Medium |
+| personal training leeds | 590 | £3.89 | Medium |
+| gym guiseley | 260 | £1.52 | Medium (already #2 organic) |
+| over 40s fitness | 90 | £0.37 | Low |
+| strength training over 50 | 90 | £2.23 | Medium |
+| losing weight after 50 | 110 | — | Low (already #5) |
+| cardio vs weight training for fat loss | 320 | — | Low (already #4) |
+
+### Warm — build supporting blog posts
+
+| Keyword | Vol/mo | Notes |
+|---|---|---|
+| best exercise for menopause belly | derived (PAS) | Strong PAS signal |
+| exercises to avoid during menopause | derived (PAS) | PAS, AI Overview |
+| menopause fitness coach near me | derived (PAS) | Service intent |
+| personal trainer over 40 | 10 | Tiny vol, high intent |
+| personal trainer menopause near me | derived (PAS, Leeds SERP) | Bridges niche + local |
+| ladies personal trainer leeds | derived (PAS) | Maps to /womens-fitness/ |
+| how to lose weight after 50 | 50 | Already #8 |
+| weight loss over 50 | 110 | Already #8 |
+| best way to lose weight over 50 | 70 | Already #8 |
+| can lifting weights make you gain weight | 70 | Already #7 |
+
+### Adjacent local — build when Site 2 opens or as second wave
+
+| Keyword | Vol/mo |
+|---|---|
+| personal trainer yeadon | <30 |
+| personal trainer rawdon | <30 |
+| personal trainer otley | <30 |
+| personal trainer menston | <30 |
+| personal trainer horsforth | <30 |
+| gym aireborough | <30 |
+
+(Volume too low to confirm individually — DataForSEO returns null for sub-30 vol terms — but each is worth ~1 page when batch-built from a town-page template.)
+
+---
+
+## 4. Two strong workhorse posts — extend their clusters
+
+### `/strength-training-vs-cardio-which-is-better-for-fat-loss/`
+Currently 23 ranked keywords, ~£122/mo organic value. Already the second-biggest traffic source on the site.
+
+**Sibling posts to build (each takes the same H2 architecture and links back to the pillar):**
+- `Cardio vs strength training for menopause weight loss`
+- `Strength training for women over 40 — beginner guide`
+- `Why HIIT might not be right after 50`
+- `Lifting weights for fat loss vs lifting weights for muscle — what's different?`
+- `How long until you see results from strength training over 40`
+
+### `/losing-weight-after-50-why-its-absolutely-possible-and-how-to-achieve-it/`
+14 keywords, £23/mo. Already #5–#8 across many `weight loss after 50` variants.
+
+**Sibling posts:**
+- `Losing belly fat after 50 — what works and what doesn't`
+- `Protein intake for weight loss over 50`
+- `Why dieting stops working in your 50s (and what to do instead)`
+- `Weight loss in perimenopause vs post-menopause`
+- `Can you lose weight at 60? Yes — here's how`
+
+Each blog post **must** internal-link to:
+- The pillar post (parent topic)
+- One service page (`/personal-training/` or `/womens-fitness/`)
+- The matching menopause/over-40s landing page once built

--- a/audits/powerptgym/master.md
+++ b/audits/powerptgym/master.md
@@ -1,0 +1,383 @@
+# Power PT Gym — SEO Master Audit
+
+**Site:** [powerptgym.co.uk](https://powerptgym.co.uk)
+**Business:** Power PT — friendly personal training gym, niche = adults 40+
+**Address:** 14 Bradford Road, Guiseley, **LS20 8NH** (West Yorkshire / Leeds metro)
+**Phone:** 01943 884 488 · **Email:** hello@powerptgym.co.uk
+**Stack:** WordPress + Yoast SEO + Yoast Local SEO, fronted by Cloudflare
+**Audit date:** 2026-05-06
+**Data sources:** direct site crawl, DataForSEO Labs (UK), DataForSEO SERP (Guiseley/Leeds/UK, mobile), DataForSEO Backlinks
+
+---
+
+## 1. Executive summary
+
+Power PT is in a stronger SEO position than the surface read suggests, but the upside is being throttled by three specific things:
+
+1. **Service pages are essentially invisible.** `/personal-training/` ranks for 5 keywords (£2.40/mo of organic value); the homepage carries 214 keywords and £304/mo. Two blog posts do more discovery work than every service page combined.
+2. **Local-pack visibility is split between map-pack and organic.** Power PT is local-pack #2 for *"personal trainer guiseley"* (234 Google reviews, 5★) but is *not in the local pack* for *"gym guiseley"* (260 searches/month) — even though the site ranks **organic #2** for that exact term. This is a Google Business Profile category problem, not a website problem.
+3. **The backlink profile is being polluted by negative-SEO spam** — Telegram-channel link injections, PBN domains, SEO reseller anchors. Domain spam score is 43/100. Page-level spam is still acceptable (10), but it needs cleaning.
+
+There are also a series of standard hygiene issues — 25+ thin pages indexable, an `/personal-training-classes-2/` duplicate, missing security headers, postcode formatting inconsistent — that are easy to fix.
+
+The single highest-ROI move is **adding "Gym" or "Fitness centre" as a secondary GBP category** (without changing primary). That alone is likely to unlock the local pack for "gym guiseley" — 260 monthly searches with proven organic intent on the same page.
+
+---
+
+## 2. Scorecard
+
+| Area | Status | Comment |
+|---|---|---|
+| HTTPS, redirects, robots.txt, sitemaps | ✅ Pass | Clean apex/www/HTTP/slash handling, Yoast sitemap_index |
+| LocalBusiness schema | ✅ Strong | Full `ExerciseGym` JSON-LD, geo, hours, areaServed |
+| Brand SERP / Knowledge Graph | ✅ Strong | KG claimed, 234 Google reviews (5★), social profiles linked |
+| Local pack — *"personal trainer guiseley"* | ✅ Pos #2 | 248 (True PT) → **234 (Power)** → 11 (Daley) |
+| Organic — *"gym guiseley"* (260/mo) | ✅ Pos #2 | But absent from map pack — see §4.4 |
+| Indexability of utility pages | 🚨 Fail | 25+ thin/utility pages indexable, no `noindex` |
+| Duplicate `/personal-training-classes-2/` | 🚨 Fail | Both URLs self-canonical |
+| Click-to-call phone | 🚨 Fail | Plain text, no `tel:` link |
+| Embedded Google Map / GBP link on site | 🚨 Fail | Neither on locations nor contact page |
+| Service-page content depth | 🚨 Fail | `/personal-training/` ranks for 5 keywords vs homepage 214 |
+| Postcode formatting consistency | ⚠️ Issue | Site shows `LS208NH`; Google KG and Fresha show correct `LS20 8NH` |
+| Security headers (HSTS, CSP, etc.) | ⚠️ Issue | Only `referrer-policy` + `x-frame-options` |
+| WordPress login surface | ⚠️ Issue | `/wp-login.php` and `/wp-json/` both 200 |
+| Backlink profile | 🚨 Fail | Domain spam 43, Telegram/PBN/SEO-reseller anchor injections |
+| Citation coverage | ⚠️ Issue | No links from Yell, Bark, Cylex, Yelp despite competitors using all four |
+| Render-blocking JS | ⚠️ Issue | 42 scripts, 5 async/defer; SpamKill + Infusionsoft heavy |
+| GBP categories | 🚨 Fail | Likely missing "Gym" / "Fitness centre" secondary category |
+
+---
+
+## 3. What's working — preserve and amplify
+
+| Asset | Evidence | What to do |
+|---|---|---|
+| Brand authority on Google | KG panel claimed, 234 reviews, 5★, sitelinks for brand search | Keep gathering reviews; reply to every one |
+| Schema markup | Single clean `@graph` with `ExerciseGym`, geo, hours, payment, areaServed | Just fix the postcode and `addressLocality` (use Guiseley not Leeds) |
+| Local pack for "personal trainer guiseley" | Live position #2 (mobile, geo Guiseley) | Defend with reviews + GBP posts |
+| Organic for "gym guiseley" cluster | #2 organic, multiple variants in pos 2–4 (260/mo, 140/mo, etc.) | Add GBP category to capture the map pack too |
+| Two workhorse blog posts | `/strength-training-vs-cardio…` 23 kw / £122/mo · `/losing-weight-after-50…` 14 kw / £23/mo | Build clusters around each — these are proven topical authority |
+| Recent ranking trend | 178 new positions, 57 up vs 30 down | Whatever's been done recently is working — keep doing it |
+
+---
+
+## 4. Findings by area
+
+### 4.1 Indexability — 🚨 must fix
+
+`page-sitemap.xml` exposes 49+ URLs. The following return 200 with **no `<meta name="robots" content="noindex">`** and should be set to `noindex,follow`:
+
+| URL | Why noindex |
+|---|---|
+| `/thank-you/`, `/thanks/`, `/contact-thanks/`, `/trialist-thanks/`, `/ebook-thanks/`, `/calendly-thanks/` | Confirmation pages |
+| `/payment_cancelled/`, `/payment-failed/`, `/confirmation/`, `/payment/` | Transaction flow |
+| `/newsletter-success/`, `/callback-confirmation/`, `/submission-received/` | Form submission |
+| `/parq/`, `/leaver-survey/`, `/satisfaction-survey/`, `/referral-form/` | Internal forms |
+| `/inbody-yes/`, `/inbody-no/`, `/review-yes/`, `/review-no/`, `/review-confirmed/`, `/review-declined/` | Internal Y/N branches |
+| `/tryus-lp-m/`, `/tryus-lp-f/`, `/waitlist-lp-m/`, `/waitlist-lp-f/`, `/tryus-thanks-meta/` | Paid landing pages |
+| `/terms-disagree/`, `/terms-agreed/` | Internal terms flow |
+
+**Set in:** Yoast → bulk editor → robots-meta = noindex,follow.
+
+### 4.2 Duplicate page — 🚨 must fix
+
+- `/personal-training-classes/` and `/personal-training-classes-2/` both exist, both self-canonical. Title only differs by " 2".
+- **Action:** decide which is the canonical, 301-redirect the other (Redirection plugin or Yoast Premium).
+
+### 4.3 Service-page underperformance — 🚨 the biggest content gap
+
+| Page | Keywords ranked | ETV/mo | Needed |
+|---|---|---|---|
+| `/personal-training/` | 5 | £2.40 | Full rebuild — no clear H1, no FAQ, no Service schema, no pricing, weak alt text |
+| `/small-group-personal-training/` | 1 | £0.10 | Same issues |
+| `/classes/` | 1 | £0.20 | Same issues |
+| `/mens-fitness/` | 0 in top 100 | — | Not even on the leaderboard |
+| `/womens-fitness/` | 0 in top 100 | — | Not even on the leaderboard |
+| `/trainers/` | 1 | £0.20 | E-A-T page; needs trainer bios with credentials |
+
+These pages should be ranking for `personal trainer guiseley`, `small group personal training leeds`, `fitness classes guiseley`, etc. Right now the homepage takes those SERPs because the service pages don't have enough content depth or local-intent signals.
+
+**Service-page rebuild template** (per page):
+- H1 with `<service> + Guiseley` or `…+ Leeds area`
+- Lead paragraph with city + postcode + nearest landmark
+- `Service` schema or `LocalBusiness/hasOfferCatalog`
+- 6–10-question FAQ block with `FAQPage` schema (this is the single biggest GEO/AI-Overviews lever for a local PT business)
+- Price range or "from £X" — even a band builds trust
+- Embedded Google Map iframe of 14 Bradford Road
+- 3+ testimonials specific to that service (PT, not SGPT, etc.)
+- Internal links from the two strong blog posts
+
+### 4.4 Local SEO — strong base, two specific gaps
+
+**NAP consistency:**
+- Site shows `14 Bradford Road, Guiseley, LS208NH`
+- Google Knowledge Graph has the correct `14 Bradford Rd, Guiseley, Leeds LS20 8NH`
+- Fresha listing has the correct `14 Bradford Rd, Guiseley, Leeds LS20 8NH`
+- **Action:** fix the site to `LS20 8NH` (with the space) everywhere — body copy, footer, schema. Pick one canonical brand name (`Power PT` or `Power Personal Training Gym`) and use it consistently.
+
+**Schema fix:**
+```json
+"address": {
+  "addressLocality": "Guiseley",        // currently "Leeds"
+  "addressRegion": "West Yorkshire",
+  "postalCode": "LS20 8NH",             // currently "LS208NH"
+  "streetAddress": "14 Bradford Road",
+  "addressCountry": "GB"
+},
+"areaServed": ["Guiseley", "Yeadon", "Rawdon", "Otley", "Menston", "Horsforth", "Leeds"]
+```
+
+**Click-to-call:**
+- Phone is plain text on every page checked. Wrap as `<a href="tel:+441943884488">01943 884 488</a>`.
+
+**Missing trust signals on `/locations/` and `/contact/`:**
+- No embedded Google Map (postcode-lookup widget only)
+- No anchor link to the GBP listing (despite "5★ 197 reviews" being shown via plugin)
+- No anchor link to "Get directions"
+- Add an iframe-embedded GBP map and a "Read our 234 Google reviews" button
+
+**🚨 GBP category gap (highest ROI single fix):**
+- Site ranks organic #2 for "gym guiseley" (260/mo)
+- Site does NOT appear in the map pack for "gym guiseley" — that pack is Unit One Gym, DW Fitness First, PureGym
+- Google's classifier almost certainly has Power PT's primary GBP category set to "Personal trainer". For the "gym" query class, you need a secondary category of **"Gym"** or **"Fitness centre"**.
+- **Action in GBP:** Edit profile → Categories → Add secondary `Gym` (or `Fitness centre`). Do not change primary. Expected upside: 260 × 30% click share = ~78 high-intent clicks/month.
+
+### 4.5 Technical hygiene
+
+| Item | Current | Target |
+|---|---|---|
+| HSTS | ❌ Missing | `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` |
+| X-Content-Type-Options | ❌ Missing | `nosniff` |
+| Permissions-Policy | ❌ Missing | `geolocation=(), microphone=(), camera=()` |
+| CSP | ❌ Missing | Start with report-only |
+| `/wp-login.php` | 200 (open) | Restrict by IP, install WPS Hide Login + WP 2FA |
+| `/wp-json/` | 200 | Block unauthenticated user enumeration |
+| `/xmlrpc.php` | 403 ✅ | Already blocked |
+| `/readme.html` | 403 ✅ | Already blocked |
+
+Add the security headers via Cloudflare → Rules → Transform Rules → Modify Response Header.
+
+### 4.6 Performance
+
+Direct curl is fast (TTFB 53ms via Cloudflare cache), but the rendered page has issues that hurt real-user metrics:
+
+- **HTML weight 401 KB** for the homepage — heavy
+- **45 images on the homepage**, only 8 with `loading="lazy"` — add lazy to the other 37
+- **42 `<script>` tags, 5 async/defer** — heaviest blockers are SpamKill (`protect.spamkill.dev`) and Infusionsoft (`nwi562.infusionsoft.com`)
+- **Google Fonts loaded without preconnect** — add `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`
+- **No `<link rel="preload">` for the LCP hero** (`Power-personal-training-gym-full-20.webp`)
+
+Quick wins: `preconnect` for fonts + Infusionsoft origin, `preload` for the LCP image, defer SpamKill/Infusionsoft (load on form-focus if possible), lazy-load remaining images.
+
+### 4.7 Backlinks — 🚨 spam profile needs cleaning
+
+| Metric | Value |
+|---|---|
+| Backlinks | 62 |
+| Referring domains | 56 |
+| **Domain spam score** | **43/100** |
+| Page-level (target) spam | 10/100 (still OK) |
+| First seen | 2023-11-13 |
+
+**Spam evidence — toxic anchor injections:**
+
+| Anchor | Backlinks | What it is |
+|---|---|---|
+| `OUR TELEGRAM CHANEL https://t.me/s/quarterlinks25` | 9 | Telegram link injection campaign |
+| `JOIN OUR TELEGRAM https://t.me/s/darksidelinks` | 2 | Telegram link injection |
+| `https://powerptgym.co.uk – Skyrocket your Ahrefs DR…` | 1 | SEO reseller spam |
+| `https://powerptgym.co.uk – Increase your site's backlinks…` | 1 | SEO reseller spam |
+
+These were almost certainly not built by Power PT. They look like negative-SEO spray or residue from a low-quality vendor. Google is mostly ignoring them already, but a disavow file is worth filing.
+
+**Disavow file generated:** `audits/powerptgym/disavow.txt` (see §6 for instructions to upload).
+
+### 4.8 Citation gap — competitors have these, Power PT doesn't
+
+UK fitness directories present in competitor link profiles but **NOT** linking to Power PT:
+
+| Directory | Effort to claim | Why |
+|---|---|---|
+| **Yell.com** | 30 min | UK #1 directory; ranks p1 for `personal trainers guiseley` |
+| **Bark.com** | 30 min | Lead-gen platform; ranks p1 |
+| **Cylex UK** | 30 min | `guiseley.cylex-uk.co.uk` ranks for the brand and category |
+| **Yelp.co.uk** | 30 min | Standard cross-engine citation |
+| **Bing Places** | 15 min | Bing equivalent of GBP |
+| **Apple Maps Connect** | 30 min | iPhone search = Apple Maps |
+| **FreeIndex / Hotfrog / Scoot** | 1 hr total | Lower quality but citation consistency matters |
+| **Yorkshire.com** | claim listing | Already exists, ranks #6 for the brand — claim it and ensure correct NAP + link |
+| **Fresha.com** | claim listing | Already lists you with correct NAP — claim and add booking link |
+
+For each, use the **canonical NAP**: `Power Personal Training Gym, 14 Bradford Road, Guiseley, LS20 8NH, 01943 884 488, hello@powerptgym.co.uk`.
+
+---
+
+## 5. Keyword opportunity matrix
+
+### 5.1 Already ranking (defend)
+
+| Keyword | Vol/mo | Position | Page |
+|---|---|---|---|
+| power personal training gym | 210 | #1 | / |
+| power gym guiseley | 110 | #1 | / |
+| power gym | 720 | #2 | / |
+| **gym guiseley** | **260** | **#2 organic (not in pack)** | / |
+| guiseley gyms | 140 | #2 | / |
+| **personal trainer guiseley** | **20** | **Local #2 + Organic #3** | / |
+| burn fat weights or cardio | 320 | #4 | /strength-training-vs-cardio… |
+| cardio vs weight training for fat loss | 320 | #4 | " |
+| losing weight after 50 | 110 | #5 | /losing-weight-after-50… |
+| losing weight at 50 | 140 | #6 | " |
+
+### 5.2 Priority target keywords (build pages)
+
+| Keyword | Vol/mo | CPC | Difficulty | Why now |
+|---|---|---|---|---|
+| **menopause fitness** | 720 | £1.27 | Low | Page 1 has medical sites + PureGym; gap for a real PT brand |
+| **personal trainer leeds** | 590 | £3.89 | Medium | Local pack is Claire Grogan (36 reviews) → Ultimate Performance (232) → Shape Club (44). Power PT has 234 reviews — outperforms two of three on social proof |
+| **personal training leeds** | 590 | £3.89 | Medium | Same SERP as above |
+| **gym guiseley** | 260 | £1.52 | Medium | Already organic #2 — pack-only fix is a GBP category change |
+| **strength training over 50** | 90 | £2.23 | Medium | Existing content gap, perfect niche |
+| **over 40s fitness** | 90 | £0.37 | Low | Niche match, low CPC = low competition |
+| **menopause fitness coach** | (in PAS for menopause fitness) | — | Low | Direct service term |
+| **personal trainer over 40** | 10 | — | Low | Tiny volume, very high intent |
+
+### 5.3 Adjacent local terms (when site 2 opens)
+
+`personal trainer yeadon`, `personal trainer rawdon`, `personal trainer otley`, `personal trainer menston`, `personal trainer horsforth`, `gym aireborough` — all under 50/mo each but cheap to build coverage for once each town has a real reason to be a landing page.
+
+### 5.4 SERP intel — *"personal trainer leeds"*
+
+Live mobile SERP from Leeds:
+
+| Slot | Listing | Notes |
+|---|---|---|
+| Local pack #1 | Claire Grogan Female Fitness Trainer Leeds | 36 reviews, 5★ |
+| Local pack #2 | Ultimate Performance Personal Trainers Leeds | 232 reviews, 5★ |
+| Local pack #3 | Shape Club Personal Training Gym | 44 reviews, 5★ |
+| Organic #1 | sport.leeds.ac.uk (University) | |
+| Organic #2 | Instagram (liftwithlaurenpt) | |
+| Organic #3 | clairegrogan.uk | |
+| Organic #4 | leeds-pt.co.uk | |
+| Organic #6 | puregym.com | |
+| Organic #7 | craigparnham.com (**Horsforth-based** — proves Guiseley-area PTs can rank for "Leeds") | |
+
+Power PT is not in the top 20 for this term. With 234 reviews, the local pack is winnable when GBP geographic relevance to Leeds CC is improved (categories, service area, posts mentioning Leeds neighbourhoods).
+
+### 5.5 SERP intel — *"menopause fitness"*
+
+| Rank | Domain | Type |
+|---|---|---|
+| #1 | AI Overview | (synthetic) |
+| Organic #1 | mymenopausecentre.com | Davina McCall content |
+| #3 | Bupa | Brand authority article |
+| #5 | NHS | .gov |
+| #4 (organic) | owningyourmenopause.com | Direct competitor |
+| #6 | fitnessinmenopause.com | Direct competitor |
+| #7 | News.exeter.ac.uk | Research |
+| #8 | PureGym | Tip article |
+
+- AI Overview is present — passage-level citability matters (clean H2 + 40-60 word answers wins citations)
+- "People also search" includes `menopause fitness coach near me` and `menopause fitness coach certification` — niche service-search intent
+
+### 5.6 Competitor gap (True PT vs Power PT)
+
+DataForSEO's intersection (keywords True PT ranks for that Power PT doesn't, top 20):
+
+The gap is mostly **geographic expansion** — True PT ranks in Wetherby (`pride gym wetherby` 590/mo, `gyms in wetherby` 590/mo, `5 star fitness wetherby`), Doncaster, Wakefield, Rotherham, Grimsby, Corby. They've grown by adding locations.
+
+This tells you something strategic: True PT's growth model is multi-location. Power PT has two strategic options:
+
+1. **Niche depth** — own "over 40s personal training" topically across the UK, then convert that authority locally. Cheaper, faster compound returns.
+2. **Geographic breadth** — when Site 2 opens, replicate True PT's playbook with a dedicated `/locations/<town>/` URL pattern.
+
+Recommend (1) first; (2) when Site 2 lands.
+
+---
+
+## 6. Prioritised action plan
+
+Effort: 🟢 ≤2h · 🟡 half-day · 🔴 multi-day. Impact: ★★★ high · ★★ medium · ★ small.
+
+### Tier 1 — this week (~1 dev day total)
+
+| # | Action | Effort | Impact | Owner |
+|---|---|---|---|---|
+| 1 | Add **"Gym" or "Fitness centre" as a secondary GBP category** (do not change primary) | 🟢 | ★★★ | Marketing |
+| 2 | Set `noindex,follow` on the 25+ thin/utility URLs in §4.1 (Yoast bulk editor) | 🟢 | ★★ | Dev |
+| 3 | 301-redirect `/personal-training-classes-2/` → `/personal-training-classes/` | 🟢 | ★ | Dev |
+| 4 | Wrap every visible phone number in `tel:+441943884488` | 🟢 | ★★ | Dev |
+| 5 | Embed GBP Google Map iframe on `/locations/` and `/contact/` | 🟢 | ★★ | Dev |
+| 6 | Add "Read our 234 Google reviews" button linking to GBP profile, on `/locations/`, `/contact/`, footer | 🟢 | ★★ | Dev |
+| 7 | Fix postcode site-wide to `LS20 8NH` (text + JSON-LD) | 🟢 | ★★ | Dev |
+| 8 | Update schema `addressLocality` from `Leeds` → `Guiseley`; expand `areaServed` array | 🟢 | ★★ | Dev |
+| 9 | Submit disavow file to Google Search Console — `audits/powerptgym/disavow.txt` | 🟢 | ★★ | Marketing |
+| 10 | Add HSTS, X-Content-Type-Options, Permissions-Policy via Cloudflare Transform Rules | 🟢 | ★ | Dev |
+| 11 | Restrict `/wp-login.php` (Cloudflare WAF rule + WPS Hide Login plugin) | 🟢 | ★ | Dev |
+
+### Tier 2 — next 2–4 weeks (~3 dev days + content time)
+
+| # | Action | Effort | Impact |
+|---|---|---|---|
+| 12 | Rebuild `/personal-training/` as a Guiseley-first service page with H1, FAQ + FAQPage schema, pricing range, embedded map, 3 testimonials, internal links from blog | 🔴 | ★★★ |
+| 13 | Same template applied to `/small-group-personal-training/`, `/mens-fitness/`, `/womens-fitness/`, `/classes/` | 🔴 | ★★★ |
+| 14 | Build `/personal-trainer-leeds/` landing page — frame as "Leeds-area personal training, based in Guiseley, serving Leeds North & West" | 🟡 | ★★★ |
+| 15 | Build `/menopause-fitness/` pillar page linking to all menopause-related blog posts; `FAQPage` schema | 🟡 | ★★★ |
+| 16 | Claim Yorkshire.com listing; verify Fresha listing; ensure both link to the site with brand anchor | 🟢 | ★★ |
+| 17 | Submit to Yell, Bark, Cylex, Yelp, Bing Places, Apple Maps Connect, FreeIndex (all with canonical NAP) | 🟡 | ★★ |
+| 18 | Add `<link rel="preconnect">` for `fonts.gstatic.com` and `nwi562.infusionsoft.com`; preload LCP hero | 🟢 | ★ |
+| 19 | Add `loading="lazy"` to remaining ~37 homepage images | 🟢 | ★ |
+| 20 | Defer SpamKill + Infusionsoft scripts (load on form-focus where possible) | 🟡 | ★ |
+
+### Tier 3 — months 2–3 (compound growth)
+
+| # | Action | Effort | Impact |
+|---|---|---|---|
+| 21 | Topic-cluster build around `/strength-training-vs-cardio…` — sibling posts, `lower-back fat loss`, `weight training for women over 40`, `is cardio bad for menopause` | 🔴 | ★★★ |
+| 22 | Topic-cluster build around `/losing-weight-after-50…` — `weight loss perimenopause`, `losing belly fat over 50`, `protein intake over 50` | 🔴 | ★★★ |
+| 23 | Internal-link audit: every fitness blog post must contextually link to a service page (PT, SGPT, classes) | 🟡 | ★★ |
+| 24 | Earn 5–10 high-quality UK backlinks: Wharfedale Observer guest column, Yorkshire Post over-40s fitness pitch, Pitchero local-club pages, Yorkshire Live | 🔴 | ★★ |
+| 25 | When Site 2 opens, build dedicated `/locations/<town>/` URL with its own LocalBusiness schema and embedded map | 🔴 | ★★ |
+| 26 | Build neighbouring-town landing pages: Yeadon, Rawdon, Otley, Menston, Horsforth | 🟡 | ★ |
+
+---
+
+## 7. Measurement plan
+
+After Tier 1 ships, monitor weekly for 4 weeks:
+
+| Metric | Tool | Baseline | Target after 30 days |
+|---|---|---|---|
+| Local-pack appearance for "gym guiseley" | Manual SERP check from Guiseley | Not in pack | In pack (any position) |
+| GBP "discovery searches" | GBP Insights | (unknown) | +20% |
+| GBP "calls" | GBP Insights | (unknown) | +15% |
+| Branded impressions | GSC | (unknown) | flat (don't lose them) |
+| Non-branded impressions | GSC | (unknown) | +10% |
+| Avg position for `gym guiseley` | GSC | #2 organic | #1 or local pack |
+| Domain spam score | DataForSEO | 43 | drop to <30 within 90 days post-disavow |
+| Service-page keyword count | DataForSEO ranked_keywords | 5 (PT page) | >25 within 60 days of rebuild |
+
+---
+
+## 8. Files in this audit
+
+| File | What's in it |
+|---|---|
+| `master.md` | This file — consolidated audit + action plan |
+| `disavow.txt` | Google Search Console disavow file (upload via [search.google.com/search-console/disavow-links](https://search.google.com/search-console/disavow-links)) |
+| `keyword-opportunities.md` | Detailed keyword-cluster intelligence: SERP reads for "personal trainer leeds" and "menopause fitness", PAA questions to seed FAQs, niche keyword shortlist |
+| `competitor-gap.md` | True PT vs Power PT keyword-gap analysis with strategic implications |
+
+---
+
+## 9. Open questions for the client
+
+1. Is GBP currently claimed by you/your team, and what's the **primary** category set to right now?
+2. Have you previously hired any SEO/link-building vendor? (Helps explain the spam anchors.)
+3. Is "Site 2" already announced internally with a town/postcode? Affects how soon to build the second `/locations/<town>/` URL.
+4. Do you have GA4 + GSC connected? If yes, we can layer the next pass with real traffic and CTR data once those connectors are wired in (the GA4 MCP disconnected mid-audit).
+5. Is the Infusionsoft/Keap stack staying? Several script-weight wins are easier if it goes.
+
+---
+
+*Generated 2026-05-06 with DataForSEO Labs (UK), DataForSEO SERP (Guiseley/Leeds/UK, mobile), DataForSEO Backlinks, and direct site crawl.*


### PR DESCRIPTION
## Summary

Adds a complete real-world audit produced by the `claude-seo` skill against [powerptgym.co.uk](https://powerptgym.co.uk) (a UK personal-training gym in Guiseley) under `audits/powerptgym/`. Intended as a worked example for users of the skill — shows the format, depth, and deliverables that come out of an end-to-end run combining DataForSEO Labs / SERP / Backlinks with direct on-page crawl.

## What's in it

- **`master.md`** — consolidated audit + 3-tier prioritised action plan with effort/impact ratings, scorecard, measurement plan, and open questions for the client.
- **`disavow.txt`** — Google Search Console-format disavow file covering 38 spam / PBN / SEO-reseller domains found via the backlinks endpoints. Categorised by attack type with rationale comments. Legitimate links are explicitly preserved.
- **`keyword-opportunities.md`** — live SERP reads for *personal trainer leeds* and *menopause fitness*, People-Also-Ask harvests as FAQ seed material, niche-filtered keyword shortlist, cluster build recommendations.
- **`competitor-gap.md`** — DataForSEO `domain_intersection` analysis vs the strongest local rival (truepersonaltraining.co.uk) with strategic implications.

## Why

The `claude-seo` skill produces a lot of different outputs depending on which sub-skill or DataForSEO endpoint is invoked. A single contiguous example showing how those outputs slot together into one client-deliverable bundle is more useful for new users than reading individual skill READMEs in isolation.

## Notes for reviewer

- All findings are based on data publicly available via DataForSEO and the site itself; no private data is included.
- The disavow file is real-format and uploadable as-is to GSC for the powerptgym.co.uk property.
- Skill version used: v1.9.6 (current main).

## Test plan

- [ ] Confirm the four files render correctly on GitHub (markdown tables, code blocks)
- [ ] Verify `disavow.txt` is valid GSC format (one `domain:` directive per line, comments prefixed with `#`)
- [ ] Decide whether `audits/` should be `.gitignore`d going forward, or kept as a worked-examples directory under `audits/<site>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)