### PR TITLE
chore(manifests): marketplace metadata polish (category, email, homepage, keywords)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,25 @@
     {
       "name": "claude-seo",
       "source": "./",
-      "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, E-E-A-T, schema markup, image optimization, GEO/AEO, backlinks, local SEO, maps intelligence, semantic topic clustering, SXO, SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, and PDF reporting."
+      "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, E-E-A-T, schema markup, image optimization, GEO/AEO, backlinks, local SEO, maps intelligence, semantic topic clustering, SXO, SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, and PDF reporting.",
+      "category": "marketing",
+      "homepage": "https://claude-seo.md",
+      "keywords": [
+        "seo",
+        "technical-seo",
+        "e-e-a-t",
+        "schema-markup",
+        "geo",
+        "ai-search",
+        "local-seo",
+        "backlinks",
+        "semantic-clustering",
+        "ecommerce-seo",
+        "hreflang",
+        "google-search-console",
+        "pagespeed",
+        "ga4"
+      ]
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,11 +4,13 @@
   "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, PDF reporting, and strategic planning across all industries.",
   "author": {
     "name": "AgriciDaniel",
+    "email": "agricidaniel@gmail.com",
     "url": "https://github.com/AgriciDaniel"
   },
   "license": "MIT",
-  "homepage": "https://github.com/AgriciDaniel/claude-seo",
+  "homepage": "https://claude-seo.md",
   "repository": "https://github.com/AgriciDaniel/claude-seo",
+  "category": "marketing",
   "keywords": [
     "seo",
     "technical-seo",


### PR DESCRIPTION
## Summary

Manifest improvements to maximize the odds of `claude-seo` being merged into `anthropics/claude-plugins-official/.claude-plugin/marketplace.json` (the source of truth behind https://claude.com/plugins).

## Research basis

The public directory at https://claude.com/plugins is rendered from `marketplace.json` in `anthropics/claude-plugins-official`, not from individual repos. Anthropic curators perform the merge after a submission. Sampling the 168 currently-listed plugins shows the higher-quality entries consistently carry `category`, `author.email`, a docs-site `homepage` (not a bare GitHub URL), and a `keywords` array on the plugin entry itself.

No SEO-focused plugin currently exists among those 168 entries. `claude-seo` would be the first.

## Changes

`.claude-plugin/plugin.json`:
- Added `author.email`: `agricidaniel@gmail.com`
- Changed `homepage` from the GitHub repo URL to the live docs site at `https://claude-seo.md`
- Added `category: "marketing"` (closest existing category in the directory schema; SEO would be a first)

`.claude-plugin/marketplace.json` (`plugins[0]` entry):
- Added `category: "marketing"`
- Added `homepage: "https://claude-seo.md"`
- Added a 14-keyword `keywords` array (high-signal subset of the plugin.json keywords)

## Not in scope

No version bump: these are listing-metadata changes, not runtime behavior. They take effect when Anthropic next reads the manifest during curation review.

## Verification

- Both JSON files parse cleanly
- `category`, `email`, `homepage`, `keywords` all present and correctly typed
- Diff: 2 files changed, 22 insertions, 2 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)