### PR TITLE
chore(v1.9.8): skill-count fix + manifest consistency CI guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "name": "AgriciDaniel"
   },
   "metadata": {
-    "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills covering technical SEO, E-E-A-T, schema markup, GEO, local SEO, semantic clustering, e-commerce SEO, international SEO, and PDF reporting."
+    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills covering technical SEO, E-E-A-T, content briefs, schema markup, GEO, local SEO, semantic clustering, e-commerce SEO, international SEO, and PDF reporting."
   },
   "plugins": [
     {
       "name": "claude-seo",
       "source": "./",
-      "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, E-E-A-T, schema markup, image optimization, GEO/AEO, backlinks, local SEO, maps intelligence, semantic topic clustering, SXO, SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, and PDF reporting.",
+      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, content quality (E-E-A-T), content briefs, schema markup, image optimization, GEO/AEO, backlinks, local SEO, maps intelligence, semantic topic clustering, SXO, SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, and PDF reporting.",
       "category": "marketing",
       "homepage": "https://claude-seo.md",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-seo",
-  "version": "1.9.7",
-  "description": "Comprehensive SEO analysis plugin for Claude Code. 24 sub-skills (20 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, PDF reporting, and strategic planning across all industries.",
+  "version": "1.9.8",
+  "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, content quality (E-E-A-T), content briefs, schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, PDF reporting, and strategic planning across all industries.",
   "author": {
     "name": "AgriciDaniel",
     "email": "agricidaniel@gmail.com",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
   test:
     name: Test suite (manifests + sync_flow)
     runs-on: ubuntu-latest
+    env:
+      # gh CLI honors GH_TOKEN automatically; sync_flow.py uses gh for auth.
+      # Without this, anonymous API requests hit GitHub's 60/hr per-IP rate
+      # limit and the sync_flow dry-run test fails on shared-runner IPs.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,20 @@ jobs:
           python3 -m py_compile scripts/sync_flow.py
           python3 -m py_compile scripts/release_report.py
           echo "All 30 scripts passed syntax check"
+
+  test:
+    name: Test suite (manifests + sync_flow)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/ -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Claude SEO is a Tier 4 SEO analysis skill with 24 sub-skills (20 core + 1 orchestrator +
+Claude SEO is a Tier 4 SEO analysis skill with 25 sub-skills (21 core + 1 orchestrator +
 1 framework integration + 2 extension mirrors), 18 sub-agents (15 core + 1 framework
 integration + 2 extension mirrors), and 30 Python execution scripts.
 
@@ -82,7 +82,7 @@ bash install.sh
 ## Architecture
 
 ```
-skills/                    # 24 sub-skills (auto-discovered)
+skills/                    # 25 sub-skills (auto-discovered)
   seo/SKILL.md            # Main orchestrator + routing
   seo-cluster/            # Semantic clustering (v1.9.0)
   seo-sxo/                # Search Experience Optimization (v1.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.8] - 2026-05-09
+
+### Fixed
+- **Skill-count drift returned via PR #56.** When the `seo-content-brief` skill
+  was merged into v1.9.7 it added a 21st core skill, but the manifest
+  reconciliation in v1.9.7 had locked the canonical phrasing at "20 core" and
+  was not re-run after Phase C. Result: plugin.json, marketplace.json,
+  README.md, CLAUDE.md, AGENTS.md, and docs/ARCHITECTURE.md all under-claimed
+  by one. Reconciled to "25 sub-skills (21 core + 1 orchestrator + 1 framework
+  integration + 2 extension mirrors)".
+
+### Added
+- **`tests/test_manifest_consistency.py`**: pytest suite that asserts
+  plugin.json + marketplace.json claimed counts match the actual on-disk
+  count of `skills/*/SKILL.md` and `agents/seo-*.md`, that plugin.json and
+  marketplace.json descriptions agree on the canonical math, that user-visible
+  docs (README, CLAUDE.md, AGENTS.md) reference the same skill count, and that
+  plugin.json `version` and CITATION.cff `version` triangulate. Closes the
+  systemic gap that allowed two skill-count drift incidents in v1.9.7.
+- **`pytest tests/` job in `.github/workflows/ci.yml`**: runs the new manifest
+  consistency suite on every push to main and every pull request, gating
+  future skill additions behind matching documentation updates.
+
+### Changed
+- This release rolls forward two commits that landed on main after the v1.9.7
+  tag was cut:
+  - `8514999`: marketplace metadata polish (added `category: "marketing"`,
+    `author.email`, `homepage: https://claude-seo.md`, and a 14-keyword array
+    to the marketplace.json plugin entry)
+  - `66a7485`: em-dash sweep on user-visible AGENTS.md and CHANGELOG.md
+  Both were intentionally scoped at v1.9.7 but landed post-tag. v1.9.8 captures
+  them properly.
+
 ## [1.9.7] - 2026-05-09
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
 repository-code: 'https://github.com/AgriciDaniel/claude-seo'
 url: 'https://github.com/AgriciDaniel/claude-seo'
 license: MIT
-version: 1.9.7
+version: 1.9.8
 date-released: '2026-05-09'
 keywords:
   - seo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 This repository contains **Claude SEO**, a Tier 4 Claude Code skill for comprehensive
 SEO analysis across all industries. It follows the Agent Skills open standard and the
-3-layer architecture (directive, orchestration, execution). 24 sub-skills (20 core +
+3-layer architecture (directive, orchestration, execution). 25 sub-skills (21 core +
 1 orchestrator + 1 framework integration + 2 extension mirrors), 18 sub-agents (15 core +
 1 framework integration + 2 extension mirrors), and an extensible reference
 system cover technical SEO, content quality,
@@ -21,9 +21,9 @@ claude-seo/
   CONTRIBUTORS.md                    # Community credits (Pro Hub Challenge)
   AGENTS.md                          # Multi-platform agent instructions (Cursor, Antigravity)
   .claude-plugin/
-    plugin.json                    # Plugin manifest (v1.9.7)
+    plugin.json                    # Plugin manifest (v1.9.8)
     marketplace.json               # Marketplace catalog for distribution
-  skills/                            # 24 sub-skills (auto-discovered)
+  skills/                            # 25 sub-skills (auto-discovered)
     seo/                           # Main orchestrator skill
       SKILL.md                     # Entry point, routing table, core rules
       references/                  # On-demand knowledge files (12 files)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Claude SEO - SEO Audit Skill for Claude Code
 
-SEO analysis plugin for Claude Code. 24 sub-skills (20 core, 1 orchestrator, 1 framework integration, 2 extension mirrors) and 18 sub-agents (15 core, 1 framework integration, 2 extension mirrors) covering technical SEO, on-page analysis, content quality (E-E-A-T), schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google SEO APIs (Search Console, PageSpeed, CrUX, GA4), PDF report generation, and strategic planning.
+SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, on-page analysis, content quality (E-E-A-T), content briefs, schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google SEO APIs (Search Console, PageSpeed, CrUX, GA4), PDF report generation, and strategic planning.
 
 ![SEO Command Demo](screenshots/seo-command-demo.gif)
 
@@ -230,7 +230,7 @@ Direct integration with Google's SEO data:
 
 ```
 ~/.claude/plugins/.../skills/seo/      # Main orchestrator
-~/.claude/plugins/.../skills/seo-*/    # 24 sub-skills (auto-discovered)
+~/.claude/plugins/.../skills/seo-*/    # 25 sub-skills (auto-discovered)
 ~/.claude/plugins/.../agents/seo-*.md  # 18 sub-agents (auto-discovered)
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ Claude SEO follows Anthropic's official Claude Code skill specification with a m
 
 ## Directory Structure
 
-The plugin ships 24 sub-skills (20 core, 1 orchestrator, 1 framework integration, 2 extension mirrors) and 18 sub-agents (15 core, 1 framework integration, 2 extension mirrors).
+The plugin ships 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors).
 
 ```
 ~/.claude/plugins/.../claude-seo/

--- a/tests/test_manifest_consistency.py
+++ b/tests/test_manifest_consistency.py
@@ -1,0 +1,146 @@
+"""
+Tests that ensure the plugin's manifest and user-visible docs claim
+counts that match reality on disk.
+
+Background: this guard exists because the v1.9.7 release process suffered
+two distinct skill-count drift incidents in a single release window. The
+first was caught by manual reconciliation (pre-Phase-A); the second slipped
+through when PR #56 merged a 21st core skill but the canonical phrasing
+locked in Phase A was not re-run. v1.9.8 closes the systemic gap.
+
+Tests run via `pytest tests/` and are wired into `.github/workflows/ci.yml`.
+"""
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+CITATION_CFF = REPO_ROOT / "CITATION.cff"
+
+
+def _count_skill_dirs() -> int:
+    """Count subdirectories of skills/ that contain a SKILL.md."""
+    skills_dir = REPO_ROOT / "skills"
+    return sum(
+        1 for d in skills_dir.iterdir()
+        if d.is_dir() and (d / "SKILL.md").is_file()
+    )
+
+
+def _count_agent_files() -> int:
+    """Count agents/seo-*.md files."""
+    agents_dir = REPO_ROOT / "agents"
+    return sum(
+        1 for f in agents_dir.iterdir()
+        if f.is_file() and f.suffix == ".md" and f.name.startswith("seo-")
+    )
+
+
+def _extract_count(text: str, unit: str) -> int:
+    """Find the first occurrence of 'N <unit>' in text and return N."""
+    match = re.search(rf"(\d+)\s+{re.escape(unit)}", text)
+    if not match:
+        raise AssertionError(f"No '{unit}' count claim found in text")
+    return int(match.group(1))
+
+
+def test_plugin_json_skill_count_matches_disk():
+    """plugin.json description's 'N sub-skills' claim must equal skills/ dir count."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    claimed = _extract_count(plugin["description"], "sub-skills")
+    actual = _count_skill_dirs()
+    assert claimed == actual, (
+        f"plugin.json description claims {claimed} sub-skills "
+        f"but disk has {actual}. "
+        f"Update the description to match the new count."
+    )
+
+
+def test_plugin_json_subagent_count_matches_disk():
+    """plugin.json description's 'N sub-agents' claim must equal agents/ count."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    claimed = _extract_count(plugin["description"], "sub-agents")
+    actual = _count_agent_files()
+    assert claimed == actual, (
+        f"plugin.json description claims {claimed} sub-agents "
+        f"but disk has {actual}. "
+        f"Update the description to match the new count."
+    )
+
+
+def test_marketplace_json_skill_count_matches_plugin_json():
+    """marketplace.json plugin entry must claim the same skill count as plugin.json."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    marketplace = json.loads(MARKETPLACE_JSON.read_text())
+    plugin_count = _extract_count(plugin["description"], "sub-skills")
+    market_count = _extract_count(
+        marketplace["plugins"][0]["description"], "sub-skills"
+    )
+    assert plugin_count == market_count, (
+        f"plugin.json claims {plugin_count} sub-skills, "
+        f"marketplace.json plugin entry claims {market_count}. "
+        f"They must agree."
+    )
+
+
+def test_marketplace_json_subagent_count_matches_plugin_json():
+    """marketplace.json plugin entry must claim the same sub-agent count as plugin.json."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    marketplace = json.loads(MARKETPLACE_JSON.read_text())
+    plugin_count = _extract_count(plugin["description"], "sub-agents")
+    market_count = _extract_count(
+        marketplace["plugins"][0]["description"], "sub-agents"
+    )
+    assert plugin_count == market_count, (
+        f"plugin.json claims {plugin_count} sub-agents, "
+        f"marketplace.json plugin entry claims {market_count}. "
+        f"They must agree."
+    )
+
+
+def test_canonical_phrasing_in_user_visible_docs():
+    """README, CLAUDE.md, AGENTS.md must reference the canonical sub-skills count."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    canonical_count = _extract_count(plugin["description"], "sub-skills")
+    target_phrase = f"{canonical_count} sub-skills"
+    for filename in ["README.md", "CLAUDE.md", "AGENTS.md"]:
+        path = REPO_ROOT / filename
+        head = "\n".join(path.read_text().splitlines()[:120])
+        assert target_phrase in head, (
+            f"{filename} does not reference '{target_phrase}' in its first "
+            f"120 lines. Update it to match plugin.json's canonical phrasing."
+        )
+
+
+def test_version_triangulation():
+    """plugin.json version must equal CITATION.cff version."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    citation_text = CITATION_CFF.read_text()
+    citation_match = re.search(r"^version:\s*(\S+)", citation_text, re.MULTILINE)
+    assert citation_match, "CITATION.cff has no 'version:' line"
+    plugin_version = plugin["version"]
+    citation_version = citation_match.group(1)
+    assert plugin_version == citation_version, (
+        f"plugin.json version is {plugin_version} but CITATION.cff has "
+        f"{citation_version}. They must match every release."
+    )
+
+
+def test_canonical_math_adds_up():
+    """The canonical phrasing's parenthetical breakdown must sum to the headline count."""
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    desc = plugin["description"]
+    headline_match = re.search(r"(\d+)\s+sub-skills\s+\(([^)]+)\)", desc)
+    assert headline_match, (
+        "plugin.json description must use the canonical 'N sub-skills (...)' "
+        "phrasing with a parenthetical breakdown"
+    )
+    headline = int(headline_match.group(1))
+    breakdown = headline_match.group(2)
+    parts = [int(n) for n in re.findall(r"(\d+)\s+(?:core|orchestrator|framework|extension)", breakdown)]
+    assert sum(parts) == headline, (
+        f"plugin.json canonical phrasing breakdown {breakdown!r} sums to "
+        f"{sum(parts)} but headline claims {headline}. Math must add up."
+    )


### PR DESCRIPTION
## Summary

Three coordinated changes that close the systemic gap behind the two skill-count drift incidents that surfaced in v1.9.7's release window.

## Why a v1.9.8 only one day after v1.9.7?

Two reasons make a clean v1.9.8 the correct fix:

1. **Skill-count drift returned via PR #56.** When `seo-content-brief` merged in Phase C, it added a 21st core skill, but the canonical phrasing locked in Phase A at "20 core" was not re-run. v1.9.7 shipped with all manifests + docs claiming 24 sub-skills when reality is 25. This is a real inconsistency that an Anthropic curator or any reviewer would notice on a sniff test.

2. **Two commits landed on `main` after v1.9.7's tag was cut.** `8514999` (marketplace metadata polish) and `66a7485` (em-dash sweep on user-visible docs) were both intentionally scoped at v1.9.7 but landed post-tag. v1.9.8 captures them properly so the release artifact reflects what was intended.

## Commits

| SHA | Title |
|---|---|
| `1d8e865` | chore(v1.9.8): reconcile 25-skill canonical phrasing + version bump |
| `9b4531f` | test(manifests): add consistency suite (7 assertions) |
| `d96e8b9` | ci: add pytest job to run manifest-consistency + sync_flow tests |

## Reconciled to canonical phrasing

`25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors)` and `18 sub-agents (15 core + 1 framework integration + 2 extension mirrors)` across plugin.json, marketplace.json (both descriptions), CLAUDE.md, AGENTS.md, README.md, docs/ARCHITECTURE.md.

Math: 21 + 1 + 1 + 2 = 25. Verified against `ls -d skills/*/`.

## New CI guard

`tests/test_manifest_consistency.py` adds 7 assertions that gate future skill additions behind matching documentation updates:

1. plugin.json description's `N sub-skills` claim equals on-disk skill count
2. plugin.json description's `N sub-agents` claim equals on-disk agent count
3. marketplace.json plugin entry's sub-skills count matches plugin.json
4. marketplace.json plugin entry's sub-agents count matches plugin.json
5. README, CLAUDE.md, AGENTS.md all reference the canonical sub-skills count
6. plugin.json `version` equals CITATION.cff `version`
7. Canonical math adds up (the breakdown sums to the headline)

Each failure message names the specific file and field to fix. Suite runs in <50 ms.

## CI workflow expanded

`.github/workflows/ci.yml` now has TWO jobs: the existing `lint` (py_compile on 30 scripts) plus a new `test` job that installs pytest and runs the full tests/ directory. Both gate every push to main and every PR.

## Verification

- 22 tests pass locally (7 new + 15 existing in `test_sync_flow.py`)
- All Python files py_compile
- JSON manifests parse cleanly
- YAML workflow file parses cleanly
- New canonical phrasing applied uniformly across all 6 user-visible files

## Not included

- The marketplace metadata polish (#84) and em-dash sweep (#85) are already on main; this PR rolls them forward into a tagged release rather than re-applying them.
- No new features or skill behavior changes.
- No GitHub Release tag pushed yet — that's the next step after merge, gated on user authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)