### PR TITLE
chore(v1.9.7): doc reconciliation + marketplace-readiness Phase A

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "name": "AgriciDaniel"
   },
   "metadata": {
-    "description": "SEO analysis tools for Claude Code"
+    "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills covering technical SEO, E-E-A-T, schema markup, GEO, local SEO, semantic clustering, e-commerce SEO, international SEO, and PDF reporting."
   },
   "plugins": [
     {
       "name": "claude-seo",
       "source": "./",
-      "description": "Comprehensive SEO analysis skill for Claude Code. 21 core sub-skills covering technical SEO, E-E-A-T, schema markup, image optimization, GEO/AEO, backlinks, local SEO, maps intelligence, semantic topic clustering, SXO, SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, and PDF reporting."
+      "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, E-E-A-T, schema markup, image optimization, GEO/AEO, backlinks, local SEO, maps intelligence, semantic topic clustering, SXO, SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, and PDF reporting."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-seo",
-  "version": "1.9.6",
-  "description": "Comprehensive SEO analysis skill for Claude Code. 20 core sub-skills covering technical SEO, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, and strategic planning across all industries.",
+  "version": "1.9.7",
+  "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, PDF reporting, and strategic planning across all industries.",
   "author": {
     "name": "AgriciDaniel",
     "url": "https://github.com/AgriciDaniel"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "deps"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Python Syntax Check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@
 
 ## Overview
 
-Claude SEO is a Tier 4 SEO analysis skill with 20 core sub-skills (+ 3 extensions),
-15 core subagents (+ 2 extension agents, 17 total), and 30 Python execution scripts.
+Claude SEO is a Tier 4 SEO analysis skill with 24 sub-skills (20 core + 1 orchestrator +
+1 framework integration + 2 extension mirrors), 18 sub-agents (15 core + 1 framework
+integration + 2 extension mirrors), and 30 Python execution scripts.
 
 ## Quick Reference
 
@@ -81,7 +82,7 @@ bash install.sh
 ## Architecture
 
 ```
-skills/                    # 23 skills (auto-discovered)
+skills/                    # 24 sub-skills (auto-discovered)
   seo/SKILL.md            # Main orchestrator + routing
   seo-cluster/            # Semantic clustering (v1.9.0)
   seo-sxo/                # Search Experience Optimization (v1.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.7] - 2026-05-09
+
+### Fixed
+- **Skill-count drift across 5 manifests** — `plugin.json` ("20 core sub-skills"),
+  `marketplace.json` ("21 core sub-skills"), `CLAUDE.md` line 7 ("21 core sub-skills"),
+  `AGENTS.md` line 8 ("20 core sub-skills") + line 84 ("23 skills"), and `README.md`
+  line 7 ("21 core sub-skills") all contradicted each other. Reconciled to canonical
+  phrasing: "24 sub-skills (20 core + 1 orchestrator + 1 framework integration +
+  2 extension mirrors)".
+- **Sub-agent count drift** — `CLAUDE.md` claimed "16 core subagents (+ 2 extension
+  agents, 18 total)" while `AGENTS.md` claimed "15 core subagents (+ 2 extension
+  agents, 17 total)". Reconciled to: "18 sub-agents (15 core + 1 framework integration +
+  2 extension mirrors)".
+- **`CLAUDE.md` self-contradiction** — line 23 stated `plugin.json (v1.9.0)`; updated
+  to current `v1.9.7`.
+- **`marketplace.json` description fields** — both `metadata.description` (top-level)
+  and `plugins[0].description` now use canonical phrasing.
+- **`CITATION.cff` version drift** — was stuck at `1.8.2` (six minor versions behind);
+  bumped to match `plugin.json` at `1.9.7` with current release date.
+
+### Added
+- **`.github/dependabot.yml`** — weekly Dependabot updates for pip and GitHub Actions
+  ecosystems (closes supply-chain hygiene gap).
+- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, closing GitHub Community
+  Standards gap.
+- **`.github/workflows/ci.yml` `permissions:` block** — restricts `GITHUB_TOKEN` to
+  `contents: read` at workflow root (least-privilege; was previously default scope).
+
+### Changed
+- Patch release driven by repository hygiene + marketplace-readiness preparation.
+  No skill behavior changes, no breaking changes, no script changes.
+
 ## [1.9.6] - 2026-04-26
 
 ### Security

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 repository-code: 'https://github.com/AgriciDaniel/claude-seo'
 url: 'https://github.com/AgriciDaniel/claude-seo'
 license: MIT
-version: 1.8.2
-date-released: '2026-04-10'
+version: 1.9.7
+date-released: '2026-05-09'
 keywords:
   - seo
   - claude-code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,9 @@
 
 This repository contains **Claude SEO**, a Tier 4 Claude Code skill for comprehensive
 SEO analysis across all industries. It follows the Agent Skills open standard and the
-3-layer architecture (directive, orchestration, execution). 21 core sub-skills (+ 3
-extensions), 16 core subagents (+ 2 extension agents, 18 total), and an extensible reference
+3-layer architecture (directive, orchestration, execution). 24 sub-skills (20 core +
+1 orchestrator + 1 framework integration + 2 extension mirrors), 18 sub-agents (15 core +
+1 framework integration + 2 extension mirrors), and an extensible reference
 system cover technical SEO, content quality,
 schema markup, image optimization, sitemap architecture, AI search optimization,
 local SEO (GBP, citations, reviews, map pack), maps intelligence, semantic topic
@@ -20,9 +21,9 @@ claude-seo/
   CONTRIBUTORS.md                    # Community credits (Pro Hub Challenge)
   AGENTS.md                          # Multi-platform agent instructions (Cursor, Antigravity)
   .claude-plugin/
-    plugin.json                    # Plugin manifest (v1.9.0)
+    plugin.json                    # Plugin manifest (v1.9.7)
     marketplace.json               # Marketplace catalog for distribution
-  skills/                            # 24 skills (auto-discovered)
+  skills/                            # 24 sub-skills (auto-discovered)
     seo/                           # Main orchestrator skill
       SKILL.md                     # Entry point, routing table, core rules
       references/                  # On-demand knowledge files (12 files)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opening a GitHub Security Advisory at https://github.com/AgriciDaniel/claude-seo/security/advisories/new (see SECURITY.md). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Claude SEO - SEO Audit Skill for Claude Code
 
-Comprehensive SEO analysis skill for Claude Code. 21 core sub-skills covering technical SEO, on-page analysis, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google SEO APIs (Search Console, PageSpeed, CrUX, GA4), PDF report generation, and strategic planning.
+Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, on-page analysis, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google SEO APIs (Search Console, PageSpeed, CrUX, GA4), PDF report generation, and strategic planning.
 
 ![SEO Command Demo](screenshots/seo-command-demo.gif)
 


### PR DESCRIPTION
## Summary

Phase A of marketplace-readiness work. Doc-only + non-breaking infra. Single rollup PR, 5 commits, one per category. No skill behavior changes.

### What changed

- **Skill/sub-agent count drift across 5 manifests** reconciled to canonical phrasing
  - Long: `24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors)` and `18 sub-agents (15 core + 1 framework integration + 2 extension mirrors)`
  - Short: `24 sub-skills`, `18 sub-agents`
  - Files: `plugin.json`, `marketplace.json` (both description fields), `CLAUDE.md` (lines 7, 23, 25), `AGENTS.md` (lines 8, 84), `README.md` (line 7)
  - Fixes the in-file self-contradictions in `CLAUDE.md` and `AGENTS.md`
- **Version bump 1.9.6 → 1.9.7** (patch — doc fixes + non-breaking infra)
- **CITATION.cff** brought current (was 1.8.2, six versions stale)
- **`.github/dependabot.yml`** added (pip + github-actions, weekly Monday)
- **`CODE_OF_CONDUCT.md`** added (Contributor Covenant 2.1, canonical text)
- **CI workflow `permissions: { contents: read }`** added (least-privilege)

### Math (verifiable)

```
skills/  on disk: 24 dirs = 20 core + 1 orchestrator (seo) + 1 framework integration (seo-flow) + 2 extension mirrors (seo-dataforseo, seo-image-gen)
agents/  on disk: 18 files = 15 core + 1 framework integration (seo-flow) + 2 extension mirrors (seo-dataforseo, seo-image-gen)
```

### Commits

- `2c798a5` chore(v1.9.7): reconcile skill-count drift across 5 manifests + version bump
- `ed6000e` chore: bump CITATION.cff to 1.9.7 to match plugin.json
- `eebf98e` chore: add Dependabot config for pip + GitHub Actions
- `4abe992` chore: add Contributor Covenant 2.1 Code of Conduct
- `8b4a612` chore(ci): add least-privilege permissions block

### Verification

- JSON: both manifests parse
- YAML: dependabot.yml structure check passes
- Stale skill-count strings: `0` hits in tracked files
- Version triangulation: plugin.json / CITATION.cff / CHANGELOG.md all on 1.9.7

### Not included (deferred)

- Phase B bug fixes (HOOK-1, OAuth #72, missing imports) — next slice
- Phase C external-PR merges (#69, #74, #67, #62, #63, #64, #70, #56, #73)
- Phase D stalled-PR verdicts (output only, no decisions)
- Phase E test scaffolding

🤖 Generated with [Claude Code](https://claude.com/claude-code)