### PR TITLE
fix(v1.9.8): Phase B bug fixes — Windows hook, OAuth refresh, missing imports, None guards

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\" \"$FILE_PATH\""
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\" \"$FILE_PATH\""
           }
         ]
       }

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -128,6 +128,16 @@ def main():
     if not filepath.endswith(valid_extensions):
         sys.exit(0)
 
+    # File-size guard: skip files >10MB to bound memory + hook latency.
+    # Real source files almost never exceed this; bigger inputs are typically
+    # generated, minified bundles or accidental binary writes.
+    MAX_FILE_BYTES = 10 * 1024 * 1024  # 10 MiB
+    try:
+        if os.path.getsize(filepath) > MAX_FILE_BYTES:
+            sys.exit(0)
+    except OSError:
+        sys.exit(0)
+
     try:
         with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
             content = f.read()

--- a/scripts/dataforseo_normalize.py
+++ b/scripts/dataforseo_normalize.py
@@ -262,6 +262,8 @@ def normalize_merchant(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     Returns:
         List of normalized product dicts.
     """
+    if not items:
+        return []
     normalized = []
     for item in items:
         # Handle rating as dict or scalar
@@ -318,6 +320,8 @@ def normalize_social(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     Returns:
         List of normalized social signal dicts.
     """
+    if not items:
+        return []
     normalized = []
     for item in items:
         signal = {
@@ -353,6 +357,8 @@ def normalize_reviews(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     Returns:
         List of normalized review dicts.
     """
+    if not items:
+        return []
     normalized = []
     for item in items:
         review = {

--- a/scripts/google_auth.py
+++ b/scripts/google_auth.py
@@ -177,6 +177,40 @@ def _save_oauth_token(token_data: dict):
         json.dump(token_data, f, indent=2)
 
 
+def _persist_oauth_client_path(creds_path: str):
+    """
+    Persist the absolute path to the OAuth client_secret JSON file in the
+    user config so future refresh_token flows can locate the client_secret
+    without re-prompting. Stores the PATH only; never the secret itself.
+
+    Closes the bug where every OAuth user 401'd within 1 hour because the
+    refresh path could not find oauth_client_path in config.
+    """
+    abs_path = os.path.abspath(os.path.expanduser(creds_path))
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    config = {}
+    if os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, "r") as f:
+                config = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            config = {}
+    config["oauth_client_path"] = abs_path
+    # Atomic write: tempfile + replace
+    import tempfile
+    fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(CONFIG_PATH), prefix=".google-api.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(config, f, indent=2)
+        os.replace(tmp_path, CONFIG_PATH)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
 def _refresh_oauth_token(client: dict, token_data: dict) -> Optional[dict]:
     """Refresh an expired OAuth token using the refresh_token."""
     import urllib.parse
@@ -325,11 +359,16 @@ def run_oauth_flow(creds_path: str):
         sys.exit(1)
 
     # Exchange code for tokens
-    _exchange_code(client, auth_code[0])
+    _exchange_code(client, auth_code[0], creds_path)
 
 
-def _exchange_code(client: dict, code: str):
-    """Exchange an authorization code for tokens."""
+def _exchange_code(client: dict, code: str, creds_path: Optional[str] = None):
+    """Exchange an authorization code for tokens.
+
+    If creds_path is provided, persist its absolute path to the user config
+    as 'oauth_client_path' so subsequent refresh flows can locate the
+    client_secret file without re-prompting.
+    """
     import urllib.parse
     import urllib.request
 
@@ -354,9 +393,20 @@ def _exchange_code(client: dict, code: str):
         _save_oauth_token(token_data)
         print("OAuth token saved successfully!")
 
-        # Also save the OAuth client path to config
-        config = load_config()
-        # Don't overwrite existing config, just suggest
+        # Persist oauth_client_path so refresh works after process restart.
+        # This is the PATH, never the client_secret value itself.
+        if creds_path:
+            try:
+                _persist_oauth_client_path(creds_path)
+                print(f"OAuth client path persisted to {CONFIG_PATH}")
+            except Exception as e:
+                print(
+                    f"Warning: Could not persist oauth_client_path: {e}. "
+                    f"Add 'oauth_client_path' to {CONFIG_PATH} manually for "
+                    f"automatic token refresh.",
+                    file=sys.stderr,
+                )
+
         print(f"\nToken saved to: {TOKEN_PATH}")
     except Exception as e:
         print(f"Error exchanging authorization code: {e}", file=sys.stderr)
@@ -728,7 +778,7 @@ def main():
             sys.exit(1)
         client = _load_oauth_client(args.creds)
         if client:
-            _exchange_code(client, args.code)
+            _exchange_code(client, args.code, args.creds)
         return
 
     if args.setup:

--- a/scripts/keyword_planner.py
+++ b/scripts/keyword_planner.py
@@ -28,6 +28,7 @@ Note: Accounts without active ad spend receive bucketed volume ranges
 
 import argparse
 import json
+import os
 import sys
 from typing import Optional
 
@@ -41,7 +42,6 @@ except ImportError:
 try:
     from google_auth import load_config
 except ImportError:
-    import os
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     from google_auth import load_config
 


### PR DESCRIPTION
## Summary

Phase B of marketplace-readiness work. 5 surgical bug fixes, one commit each. No new dependencies, no behavior changes outside the bug paths. All scripts py_compile clean.

### Commits

| Commit | What | Closes |
|---|---|---|
| `b9d3fc7` | `hooks/hooks.json`: `python3` → `python` | **#68** Windows breakage |
| `bced32e` | `keyword_planner.py`: add top-level `import os` | NameError at OAuth path |
| `07b9f70` | `google_auth.py`: persist `oauth_client_path` after exchange | **#72** 1-hr OAuth 401 |
| `ab1fffa` | `dataforseo_normalize.py`: None-guard 3 normalizers | **#58** root cause |
| `5a1d60a` | `validate-schema.py`: 10 MB file-size guard | DoS surface |

### Verification per commit

**HOOK-1** — `python` prefix verified by JSON parse + assertion. Closes #68 (Windows hook fails because `python3` triggers Microsoft Store stub).

**SCRIPT-1** — AST check confirms `os` is in top-level imports (was only inside `except ImportError`). py_compile passes. Lines 91-92 (`os.path.expanduser`, `os.path.exists`) now resolve at runtime regardless of `google_auth` import path.

**OAuth #72** — New `_persist_oauth_client_path()` helper. Atomic write (tempfile + os.replace). 3 dev-time unit cases:
- Fresh config: `oauth_client_path` written
- Existing config: `api_key` + `service_account_path` preserved (merge, not clobber)
- Security: `client_secret` value never written to config (PATH only)

**ISSUE-58** — `normalize_merchant`, `normalize_social`, `normalize_reviews` now `if not items: return []` early-return. Tested with `None` and `[]` — both safe.

**HOOK-4** — Real-file regression test: 11 MB synthetic HTML → exit 0, no read attempted. Small file path unchanged.

### Skipped (with reasoning)

- **ISSUE-17** (seo-geo wiring) — Already wired in `skills/seo/SKILL.md:58` and `skills/seo-audit/SKILL.md:27`. Root cause is missing `Write` tool in `agents/seo-geo.md:6`, which is exactly **PR #74** (Phase C).
- **ISSUE-59** (`<style>` strip in word count) — `parse_html.py:176` already decomposes `<style>` before counting. The remaining failure path is in DataForSEO's upstream `content_parsing_live` endpoint (MCP server, not this repo).

### Not bumping plugin.json

Bug-fix-only patch. Version stays at 1.9.7 from Phase A; the next bump (1.9.8) lands when external PRs (Phase C) are merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)