### PR TITLE
fix(uninstall): use glob enumeration so future skills are cleaned up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   future skill additions behind matching documentation updates.
 
 ### Changed
+- **`uninstall.sh` and `uninstall.ps1` now use glob enumeration** rather than a
+  hardcoded skill list. The previous scripts had been frozen at v1.4.0-era
+  state and missed 12 sub-skills and 11 sub-agents added between v1.5 and
+  v1.9.8 (`seo-backlinks`, `seo-cluster`, `seo-content-brief`, `seo-dataforseo`,
+  `seo-drift`, `seo-ecommerce`, `seo-flow`, `seo-google`, `seo-image-gen`,
+  `seo-local`, `seo-maps`, `seo-sxo` and the corresponding agents). Anyone who
+  ran the old uninstaller got half a cleanup. Glob enumeration auto-tracks
+  future skill additions without requiring uninstaller maintenance. Sandbox
+  test confirms the new scripts remove every `seo` and `seo-*` skill plus
+  every `seo-*.md` agent while leaving sibling skills (e.g. `blog-writer`,
+  `security`) untouched.
 - This release rolls forward two commits that landed on main after the v1.9.7
   tag was cut:
   - `8514999`: marketplace metadata polish (added `category: "marketing"`,

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,6 +1,16 @@
 #!/usr/bin/env pwsh
-# claude-seo uninstaller for Windows
-# Cleanly removes all SEO skills, agents, and scripts
+# claude-seo manual-install uninstaller (Windows)
+#
+# Removes the orchestrator skill (~/.claude/skills/seo), all sub-skills
+# (~/.claude/skills/seo-*), and all sub-agents (~/.claude/agents/seo-*.md).
+#
+# Uses glob enumeration rather than a hardcoded list so future skill
+# additions are cleaned up automatically without releasing a new
+# uninstaller.
+#
+# Plugin-install users should use Claude Code's own command instead:
+#   /plugin uninstall claude-seo@agricidaniel-seo
+#   /plugin marketplace remove AgriciDaniel/claude-seo
 
 $ErrorActionPreference = "Stop"
 
@@ -15,42 +25,43 @@ function Main {
     Write-Color Cyan "=== Uninstalling claude-seo ==="
     Write-Host ""
 
-    # Remove main skill (includes venv, references, scripts, hooks)
-    $seoDir = Join-Path $SkillDir "seo"
-    if (Test-Path $seoDir) {
-        Remove-Item -Recurse -Force $seoDir
-        Write-Color Green "  Removed: $seoDir"
+    $removedSkills = 0
+    $removedAgents = 0
+
+    # Remove orchestrator if present
+    $orchestratorPath = Join-Path $SkillDir "seo"
+    if (Test-Path $orchestratorPath -PathType Container) {
+        Remove-Item -Recurse -Force $orchestratorPath
+        Write-Color Green "  Removed: $orchestratorPath"
+        $removedSkills++
     }
 
-    # Remove sub-skills
-    $subSkills = @(
-        "seo-audit", "seo-competitor-pages", "seo-content", "seo-geo",
-        "seo-hreflang", "seo-images", "seo-page", "seo-plan",
-        "seo-programmatic", "seo-schema", "seo-sitemap", "seo-technical"
-    )
-    foreach ($skill in $subSkills) {
-        $skillPath = Join-Path $SkillDir $skill
-        if (Test-Path $skillPath) {
-            Remove-Item -Recurse -Force $skillPath
-            Write-Color Green "  Removed: $skillPath"
+    # Remove every seo-* sub-skill directory
+    if (Test-Path $SkillDir -PathType Container) {
+        Get-ChildItem -Path $SkillDir -Directory -Filter "seo-*" -ErrorAction SilentlyContinue | ForEach-Object {
+            Remove-Item -Recurse -Force $_.FullName
+            Write-Color Green "  Removed: $($_.FullName)"
+            $script:removedSkills++
         }
     }
 
-    # Remove agents
-    $agents = @(
-        "seo-technical", "seo-content", "seo-schema",
-        "seo-sitemap", "seo-performance", "seo-visual", "seo-geo"
-    )
-    foreach ($agent in $agents) {
-        $agentPath = Join-Path $AgentDir "$agent.md"
-        if (Test-Path $agentPath) {
-            Remove-Item -Force $agentPath
-            Write-Color Green "  Removed: $agentPath"
+    # Remove every seo-*.md agent file
+    if (Test-Path $AgentDir -PathType Container) {
+        Get-ChildItem -Path $AgentDir -File -Filter "seo-*.md" -ErrorAction SilentlyContinue | ForEach-Object {
+            Remove-Item -Force $_.FullName
+            Write-Color Green "  Removed: $($_.FullName)"
+            $script:removedAgents++
         }
     }
 
     Write-Host ""
-    Write-Color Cyan "=== claude-seo uninstalled ==="
+    if ($removedSkills -eq 0 -and $removedAgents -eq 0) {
+        Write-Color Yellow "Nothing to remove. Claude SEO does not appear to be installed."
+        Write-Color Yellow "If you installed via /plugin install, run /plugin uninstall instead."
+        return
+    }
+
+    Write-Color Cyan "=== claude-seo uninstalled ($removedSkills skill dirs, $removedAgents agent files) ==="
     Write-Host ""
     Write-Color Yellow "Restart Claude Code to complete removal."
 }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,23 +1,64 @@
 #!/usr/bin/env bash
+# claude-seo manual-install uninstaller (Unix / macOS / Linux)
+#
+# Removes the orchestrator skill (~/.claude/skills/seo), all sub-skills
+# (~/.claude/skills/seo-*), and all sub-agents (~/.claude/agents/seo-*.md).
+#
+# Uses glob enumeration rather than a hardcoded list so future skill
+# additions are cleaned up automatically without releasing a new
+# uninstaller.
+#
+# Plugin-install users should use Claude Code's own command instead:
+#   /plugin uninstall claude-seo@agricidaniel-seo
+#   /plugin marketplace remove AgriciDaniel/claude-seo
 set -euo pipefail
+
+SKILL_DIR="${HOME}/.claude/skills"
+AGENT_DIR="${HOME}/.claude/agents"
 
 main() {
     echo "→ Uninstalling Claude SEO..."
 
-    # Remove main skill (includes venv and requirements.txt)
-    rm -rf "${HOME}/.claude/skills/seo"
+    local removed_skills=0
+    local removed_agents=0
 
-    # Remove sub-skills
-    for skill in seo-audit seo-competitor-pages seo-content seo-geo seo-hreflang seo-images seo-page seo-plan seo-programmatic seo-schema seo-sitemap seo-technical; do
-        rm -rf "${HOME}/.claude/skills/${skill}"
+    # Allow empty globs to expand to nothing rather than the literal pattern
+    shopt -s nullglob
+
+    # Remove orchestrator if present
+    if [ -d "${SKILL_DIR}/seo" ]; then
+        rm -rf "${SKILL_DIR}/seo"
+        echo "  Removed: ${SKILL_DIR}/seo"
+        removed_skills=$((removed_skills + 1))
+    fi
+
+    # Remove every seo-* sub-skill directory
+    for skill_path in "${SKILL_DIR}"/seo-*; do
+        if [ -d "${skill_path}" ]; then
+            rm -rf "${skill_path}"
+            echo "  Removed: ${skill_path}"
+            removed_skills=$((removed_skills + 1))
+        fi
     done
 
-    # Remove agents
-    for agent in seo-technical seo-content seo-schema seo-sitemap seo-performance seo-visual seo-geo; do
-        rm -f "${HOME}/.claude/agents/${agent}.md"
+    # Remove every seo-*.md agent file
+    for agent_path in "${AGENT_DIR}"/seo-*.md; do
+        if [ -f "${agent_path}" ]; then
+            rm -f "${agent_path}"
+            echo "  Removed: ${agent_path}"
+            removed_agents=$((removed_agents + 1))
+        fi
     done
 
-    echo "✓ Claude SEO uninstalled."
+    shopt -u nullglob
+
+    if [ "${removed_skills}" -eq 0 ] && [ "${removed_agents}" -eq 0 ]; then
+        echo "  Nothing to remove. Claude SEO does not appear to be installed."
+        echo "  If you installed via /plugin install, run /plugin uninstall instead."
+        return 0
+    fi
+
+    echo "✓ Claude SEO uninstalled (${removed_skills} skill dirs, ${removed_agents} agent files)."
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

The uninstall scripts (`uninstall.sh` and `uninstall.ps1`) had been frozen at v1.4.0-era state with a hardcoded list of 12 sub-skills and 7 agents. Between v1.5 and v1.9.8 we shipped:

| Added since v1.4.0 | Old uninstaller knew? |
|---|---|
| `seo-backlinks` | ❌ |
| `seo-cluster` | ❌ |
| `seo-content-brief` | ❌ |
| `seo-dataforseo` | ❌ |
| `seo-drift` | ❌ |
| `seo-ecommerce` | ❌ |
| `seo-flow` | ❌ |
| `seo-google` | ❌ |
| `seo-image-gen` | ❌ |
| `seo-local` | ❌ |
| `seo-maps` | ❌ |
| `seo-sxo` | ❌ |
| 11 corresponding agents | ❌ |

Anyone running `bash uninstall.sh` today got half a cleanup. And `docs/INSTALLATION.md` (recently updated as part of the docs cleanup) now points users at this broken script.

## Fix

Both scripts now enumerate skills via glob matching:

- `~/.claude/skills/seo` (orchestrator)
- `~/.claude/skills/seo-*` (any sub-skill, present and future)
- `~/.claude/agents/seo-*.md` (any agent file)

This auto-tracks future additions without requiring uninstaller maintenance per release. Sibling skills that do not start with `seo` are explicitly preserved.

## Verification

Sandbox-tested with 8 assertions covering: orchestrator removal, old hardcoded list (`seo-audit`) still works, new skills (`seo-content-brief`, `seo-flow`) now cleaned up, non-seo skills (`blog-writer`, `security`) preserved, agent file removal, non-seo agent files preserved, plus an empty-installation edge case (exit 0 with a helpful message pointing at `/plugin uninstall` for plugin-install users).

## Scope

This is the manual-install uninstall path. Plugin-install users (the recommended path documented at the top of `docs/INSTALLATION.md`) use `/plugin uninstall claude-seo@agricidaniel-seo` and are unaffected by this change.

## Bundled into v1.9.8

Caught during pre-release verification. Bundled into v1.9.8 since the tag has not been pushed yet. CHANGELOG `[1.9.8]` entry updated to document the fix alongside the other v1.9.8 changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)