### PR TITLE
fix(seo-geo): add Write tool to enable report generation

### DIFF
--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -3,7 +3,7 @@ name: seo-geo
 description: GEO and AI search specialist. Analyzes AI crawler accessibility, llms.txt compliance, passage-level citability, brand mention signals, and platform-specific optimization for Google AI Overviews, ChatGPT, Perplexity, and Bing Copilot.
 model: sonnet
 maxTurns: 20
-tools: Read, Bash, WebFetch, Glob, Grep
+tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---
 
 You are a Generative Engine Optimization (GEO) specialist. When given a URL:


### PR DESCRIPTION
## Summary

The `seo-geo` agent is the only writing agent in the repo missing the `Write` tool from its frontmatter. Without it, the agent has no native file-creation path — its only option is `Bash << EOF` heredocs, which break on long markdown bodies (em-dashes, single quotes) and leave the agent stuck in heredoc-quoting retry loops. In practice, the agent burns ~12 minutes on the same URL and produces no output.

This change adds `Write` to the tools list, bringing `seo-geo` in line with every other writing agent in the repo:

| Agent | Tools |
|---|---|
| `seo-local` | `Read, Bash, WebFetch, Glob, Grep, Write` |
| `seo-sxo` | `Read, Bash, WebFetch, WebSearch, Glob, Grep, Write` |
| `seo-content` | `Read, Bash, Write, Grep` |
| `seo-schema` | `Read, Bash, Write` |
| `seo-geo` (before) | `Read, Bash, WebFetch, Glob, Grep` |
| `seo-geo` (after) | `Read, Bash, WebFetch, Glob, Grep, Write` |

## Reproduction

1. Run a full audit (`/seo-audit <url>`) on any site that triggers the seo-geo subagent.
2. Observe the agent runs to its turn budget without writing a usable report — its final "result" message is meta-commentary about Bash heredoc quoting failures.

## Test plan

- [x] Locally edited `agents/seo-geo.md`, then invoked the agent on a real audit (HVAC SAB, ~100 URLs, pre-parsed JSON inputs)
- [x] Before fix: agent timed out at ~12 min, wrote 0 bytes
- [x] After fix: agent wrote 8.6 KB / 122 lines of structured analysis (GEO score, crawler-access table, llms.txt assessment, citability rationale, authority signals, defect impact) on first try

## Notes

- One-line, frontmatter-only change. No prompt-body edits.
- Considered also adding tool-usage guidance discouraging heredoc-based file writing, but kept this PR minimal so it's easy to review and merge. Happy to send that as a follow-up if useful.