### PR TITLE
docs: full repo doc cleanup for marketplace submission (README + docs/ + CONTRIBUTORS + translations)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,9 @@ bash install.sh
 ## Community Extensions (Pro Hub Challenge)
 
 Claude SEO accepts community-built extensions through challenges and PRs.
-v1.9.0 integrated 5 community submissions — see [CONTRIBUTORS.md](CONTRIBUTORS.md).
+v1.9.0 integrated 5 challenge submissions and v1.9.7 added 9 community pull
+requests from 7 contributors. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for the
+full credits.
 
 To submit a community extension:
 1. Build your skill/agent/script following the patterns in this repo

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,17 +19,33 @@ into v1.9.0 with the contributors' permission.
 | **Florian Schmitz** | SXO Skill | [tools-enerix/claude-sxo-skill](https://github.com/tools-enerix/claude-sxo-skill) | `seo-sxo` (core skill) |
 | **Dan Colta** | SEO Drift Monitor | [dancolta/seo-drift-monitor](https://github.com/dancolta/seo-drift-monitor) | `seo-drift` (core skill) |
 | **Matej Marjanovic** | E-commerce + DataForSEO Cost Config + ASO + Platform Support | [matej-marjanovic/claude-seo](https://github.com/matej-marjanovic/claude-seo) | `seo-ecommerce` (core), cost infrastructure, `seo-aso` (extension), `AGENTS.md` |
-| **Benjamin Samar** | SEO Dungeon | -- | Reviewed (not integrated in v1.9.0) |
+| **Benjamin Samar** | SEO Dungeon | n/a | Reviewed (not integrated in v1.9.0) |
 
 ## Framework Integration (v1.9.5)
 
 | Source | Type | License | Integrated As |
 |--------|------|---------|--------------|
-| **[FLOW](https://github.com/AgriciDaniel/flow)** — Daniel Agrici | 41 AI prompts + framework doc + bibliography | CC BY 4.0 | `seo-flow` skill + `skills/seo-flow/references/` |
+| **[FLOW](https://github.com/AgriciDaniel/flow)** by Daniel Agrici | 41 AI prompts + framework doc + bibliography | CC BY 4.0 | `seo-flow` skill + `skills/seo-flow/references/` |
 
 Attribution header on every bundled prompt file (automated by `scripts/sync_flow.py`).
 
 ## Community Pull Requests
+
+### v1.9.7
+
+| Contributor | PR | What |
+|------------|-----|------|
+| [@xiaolai](https://github.com/xiaolai) | [#62](https://github.com/AgriciDaniel/claude-seo/pull/62) | Sync `extensions/dataforseo` skill with core |
+| [@xiaolai](https://github.com/xiaolai) | [#63](https://github.com/AgriciDaniel/claude-seo/pull/63) | Sync `extensions/banana` `seo-image-gen` skill |
+| [@xiaolai](https://github.com/xiaolai) | [#64](https://github.com/AgriciDaniel/claude-seo/pull/64) | Pin MCP server package versions in extension installers |
+| [@CrepuscularIRIS](https://github.com/CrepuscularIRIS) | [#67](https://github.com/AgriciDaniel/claude-seo/pull/67) | Detect marketplace plugin install path in DataForSEO extension |
+| [@evanlu14](https://github.com/evanlu14) | [#69](https://github.com/AgriciDaniel/claude-seo/pull/69) | `pagespeed_check` KeyError fix (`audit_details`) |
+| [@EDSprog](https://github.com/EDSprog) | [#70](https://github.com/AgriciDaniel/claude-seo/pull/70) | Update README install section |
+| [@NicT89](https://github.com/NicT89) | [#73](https://github.com/AgriciDaniel/claude-seo/pull/73) | Migrate `moz_api` to v2 REST endpoints |
+| [@AndronMan](https://github.com/AndronMan) | [#74](https://github.com/AgriciDaniel/claude-seo/pull/74) | Add `Write` tool to `seo-geo` agent |
+| [@puneetindersingh](https://github.com/puneetindersingh) | [#56](https://github.com/AgriciDaniel/claude-seo/pull/56) | Add `seo-content-brief` skill |
+
+### v1.9.0 and earlier
 
 | Contributor | PR | What |
 |------------|-----|------|

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -44,6 +44,9 @@ When configured with Google API credentials, these scripts transmit data to Goog
 | `indexing_notify.py` | Indexing API | URLs to submit for indexing |
 | `ga4_report.py` | Analytics Data | Authenticated query for your GA4 properties |
 | `crux_history.py` | CrUX History | URL or origin to query |
+| `nlp_analyze.py` | Cloud Natural Language | Text content for entity / sentiment / category analysis |
+| `keyword_planner.py` | Google Ads (Keyword Planner) | Seed keywords for volume, CPC, and competition lookups |
+| `youtube_search.py` | YouTube Data API v3 | Search queries for YouTube SEO research |
 
 Google API usage is governed by [Google's Privacy Policy](https://policies.google.com/privacy) and the [Google API Terms of Service](https://developers.google.com/terms).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-<!-- Updated: 2026-04-14 -->
-
 ![Claude SEO](screenshots/cover-image.jpeg)
 
 # Claude SEO - SEO Audit Skill for Claude Code
 
-Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, on-page analysis, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google SEO APIs (Search Console, PageSpeed, CrUX, GA4), PDF report generation, and strategic planning.
+SEO analysis plugin for Claude Code. 24 sub-skills (20 core, 1 orchestrator, 1 framework integration, 2 extension mirrors) and 18 sub-agents (15 core, 1 framework integration, 2 extension mirrors) covering technical SEO, on-page analysis, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google SEO APIs (Search Console, PageSpeed, CrUX, GA4), PDF report generation, and strategic planning.
 
 ![SEO Command Demo](screenshots/seo-command-demo.gif)
 
@@ -22,13 +20,15 @@ Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 or
 - [Commands](#commands)
 - [Features](#features)
 - [Architecture](#architecture)
-- [Extensions](#extensions)
-- [Showcase](#showcase)
-- [Ecosystem](#ecosystem)
-- [Documentation](#documentation)
 - [Requirements](#requirements)
 - [Uninstall](#uninstall)
+- [Extensions](#extensions)
+- [Ecosystem](#ecosystem)
+- [Documentation](#documentation)
+- [Community Contributors](#community-contributors)
+- [License](#license)
 - [Contributing](#contributing)
+- [Author](#author)
 
 ## Installation
 
@@ -50,19 +50,7 @@ bash claude-seo/install.sh
 ```
 
 <details>
-<summary>One-liner (curl)</summary>
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh | bash
-```
-
-Or via [install.cat](https://install.cat):
-
-```bash
-curl -fsSL install.cat/AgriciDaniel/claude-seo | bash
-```
-
-Prefer to review the script before running?
+<summary>One-liner (curl, review then run)</summary>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh > install.sh
@@ -185,7 +173,7 @@ Validate and generate hreflang tags for multi-language sites.
 - **INP** (Interaction to Next Paint): Target < 200ms
 - **CLS** (Cumulative Layout Shift): Target < 0.1
 
-> Note: INP replaced FID on March 12, 2024. FID was fully removed from all Chrome tools on September 9, 2024.
+> Note: INP replaced FID on March 12, 2024. FID was removed from all Chrome tools on September 9, 2024.
 
 ### E-E-A-T Analysis
 Updated to September 2025 Quality Rater Guidelines:
@@ -204,21 +192,21 @@ Updated to September 2025 Quality Rater Guidelines:
   - SpecialAnnouncement: Deprecated (July 2025)
 
 ### AI Search Optimization (GEO)
-New for 2026 - optimize for:
+Optimize for:
 - Google AI Overviews
 - ChatGPT web search
 - Perplexity
 - Other AI-powered search
 
-### Google SEO APIs (New in v1.7.0)
+### Google SEO APIs
 Direct integration with Google's SEO data:
 - **PageSpeed Insights + CrUX**: Lab and field Core Web Vitals data
 - **Search Console**: Top queries, URL inspection, sitemap status
 - **Indexing API**: Notify Google of new/updated/removed URLs
 - **GA4**: Organic traffic, top landing pages, device/country breakdown
-- **PDF Reports**: Enterprise A4 reports with charts via WeasyPrint + matplotlib
+- **PDF Reports**: A4 reports with charts via WeasyPrint and matplotlib
 
-4-tier credential system — get value at every level:
+4-tier credential system. Get value at every level:
 | Tier | Auth | APIs |
 |------|------|------|
 | 0 | API key | PSI, CrUX, CrUX History |
@@ -226,7 +214,7 @@ Direct integration with Google's SEO data:
 | 2 | + GA4 config | + GA4 organic traffic |
 | 3 | + Ads token | + Keyword Planner |
 
-### Local SEO & Maps Intelligence (New in v1.6.0)
+### Local SEO and Maps Intelligence
 - Google Business Profile optimization
 - NAP consistency auditing
 - Citation and review analysis
@@ -241,27 +229,20 @@ Direct integration with Google's SEO data:
 ## Architecture
 
 ```
-~/.claude/skills/seo/         # Main orchestrator skill
-~/.claude/skills/seo-*/       # Sub-skills (21 + 3 extensions)
-~/.claude/agents/seo-*.md     # Subagents (15 + 2 extensions)
+~/.claude/plugins/.../skills/seo/      # Main orchestrator
+~/.claude/plugins/.../skills/seo-*/    # 24 sub-skills (auto-discovered)
+~/.claude/plugins/.../agents/seo-*.md  # 18 sub-agents (auto-discovered)
 ```
 
-### Video & Live Schema (New)
+### Video and Live Schema
 Additional schema types for video content, live streaming, and key moments:
 - VideoObject: Video page markup with thumbnails, duration, upload date
 - BroadcastEvent: LIVE badge support for live streaming content
-- Clip: Key moments / chapters within videos
+- Clip: Key moments and chapters within videos
 - SeekToAction: Enable seek functionality in video rich results
 - SoftwareSourceCode: Open source and code repository pages
 
-See `schema/templates.json` for ready-to-use JSON-LD snippets.
-
-### Recently Added
-- Programmatic SEO skill (`/seo programmatic`)
-- Competitor comparison pages skill (`/seo competitor-pages`)
-- Multi-language hreflang validation (`/seo hreflang`)
-- Video & Live schema types (VideoObject, BroadcastEvent, Clip, SeekToAction)
-- Google SEO quick-reference guide
+See `schema/templates.json` for ready-to-use JSON-LD snippets. Full release history in [CHANGELOG.md](CHANGELOG.md).
 
 ## Requirements
 
@@ -286,13 +267,9 @@ curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/uninst
 
 </details>
 
-### MCP Integrations
-
-Integrates with MCP servers for live SEO data, including official servers from **Ahrefs** (`@ahrefs/mcp`) and **Semrush**, plus community servers for Google Search Console, PageSpeed Insights, and DataForSEO. See [MCP Integration Guide](docs/MCP-INTEGRATION.md) for setup.
-
 ## Extensions
 
-Optional add-ons that integrate external data sources via MCP servers.
+Optional add-ons that integrate external data sources via MCP servers. The plugin works with official servers from **Ahrefs** (`@ahrefs/mcp`) and **Semrush**, plus community servers for Google Search Console, PageSpeed Insights, and DataForSEO. See [MCP Integration Guide](docs/MCP-INTEGRATION.md) for setup details.
 
 ### DataForSEO
 
@@ -351,48 +328,25 @@ Full-site crawling and URL discovery using the [Firecrawl](https://www.firecrawl
 
 See [Firecrawl Extension](extensions/firecrawl/README.md) for full documentation.
 
-## Showcase
-
-Community projects built on top of Claude SEO:
-
-<table>
-<tr>
-<td width="40%">
-  <a href="https://github.com/avalonreset/claude-seo-dungeon">
-    <img src="https://raw.githubusercontent.com/avalonreset/claude-seo-dungeon/main/screenshots/battle-scene.webp" alt="Claude SEO Dungeon - turn-based SEO battle scene with Guild Ledger">
-  </a>
-</td>
-<td width="60%">
-
-**[Claude SEO Dungeon](https://github.com/avalonreset/claude-seo-dungeon)** -- a 16-bit gamified dungeon crawler that turns SEO audits into boss battles. Built on Claude SEO v1.9.0 with Phaser 3, every detected issue becomes a demon and every fix becomes a real commit to your codebase. The Guild Ledger streams Claude's tool calls in real time as you fight.
-
-Built by [@avalonreset](https://github.com/avalonreset) -- live at [seodungeon.com](https://seodungeon.com).
-
-</td>
-</tr>
-</table>
-
-Want your project featured here? [Open an issue](https://github.com/AgriciDaniel/claude-seo/issues/new) with a link.
-
 ## Ecosystem
 
 Claude SEO is part of a family of Claude Code skills that work together:
 
 | Skill | What it does | How it connects |
 |-------|-------------|-----------------|
-| [Claude SEO](https://github.com/AgriciDaniel/claude-seo) | SEO analysis, audits, schema, GEO | Core -- analyzes sites, generates action plans |
-| [Claude Blog](https://github.com/AgriciDaniel/claude-blog) | Blog writing, optimization, scoring | Companion -- write content optimized by SEO findings |
-| [Claude Banana](https://github.com/AgriciDaniel/banana-claude) | AI image generation via Gemini | Shared -- generates images for SEO assets and blog posts |
-| [Codex SEO](https://github.com/AgriciDaniel/codex-seo) | Codex-first SEO skill suite | Port -- same SEO system adapted for Codex skills, TOML agents, plugins, and deterministic runners |
-| [AI Marketing Claude](https://github.com/zubair-trabzada/ai-marketing-claude) | Copywriting, emails, social, ads, funnels, CRO | Community -- post-audit marketing action from SEO findings |
-| [FLOW](https://github.com/AgriciDaniel/flow) | Evidence-led SEO framework (41 AI prompts, CC BY 4.0) | Knowledge base — powers `seo-flow` prompts |
+| [Claude SEO](https://github.com/AgriciDaniel/claude-seo) | SEO analysis, audits, schema, GEO | Core. Analyzes sites and generates action plans. |
+| [Claude Blog](https://github.com/AgriciDaniel/claude-blog) | Blog writing, optimization, scoring | Companion. Writes content optimized by SEO findings. |
+| [Claude Banana](https://github.com/AgriciDaniel/banana-claude) | AI image generation via Gemini | Shared. Generates images for SEO assets and blog posts. |
+| [Codex SEO](https://github.com/AgriciDaniel/codex-seo) | Codex-first SEO skill suite | Port. Same SEO system adapted for Codex skills, TOML agents, plugins, and deterministic runners. |
+| [AI Marketing Claude](https://github.com/zubair-trabzada/ai-marketing-claude) | Copywriting, emails, social, ads, funnels, CRO | Community. Post-audit marketing action from SEO findings. |
+| [FLOW](https://github.com/AgriciDaniel/flow) | Evidence-led SEO framework (41 AI prompts, CC BY 4.0) | Knowledge base. Powers `seo-flow` prompts. |
 
 **Workflow example:**
-1. `/seo audit https://example.com` -- identify content gaps and technical issues
-2. `/seo backlinks https://example.com` -- analyze link profile and competitor gaps
-3. `/blog write "target keyword"` -- create SEO-optimized blog posts
-4. `/seo image-gen hero "blog topic"` -- generate hero images (banana extension)
-5. `/seo geo https://example.com/blog/post` -- optimize for AI citations
+1. `/seo audit https://example.com` to identify content gaps and technical issues
+2. `/seo backlinks https://example.com` to analyze link profile and competitor gaps
+3. `/blog write "target keyword"` to create SEO-optimized blog posts
+4. `/seo image-gen hero "blog topic"` to generate hero images (banana extension)
+5. `/seo geo https://example.com/blog/post` to optimize for AI citations
 
 ## Documentation
 
@@ -426,21 +380,10 @@ Contributions welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before sub
 
 ---
 
-Built for Claude Code by [@AgriciDaniel](https://github.com/AgriciDaniel)
-
----
-
-## Publishing Pipeline
-
-For a full GUI-based publishing workflow from SEO research to published content, see [Rankenstein](https://rankenstein.pro) - the AI content engine built on the same SEO principles.
-
----
-
 ## Author
 
-Built by [Agrici Daniel](https://agricidaniel.com/about) - AI Workflow Architect.
+Built by [Agrici Daniel](https://agricidaniel.com/about), AI Workflow Architect.
 
-- [Blog](https://agricidaniel.com/blog) - Deep dives on AI marketing automation
-- [AI Marketing Hub](https://www.skool.com/ai-marketing-hub) - Free community, 2,800+ members
-- [YouTube](https://www.youtube.com/@AgriciDaniel) - Tutorials and demos
+- [Blog](https://agricidaniel.com/blog): deep dives on AI marketing automation
+- [YouTube](https://www.youtube.com/@AgriciDaniel): tutorials and demos
 - [All open-source tools](https://github.com/AgriciDaniel)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,38 +6,59 @@ Claude SEO follows Anthropic's official Claude Code skill specification with a m
 
 ## Directory Structure
 
+The plugin ships 24 sub-skills (20 core, 1 orchestrator, 1 framework integration, 2 extension mirrors) and 18 sub-agents (15 core, 1 framework integration, 2 extension mirrors).
+
 ```
-~/.claude/
+~/.claude/plugins/.../claude-seo/
 ├── skills/
-│   ├── seo/              # Main orchestrator skill
-│   │   ├── SKILL.md          # Entry point with routing logic
-│   │   └── references/       # On-demand reference files
-│   │       ├── cwv-thresholds.md
-│   │       ├── schema-types.md
-│   │       ├── eeat-framework.md
-│   │       └── quality-gates.md
+│   ├── seo/                    # Main orchestrator
+│   │   ├── SKILL.md
+│   │   └── references/         # On-demand reference files (12 files)
 │   │
-│   ├── seo-audit/            # Full site audit
-│   ├── seo-competitor-pages/ # Competitor comparison pages
-│   ├── seo-content/          # E-E-A-T analysis
-│   ├── seo-geo/              # AI search optimization
-│   ├── seo-hreflang/         # Hreflang/i18n SEO
-│   ├── seo-images/           # Image optimization
-│   ├── seo-page/             # Single page analysis
-│   ├── seo-plan/             # Strategic planning
-│   │   └── assets/           # Industry templates
-│   ├── seo-programmatic/     # Programmatic SEO
-│   ├── seo-schema/           # Schema markup
-│   ├── seo-sitemap/          # Sitemap analysis/generation
-│   └── seo-technical/        # Technical SEO
+│   ├── seo-audit/              # Full site audit (parallel subagents)
+│   ├── seo-page/               # Single page analysis
+│   ├── seo-technical/          # Technical SEO (9 categories)
+│   ├── seo-content/            # E-E-A-T and content quality
+│   ├── seo-content-brief/      # Competitive content brief generation
+│   ├── seo-schema/             # Schema markup detection and generation
+│   ├── seo-sitemap/            # XML sitemap analysis and generation
+│   ├── seo-images/             # Image optimization analysis
+│   ├── seo-geo/                # AI search optimization (GEO)
+│   ├── seo-local/              # Local SEO (GBP, citations, reviews)
+│   ├── seo-maps/               # Maps intelligence (geo-grid, GBP audit)
+│   ├── seo-backlinks/          # Backlink profile analysis
+│   ├── seo-cluster/            # Semantic topic clustering (SERP-based)
+│   ├── seo-sxo/                # Search Experience Optimization
+│   ├── seo-drift/              # SEO drift monitoring (baselines)
+│   ├── seo-ecommerce/          # E-commerce SEO (product schema, marketplaces)
+│   ├── seo-hreflang/           # International SEO and hreflang
+│   ├── seo-plan/               # Strategic SEO planning (industry templates)
+│   ├── seo-programmatic/       # Programmatic SEO at scale
+│   ├── seo-competitor-pages/   # Competitor comparison page generation
+│   ├── seo-google/             # Google SEO APIs (GSC, PSI, CrUX, GA4)
+│   ├── seo-flow/               # FLOW framework integration (CC BY 4.0)
+│   ├── seo-dataforseo/         # DataForSEO MCP mirror (extension surface)
+│   └── seo-image-gen/          # Banana MCP mirror (extension surface)
 │
 └── agents/
-    ├── seo-technical.md      # Technical SEO specialist
-    ├── seo-content.md        # Content quality reviewer
-    ├── seo-schema.md         # Schema markup expert
-    ├── seo-sitemap.md        # Sitemap architect
-    ├── seo-performance.md    # Performance analyzer
-    └── seo-visual.md         # Visual analyzer
+    ├── seo-technical.md        # Crawlability, indexability, security
+    ├── seo-content.md          # E-E-A-T, readability, thin content
+    ├── seo-schema.md           # Structured data validation
+    ├── seo-sitemap.md          # Sitemap quality gates
+    ├── seo-performance.md      # Core Web Vitals
+    ├── seo-visual.md           # Screenshots, mobile rendering
+    ├── seo-geo.md              # AI crawler access, citability
+    ├── seo-local.md            # GBP signals, NAP, reviews
+    ├── seo-maps.md             # Geo-grid, competitor radius mapping
+    ├── seo-backlinks.md        # Moz, Bing Webmaster, Common Crawl
+    ├── seo-cluster.md          # Semantic clustering analysis
+    ├── seo-sxo.md              # Page-type, user stories, personas
+    ├── seo-drift.md            # Baseline comparison, regression detection
+    ├── seo-ecommerce.md        # Product schema, marketplace intelligence
+    ├── seo-google.md           # GSC, PSI, CrUX, GA4 analyst
+    ├── seo-flow.md             # FLOW framework prompt selection
+    ├── seo-dataforseo.md       # DataForSEO MCP mirror
+    └── seo-image-gen.md        # Banana MCP mirror
 ```
 
 ## Component Types
@@ -84,37 +105,44 @@ Reference files contain static data loaded on-demand to avoid bloating the main 
 ### Full Audit (`/seo audit`)
 
 ```
-User Request
+User request
     │
     ▼
-┌─────────────────┐
-│   seo       │  ← Main orchestrator
-│   (SKILL.md)    │
-└────────┬────────┘
-         │
-         │  Detects business type
+┌──────────────────┐
+│   seo            │  Main orchestrator (skills/seo/SKILL.md)
+└────────┬─────────┘
+         │  Detects business type and signals
          │  Spawns subagents in parallel
          │
-    ┌────┴────┬────────┬────────┬────────┬────────┐
-    ▼         ▼        ▼        ▼        ▼        ▼
-┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐
-│tech   │ │content│ │schema │ │sitemap│ │perf   │ │visual │
-│agent  │ │agent  │ │agent  │ │agent  │ │agent  │ │agent  │
-└───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘
-    │         │        │        │        │        │
-    └─────────┴────────┴────┬───┴────────┴────────┘
-                            │
-                            ▼
-                    ┌───────────────┐
-                    │  Aggregate    │
-                    │  Results      │
-                    └───────┬───────┘
-                            │
-                            ▼
-                    ┌───────────────┐
-                    │  Generate     │
-                    │  Report       │
-                    └───────────────┘
+    ┌────┴────┬────────┬────────┬────────┬────────┬────────┐
+    ▼         ▼        ▼        ▼        ▼        ▼        ▼
+┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐ ┌───────┐
+│tech   │ │content│ │schema │ │sitemap│ │perf   │ │visual │ │geo    │
+└───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘ └───┬───┘
+    │         │         │         │         │         │         │
+    └─────────┴─────────┴────┬────┴─────────┴─────────┴─────────┘
+                             │
+                             │  Conditional spawns:
+                             │  - seo-google     (Google API creds detected)
+                             │  - seo-local      (local business detected)
+                             │  - seo-maps       (local + DataForSEO MCP)
+                             │  - seo-backlinks  (Moz/Bing/CC available)
+                             │  - seo-cluster    (content strategy signals)
+                             │  - seo-sxo        (always in full audits)
+                             │  - seo-drift      (baseline exists for URL)
+                             │  - seo-ecommerce  (e-commerce detected)
+                             ▼
+                    ┌────────────────┐
+                    │  Aggregate     │
+                    │  Results       │
+                    └────────┬───────┘
+                             │
+                             ▼
+                    ┌────────────────┐
+                    │  Generate      │
+                    │  Health Score  │
+                    │  + Action Plan │
+                    └────────────────┘
 ```
 
 ### Individual Command
@@ -194,67 +222,54 @@ User Request (e.g., /seo page)
 
 ## Extensions
 
-Extensions are opt-in add-ons that integrate external data sources via MCP servers. They live in `extensions/<name>/` and include their own install/uninstall scripts.
+Extensions are opt-in add-ons that integrate external data sources via MCP servers. They live in `extensions/<name>/` and ship their own install / uninstall scripts.
 
 ```
 extensions/
 ├── dataforseo/               # DataForSEO MCP integration
-│   ├── README.md                  # Extension documentation
-│   ├── install.sh                 # Unix installer
-│   ├── install.ps1                # Windows installer
-│   ├── uninstall.sh               # Unix uninstaller
-│   ├── uninstall.ps1              # Windows uninstaller
-│   ├── field-config.json          # API response field filtering
-│   ├── skills/
-│   │   └── seo-dataforseo/
-│   │       └── SKILL.md           # Sub-skill (22 commands)
-│   ├── agents/
-│   │   └── seo-dataforseo.md      # Subagent
-│   └── docs/
-│       └── DATAFORSEO-SETUP.md    # Account setup guide
+│   ├── README.md
+│   ├── install.sh
+│   ├── install.ps1
+│   ├── uninstall.sh
+│   ├── uninstall.ps1
+│   ├── field-config.json
+│   ├── skills/seo-dataforseo/SKILL.md
+│   ├── agents/seo-dataforseo.md
+│   └── docs/DATAFORSEO-SETUP.md
 │
-└── banana/                   # Banana Image Generation (Gemini AI)
-    ├── README.md                  # Extension documentation
-    ├── install.sh                 # Unix installer
-    ├── uninstall.sh               # Unix uninstaller
-    ├── skills/
-    │   └── seo-image-gen/
-    │       └── SKILL.md           # Sub-skill (6 commands)
-    ├── agents/
-    │   └── seo-image-gen.md       # Image audit subagent
-    ├── scripts/                   # Python scripts (stdlib only)
-    │   ├── generate.py            # Direct API fallback
-    │   ├── edit.py                # Image editing fallback
-    │   ├── batch.py               # CSV batch workflow
-    │   ├── cost_tracker.py        # Usage and cost tracking
-    │   ├── presets.py             # Brand preset management
-    │   ├── setup_mcp.py           # MCP configuration
-    │   └── validate_setup.py      # Installation verification
-    ├── references/                # On-demand knowledge
-    │   ├── prompt-engineering.md  # 6-component Reasoning Brief
-    │   ├── gemini-models.md       # Model specs and pricing
-    │   ├── mcp-tools.md           # MCP tool reference
-    │   ├── post-processing.md     # ImageMagick recipes
-    │   ├── cost-tracking.md       # Cost tracking guide
-    │   ├── presets.md             # Preset schema
-    │   └── seo-image-presets.md   # SEO-specific presets
-    └── docs/
-        └── BANANA-SETUP.md        # API key and MCP setup
+├── banana/                   # AI image generation via Gemini
+│   ├── README.md
+│   ├── install.sh
+│   ├── uninstall.sh
+│   ├── skills/seo-image-gen/SKILL.md
+│   ├── agents/seo-image-gen.md
+│   ├── scripts/              # Python fallback scripts (stdlib only)
+│   ├── references/           # 7 reference files (prompt engineering, models, presets)
+│   └── docs/BANANA-SETUP.md
+│
+└── firecrawl/                # Firecrawl MCP for full-site crawling
+    ├── README.md
+    ├── install.sh
+    ├── install.ps1
+    ├── uninstall.sh
+    ├── uninstall.ps1
+    └── skills/seo-firecrawl/SKILL.md
 ```
 
 ### Available Extensions
 
-| Extension | Package | What it Adds |
-|-----------|---------|-------------|
-| **DataForSEO** | `dataforseo-mcp-server` | 22 commands: live SERP, keywords, backlinks, on-page analysis, content analysis, business listings, AI visibility, LLM mentions |
-| **Banana Image Gen** | `@ycse/nanobanana-mcp` | 6 commands: OG image, hero image, product photo, infographic, custom, and batch generation via Gemini AI |
+| Extension | Package (pinned) | What it adds |
+|-----------|------------------|--------------|
+| **DataForSEO** | `dataforseo-mcp-server@2.8.10` | Live SERP data, keyword research, backlinks, on-page analysis, business listings, AI visibility, LLM mention tracking |
+| **Banana Image Gen** | `@ycse/nanobanana-mcp@1.1.1` | AI image generation for SEO assets via Gemini (OG images, hero images, product photos, infographics, batch) |
+| **Firecrawl** | `firecrawl-mcp@3.11.0` | Full-site crawling and URL discovery for audits |
 
 ### Extension Convention
 
-Each extension follows this pattern:
 1. Self-contained in `extensions/<name>/`
-2. Own `install.sh` and `install.ps1` that copy files and configure MCP
-3. Own `uninstall.sh` and `uninstall.ps1` that cleanly reverse installation
-4. Installs skill to `~/.claude/skills/seo-<name>/`
-5. Installs agent to `~/.claude/agents/seo-<name>.md`
-6. Merges MCP config into `~/.claude/settings.json` (non-destructive)
+2. Own `install.sh` and `install.ps1` that copy files and configure MCP (where applicable)
+3. Own `uninstall.sh` and `uninstall.ps1` that reverse installation
+4. Installs the sub-skill mirror to the plugin's skill directory
+5. Installs the sub-agent mirror to the plugin's agent directory
+6. Merges MCP config into `~/.claude/settings.json` non-destructively
+7. MCP server versions are pinned (`@<version>`) for supply-chain stability

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -260,6 +260,223 @@ Programmatic SEO analysis and planning for pages generated at scale.
 
 ---
 
+### `/seo local <url>`
+
+Local SEO analysis covering Google Business Profile, citations, reviews, and the map pack.
+
+**Example:**
+```
+/seo local https://example.com
+```
+
+**What it analyzes:**
+- Google Business Profile signals (categories, hours, photos, posts)
+- NAP (Name, Address, Phone) consistency across the page and external citations
+- Review velocity, response rate, and sentiment
+- Local schema markup (LocalBusiness, Restaurant, Service-specific types)
+- Industry-specific local factors (brick-and-mortar, SAB, hybrid)
+- Map pack visibility signals
+
+---
+
+### `/seo maps [command] [args]`
+
+Maps intelligence: geo-grid rank tracking, GBP profile audits, review intelligence, cross-platform NAP verification, competitor radius mapping.
+
+**Examples:**
+```
+/seo maps geogrid "coffee shop austin tx"
+/seo maps audit https://www.google.com/maps/place/...
+/seo maps reviews <place_id>
+/seo maps competitors "auto repair denver" 5mi
+```
+
+**Capabilities:**
+- Rank tracking on a geographic grid (typically 49 points)
+- GBP profile audit with completeness scoring
+- Review aggregation across Google, Yelp, Facebook, Bing
+- Competitor discovery within a configurable radius
+
+---
+
+### `/seo backlinks <url>`
+
+Backlink profile analysis with a 3-tier data cascade: free (Common Crawl + verification), free with signup (Moz, Bing Webmaster Tools), paid (DataForSEO).
+
+**Examples:**
+```
+/seo backlinks https://example.com
+/seo backlinks setup
+/seo backlinks verify https://example.com
+```
+
+**What it analyzes:**
+- Domain Authority and Page Authority (Moz)
+- Referring domain count and growth
+- Anchor text distribution (branded, exact, partial, naked URL)
+- Toxic / spammy backlink detection
+- Lost backlinks
+- Competitor link gap
+
+---
+
+### `/seo cluster <seed-keyword>`
+
+SERP-based semantic topic clustering for content architecture planning. Built on the Pro Hub Challenge Semantic Cluster Engine.
+
+**Example:**
+```
+/seo cluster "claude code skills"
+```
+
+**What it produces:**
+- Keyword expansion from the seed (50-200 candidates)
+- Pairwise SERP overlap comparison to detect semantic clusters
+- Intent classification per cluster (informational, commercial, transactional, navigational)
+- Hub-and-spoke content architecture proposal
+- Internal link matrix between cluster pages
+- Interactive `cluster-map.html` visualization
+
+---
+
+### `/seo sxo <url>`
+
+Search Experience Optimization: SERP backwards analysis, page-type mismatch detection, persona scoring.
+
+**Example:**
+```
+/seo sxo https://example.com/blog/how-to-x
+```
+
+**What it produces:**
+- Page-type taxonomy classification (article, landing, product, tool, listing)
+- SERP intent vs page-type alignment check
+- User stories derived from SERP signals
+- Multi-persona scoring (researcher, buyer, expert, casual visitor)
+- Wireframe-level recommendations for fixing mismatches
+
+---
+
+### `/seo drift baseline|compare|history <url>`
+
+SEO drift monitoring. Captures baselines of SEO-critical page elements and compares against stored snapshots to detect regressions.
+
+**Examples:**
+```
+/seo drift baseline https://example.com
+/seo drift compare https://example.com
+/seo drift history https://example.com
+```
+
+**What it tracks:** title, meta description, canonical, hreflang, Open Graph, schema, headings, internal links, robots, sitemap entry, indexability, Core Web Vitals, response status, redirect chain.
+
+**17 comparison rules** classify changes by severity (CRITICAL, HIGH, MEDIUM). SQLite-backed baselines.
+
+---
+
+### `/seo ecommerce <url>`
+
+E-commerce SEO covering product schema, marketplace intelligence, and pricing gap analysis.
+
+**Example:**
+```
+/seo ecommerce https://shop.example.com/product/x
+```
+
+**What it analyzes:**
+- Product schema (Product, Offer, AggregateRating, Review)
+- Google Shopping visibility
+- Amazon marketplace presence
+- Pricing gap vs competitors
+- Out-of-stock and availability signals
+- Faceted navigation crawl traps
+
+---
+
+### `/seo flow [stage] [url|topic]`
+
+FLOW framework integration: evidence-led prompts for the Find, Leverage, Optimize, Win, and Local stages of a content campaign.
+
+**Examples:**
+```
+/seo flow find "topic"
+/seo flow leverage https://example.com
+/seo flow optimize "target keyword"
+```
+
+**41 prompts** sourced from FLOW (CC BY 4.0). Each prompt is grounded in a specific evidence source (SERP data, GSC, GA4, customer interviews) with attribution preserved.
+
+---
+
+### `/seo google [command] [url]`
+
+Google SEO APIs. 4-tier credential system covering PageSpeed Insights, CrUX, CrUX History, Search Console, URL Inspection, Indexing API, GA4, and Keyword Planner.
+
+**Examples:**
+```
+/seo google setup
+/seo google check
+/seo google psi https://example.com
+/seo google gsc-queries https://example.com
+/seo google indexing-notify https://example.com
+/seo google ga4-organic
+/seo google report full
+```
+
+**Tiers:**
+- Tier 0 (API key only): PSI, CrUX, CrUX History
+- Tier 1 (+ OAuth or Service Account): GSC, URL Inspection, Indexing API
+- Tier 2 (+ GA4 property config): GA4 organic traffic
+- Tier 3 (+ Google Ads developer token): Keyword Planner
+
+PDF and HTML reports generated via WeasyPrint and matplotlib.
+
+---
+
+### `/seo image-gen [use-case] <description>`
+
+AI image generation for SEO assets (extension). Powered by Gemini via nanobanana-mcp.
+
+**Prerequisites:** Banana extension installed (`./extensions/banana/install.sh`)
+
+**Use Cases:**
+```
+/seo image-gen og <description>          # OG/social preview image (16:9, 1K)
+/seo image-gen hero <description>        # Blog hero image (16:9, 2K)
+/seo image-gen product <description>     # Product photography (4:3, 2K)
+/seo image-gen infographic <description> # Infographic visual (2:3, 4K)
+/seo image-gen custom <description>      # Custom with full Creative Director pipeline
+/seo image-gen batch <description> [N]   # Generate N variations (default: 3)
+```
+
+**What it does:**
+1. Maps SEO use case to optimized domain mode, aspect ratio, and resolution
+2. Constructs 6-component Reasoning Brief (Creative Director pipeline)
+3. Generates image via Gemini API
+4. Provides SEO checklist (alt text, file naming, WebP, schema markup)
+
+---
+
+### `/seo firecrawl [command] <url>`
+
+Full-site crawling and URL discovery via Firecrawl MCP (extension).
+
+**Prerequisites:** Firecrawl extension installed (`./extensions/firecrawl/install.sh`)
+
+**Examples:**
+```
+/seo firecrawl crawl https://example.com
+/seo firecrawl map https://example.com
+/seo firecrawl scrape https://example.com/page
+```
+
+**What it does:**
+- `crawl` walks the site discovering URLs and capturing content
+- `map` returns the full URL inventory for a domain
+- `scrape` extracts a single page in a model-friendly format
+
+---
+
 ### `/seo dataforseo [command]`
 
 Live SEO data via DataForSEO MCP server (extension). 22 commands across 9 API modules.
@@ -314,53 +531,32 @@ Live SEO data via DataForSEO MCP server (extension). 22 commands across 9 API mo
 
 ---
 
-### `/seo image-gen [use-case] <description>`
-
-AI image generation for SEO assets (extension). Powered by Gemini via nanobanana-mcp.
-
-**Prerequisites:** Banana extension installed (`./extensions/banana/install.sh`)
-
-**Use Cases:**
-```
-/seo image-gen og <description>          # OG/social preview image (16:9, 1K)
-/seo image-gen hero <description>        # Blog hero image (16:9, 2K)
-/seo image-gen product <description>     # Product photography (4:3, 2K)
-/seo image-gen infographic <description> # Infographic visual (2:3, 4K)
-/seo image-gen custom <description>      # Custom with full Creative Director pipeline
-/seo image-gen batch <description> [N]   # Generate N variations (default: 3)
-```
-
-**Example:**
-```
-/seo image-gen og "Professional SaaS analytics dashboard with clean UI"
-/seo image-gen hero "Dramatic sunset over modern city skyline"
-/seo image-gen product "Wireless noise-canceling headphones on marble surface"
-```
-
-**What it does:**
-1. Maps SEO use case to optimized domain mode, aspect ratio, and resolution
-2. Constructs 6-component Reasoning Brief (Creative Director pipeline)
-3. Generates image via Gemini API
-4. Provides SEO checklist (alt text, file naming, WebP, schema markup)
-
----
-
 ## Quick Reference
 
 | Command | Use Case |
 |---------|----------|
-| `/seo audit <url>` | Full website audit |
-| `/seo competitor-pages [url\|generate]` | Competitor comparison pages |
-| `/seo content <url>` | E-E-A-T analysis |
-| `/seo geo <url>` | AI search optimization |
-| `/seo hreflang [url]` | Hreflang/i18n SEO audit |
-| `/seo images <url>` | Image optimization |
-| `/seo image-gen [use-case] <desc>` | AI image generation (extension) |
+| `/seo audit <url>` | Full website audit with parallel subagents |
 | `/seo page <url>` | Single page analysis |
-| `/seo plan <type>` | Strategic planning |
-| `/seo programmatic [url\|plan]` | Programmatic SEO analysis |
-| `/seo schema <url>` | Schema validation |
+| `/seo technical <url>` | Technical SEO across 9 categories |
+| `/seo content <url>` | E-E-A-T and content quality |
+| `/seo schema <url>` | Schema markup detection, validation, generation |
 | `/seo sitemap <url>` | Sitemap validation |
-| `/seo sitemap generate` | Create new sitemap |
-| `/seo technical <url>` | Technical SEO check |
+| `/seo sitemap generate` | Create new sitemap with industry templates |
+| `/seo images <url>` | Image optimization |
+| `/seo geo <url>` | AI search optimization (GEO) |
+| `/seo local <url>` | Local SEO (GBP, citations, reviews) |
+| `/seo maps [command]` | Maps intelligence (geo-grid, GBP audit, competitors) |
+| `/seo backlinks <url>` | Backlink profile analysis |
+| `/seo cluster <seed>` | SERP-based semantic clustering |
+| `/seo sxo <url>` | Search Experience Optimization |
+| `/seo drift baseline\|compare\|history <url>` | SEO drift monitoring |
+| `/seo ecommerce <url>` | E-commerce SEO |
+| `/seo hreflang [url]` | Hreflang and international SEO |
+| `/seo plan <type>` | Strategic planning by industry |
+| `/seo programmatic [url\|plan]` | Programmatic SEO analysis |
+| `/seo competitor-pages [url\|generate]` | Competitor comparison pages |
+| `/seo flow [stage] [url\|topic]` | FLOW framework prompts |
+| `/seo google [command] [url]` | Google SEO APIs (GSC, PSI, CrUX, GA4) |
 | `/seo dataforseo [command]` | Live SEO data (extension) |
+| `/seo image-gen [use-case] <desc>` | AI image generation (extension) |
+| `/seo firecrawl [command] <url>` | Full-site crawling (extension) |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -11,19 +11,39 @@ Optional:
 
 ## Quick Install
 
-### Unix/macOS/Linux
+### Plugin Install (Claude Code 1.0.33+)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh | bash
+The recommended path. Inside Claude Code:
+
+```
+/plugin marketplace add AgriciDaniel/claude-seo
+/plugin install claude-seo@agricidaniel-seo
 ```
 
-### Windows (PowerShell)
+### Manual Install (Unix, macOS, Linux)
+
+```bash
+git clone --depth 1 https://github.com/AgriciDaniel/claude-seo.git
+bash claude-seo/install.sh
+```
+
+Review-then-run alternative:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh > install.sh
+cat install.sh        # review
+bash install.sh       # run when satisfied
+rm install.sh
+```
+
+### Manual Install (Windows, PowerShell)
 
 ```powershell
 git clone --depth 1 https://github.com/AgriciDaniel/claude-seo.git
-cd claude-seo
-powershell -ExecutionPolicy Bypass -File install.ps1
+powershell -ExecutionPolicy Bypass -File claude-seo\install.ps1
 ```
+
+The Windows path uses `git clone` rather than `irm | iex` because Claude Code's own security guardrails flag piped remote-script execution. Inspect `install.ps1` before running.
 
 ## Manual Installation
 
@@ -89,34 +109,21 @@ You should see a help message or prompt for a URL.
 
 ## Uninstallation
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/uninstall.sh | bash
+If installed as a plugin:
+
+```
+/plugin uninstall claude-seo@agricidaniel-seo
+/plugin marketplace remove AgriciDaniel/claude-seo
 ```
 
-Or manually:
+If installed manually, run the uninstaller from a fresh clone:
 
 ```bash
-rm -rf ~/.claude/skills/seo
-rm -rf ~/.claude/skills/seo-audit
-rm -rf ~/.claude/skills/seo-backlinks
-rm -rf ~/.claude/skills/seo-competitor-pages
-rm -rf ~/.claude/skills/seo-content
-rm -rf ~/.claude/skills/seo-dataforseo
-rm -rf ~/.claude/skills/seo-geo
-rm -rf ~/.claude/skills/seo-google
-rm -rf ~/.claude/skills/seo-hreflang
-rm -rf ~/.claude/skills/seo-image-gen
-rm -rf ~/.claude/skills/seo-images
-rm -rf ~/.claude/skills/seo-local
-rm -rf ~/.claude/skills/seo-maps
-rm -rf ~/.claude/skills/seo-page
-rm -rf ~/.claude/skills/seo-plan
-rm -rf ~/.claude/skills/seo-programmatic
-rm -rf ~/.claude/skills/seo-schema
-rm -rf ~/.claude/skills/seo-sitemap
-rm -rf ~/.claude/skills/seo-technical
-rm -f ~/.claude/agents/seo-*.md
+git clone --depth 1 https://github.com/AgriciDaniel/claude-seo.git
+bash claude-seo/uninstall.sh
 ```
+
+`uninstall.sh` removes all installed sub-skills, sub-agents, and the plugin's MCP entries from `~/.claude/settings.json`. Do not maintain a hand-coded `rm` list. The shipped uninstaller is the canonical source.
 
 ## Upgrading
 

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -1,4 +1,3 @@
-<!-- Updated: 2026-02-07 -->
 # MCP Integration
 
 ## Overview

--- a/translations/uk/CONTRIBUTING.md
+++ b/translations/uk/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 <!-- i18n-source-sha: HEAD -->
 <!-- i18n-date: 2026-04-10 -->
 
+> **Translation may be behind the English source.** Refer to [the English version](../../CONTRIBUTING.md) for the latest content.
+>
+> **Переклад може відставати від англійської версії.** Актуальний вміст: [англійська версія](../../CONTRIBUTING.md).
+
 # Внесок у claude-seo
 
 Дякуємо за інтерес до участі! Ось як долучитися.

--- a/translations/uk/PRIVACY.md
+++ b/translations/uk/PRIVACY.md
@@ -2,6 +2,10 @@
 <!-- i18n-source-sha: HEAD -->
 <!-- i18n-date: 2026-04-10 -->
 
+> **Translation may be behind the English source.** Refer to [the English version](../../PRIVACY.md) for the latest content.
+>
+> **Переклад може відставати від англійської версії.** Актуальний вміст: [англійська версія](../../PRIVACY.md).
+
 # Конфіденційність
 
 ## Обробка даних

--- a/translations/uk/README.md
+++ b/translations/uk/README.md
@@ -2,6 +2,10 @@
 <!-- i18n-source-sha: HEAD -->
 <!-- i18n-date: 2026-04-10 -->
 
+> **Translation may be behind the English source.** Refer to [the English version](../../README.md) for the latest content.
+>
+> **Переклад може відставати від англійської версії.** Актуальний вміст: [англійська версія](../../README.md).
+
 ![Claude SEO](../../screenshots/cover-image.jpeg)
 
 # Claude SEO — навичка SEO-аудиту для Claude Code

--- a/translations/uk/SECURITY.md
+++ b/translations/uk/SECURITY.md
@@ -2,6 +2,10 @@
 <!-- i18n-source-sha: HEAD -->
 <!-- i18n-date: 2026-04-10 -->
 
+> **Translation may be behind the English source.** Refer to [the English version](../../SECURITY.md) for the latest content.
+>
+> **Переклад може відставати від англійської версії.** Актуальний вміст: [англійська версія](../../SECURITY.md).
+
 # Політика безпеки
 
 ## Повідомлення про вразливість

--- a/translations/uk/docs/INSTALLATION.md
+++ b/translations/uk/docs/INSTALLATION.md
@@ -2,6 +2,10 @@
 <!-- i18n-source-sha: HEAD -->
 <!-- i18n-date: 2026-04-10 -->
 
+> **Translation may be behind the English source.** Refer to [the English version](../../../docs/INSTALLATION.md) for the latest content.
+>
+> **Переклад може відставати від англійської версії.** Актуальний вміст: [англійська версія](../../../docs/INSTALLATION.md).
+
 # Посібник зі встановлення
 
 ## Передумови

--- a/translations/uk/docs/TROUBLESHOOTING.md
+++ b/translations/uk/docs/TROUBLESHOOTING.md
@@ -2,6 +2,10 @@
 <!-- i18n-source-sha: HEAD -->
 <!-- i18n-date: 2026-04-10 -->
 
+> **Translation may be behind the English source.** Refer to [the English version](../../../docs/TROUBLESHOOTING.md) for the latest content.
+>
+> **Переклад може відставати від англійської версії.** Актуальний вміст: [англійська версія](../../../docs/TROUBLESHOOTING.md).
+
 # Усунення неполадок
 
 ## Типові проблеми


### PR DESCRIPTION
## Summary

Comprehensive doc-only cleanup pass to bring every tracked Markdown file in line with v1.9.7 reality. Marketplace-readiness work, no skill behavior changes.

## Slate (D1 through D8)

| ID | File | Change |
|---|---|---|
| README | README.md | Drop Showcase + Publishing Pipeline, fold MCP Integrations into Extensions, consolidate two trailing footers, fix architecture skill counts (21+3 to 24, 15+2 to 18), drop "(New in vX.Y.Z)" version markers, drop Recently Added, tighten curl details, ToC reordered to match doc + add missing entries (License, Author, Community Contributors). Zero em dashes. Zero filler ("Comprehensive", "fully", "Enterprise", "New for 2026") |
| D1 | CONTRIBUTORS.md | Add 9 v1.9.7 community PRs from 7 contributors (xiaolai, CrepuscularIRIS, evanlu14, EDSprog, NicT89, AndronMan, puneetindersingh) under a new sub-section. Closes the gap between this file and GitHub's contributor count |
| D2 | docs/ARCHITECTURE.md | Rewrite directory tree to current state: 24 sub-skills, 18 sub-agents, 3 extensions (DataForSEO + Banana + Firecrawl). Was stuck at v1.4-era state. Updated orchestration flow to show conditional subagent spawns |
| D3 | docs/COMMANDS.md | Add 11 missing command sections (local, maps, backlinks, cluster, sxo, drift, ecommerce, flow, google, image-gen, firecrawl). Quick-reference table now matches README (25 entries) |
| D4 | docs/INSTALLATION.md | Add plugin install path as the recommended option. Replace hardcoded 19-line uninstall list with a pointer to the shipped uninstall.sh |
| D5 | docs/MCP-INTEGRATION.md | Drop stale `<!-- Updated: 2026-02-07 -->` HTML comment |
| D6 | PRIVACY.md | Add nlp_analyze.py, keyword_planner.py, youtube_search.py to the Google APIs disclosure table |
| D7 | CONTRIBUTING.md | Refresh "v1.9.0 integrated 5 community submissions" line to also cover the 9 v1.9.7 PRs from 7 contributors |
| D8 | translations/uk/* (6 files) | Bilingual stale-notice header added to each file with a relative link to the canonical English source |

## Style constraints applied

- Zero em dashes in any English-language file touched
- Zero `--` used as em-dash substitute in prose (CLI flags in code blocks are fine)
- No filler words (Comprehensive, fully, Enterprise, etc.) in touched English content
- Existing Ukrainian body em dashes deliberately left alone — full re-translation is a separate slice

## Commits

| SHA | Title |
|---|---|
| `2cf9d04` | docs(readme): structural cleanup, drift fixes, em-dash and filler sweep |
| `0d46250` | docs(contributors): add 9 v1.9.7 community PRs from 7 contributors |
| `8e61f48` | docs(architecture): rewrite directory tree to match v1.9.7 surface |
| `12e1216` | docs(commands): add 11 missing command sections, refresh quick-ref |
| `cdfe72a` | docs(installation): add plugin install path, drop hardcoded uninstall list |
| `2cef95e` | docs: small drift fixes (MCP, PRIVACY, CONTRIBUTING) |
| `869d046` | docs(translations/uk): add bilingual stale-notice header |

## Verification

- All edited files: 0 em dashes, 0 `--` in prose, 0 filler
- ToC anchors in README all resolve
- Skill counts in ARCHITECTURE.md match disk: `ls -d skills/*/ | wc -l` returns 24, `ls agents/*.md | wc -l` returns 18
- Manifests still valid JSON
- 14 files changed, +476/-271 lines

## Out of scope (separate slates)

- Re-translating Ukrainian content to match latest English (large; tracked via the new stale-notice headers)
- Em-dash sweep across the 20+ skill / agent / extension SKILL.md files (large surface; better as its own slate)
- CHANGELOG.md historical entries (frozen by convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)