### PR TITLE
fix(install): bump default tag to v1.9.8 + close drift gaps in CI guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`install.sh` and `install.ps1` default tag pinned to `v1.9.0`**, four
+  releases stale (v1.9.5/.6/.7/.8 all missed the bump). Anyone running
+  `curl -fsSL .../install.sh | bash` got the April 14 release, missing the
+  FLOW framework integration, the security audit pass, the doc reconciliation,
+  and the manifest CI guard plus all v1.9.8 Phase B bug fixes (Windows hook,
+  OAuth refresh, missing imports, None guards). Bumped both to `v1.9.8`.
+  Plugin-install users (`/plugin install claude-seo@agricidaniel-seo`) were
+  unaffected because that path reads plugin.json directly.
+- **`pyproject.toml` version stuck at `1.9.6`** while plugin.json and
+  CITATION.cff shipped at 1.9.8. The v1.9.8 manifest CI guard's
+  `test_version_triangulation` only covered plugin.json ↔ CITATION.cff;
+  pyproject.toml was outside scope so the drift slipped through. Bumped to
+  1.9.8 and extended the CI guard to cover it.
+
+### Added
+- **`tests/test_manifest_consistency.py`** gains two new assertions:
+  - `test_pyproject_version_matches_plugin_json`: pyproject.toml version
+    must equal plugin.json version on every release.
+  - `test_install_scripts_default_tag_matches_plugin_version`: install.sh
+    `REPO_TAG` and install.ps1 `$RepoTag` defaults must equal
+    `v{plugin.json version}` on every release.
+  - Both tests verified with negative-case smoke tests (revert the value,
+    confirm the assertion fires with a clear actionable error message).
+  - Total assertions in the manifest consistency suite: 7 → 9.
+
+### Changed
+- Inline comments in `install.sh:13` and `install.ps1:90` now state that the
+  default tag MUST be bumped on every release and reference the CI guard that
+  enforces it. This makes the release-checklist requirement obvious to anyone
+  reading the file.
+
 ## [1.9.8] - 2026-05-09
 
 ### Fixed

--- a/install.ps1
+++ b/install.ps1
@@ -86,8 +86,10 @@ $SkillDir = "$env:USERPROFILE\.claude\skills\seo"
 $AgentDir = "$env:USERPROFILE\.claude\agents"
 $RepoUrl = "https://github.com/AgriciDaniel/claude-seo"
 # Pin to a specific release tag to prevent silent updates from main.
+# This default MUST be bumped on every release. CI guard
+# (tests/test_manifest_consistency.py) enforces this matches plugin.json.
 # Override: $env:CLAUDE_SEO_TAG = 'main'; .\install.ps1
-$RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v1.9.0' }
+$RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v1.9.8' }
 
 # Create directories
 New-Item -ItemType Directory -Force -Path $SkillDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,10 @@ main() {
     AGENT_DIR="${HOME}/.claude/agents"
     REPO_URL="https://github.com/AgriciDaniel/claude-seo"
     # Pin to a specific release tag to prevent silent updates from main.
+    # This default MUST be bumped on every release. CI guard
+    # (tests/test_manifest_consistency.py) enforces this matches plugin.json.
     # Override: CLAUDE_SEO_TAG=main bash install.sh
-    REPO_TAG="${CLAUDE_SEO_TAG:-v1.9.0}"
+    REPO_TAG="${CLAUDE_SEO_TAG:-v1.9.8}"
 
     echo "════════════════════════════════════════"
     echo "║   Claude SEO - Installer             ║"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-seo"
-version = "1.9.6"
+version = "1.9.8"
 description = "Comprehensive SEO analysis skill for Claude Code"
 requires-python = ">=3.10"
 license = "MIT"

--- a/tests/test_manifest_consistency.py
+++ b/tests/test_manifest_consistency.py
@@ -128,6 +128,61 @@ def test_version_triangulation():
     )
 
 
+def test_pyproject_version_matches_plugin_json():
+    """pyproject.toml version must equal plugin.json version.
+
+    Background: pyproject.toml drifted to 1.9.6 while plugin.json was at
+    1.9.8. The original triangulation test only covered CITATION.cff,
+    so pyproject.toml drift slipped past CI. This guard closes that gap.
+    """
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text()
+    pyproject_match = re.search(
+        r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE
+    )
+    assert pyproject_match, "pyproject.toml has no 'version = \"...\"' line"
+    plugin_version = plugin["version"]
+    pyproject_version = pyproject_match.group(1)
+    assert plugin_version == pyproject_version, (
+        f"plugin.json version is {plugin_version} but pyproject.toml has "
+        f"{pyproject_version}. Bump pyproject.toml on every release."
+    )
+
+
+def test_install_scripts_default_tag_matches_plugin_version():
+    """install.sh and install.ps1 default REPO_TAG must equal v{plugin version}.
+
+    Background: install.sh and install.ps1 default tag was v1.9.0 while
+    plugin.json shipped at 1.9.8 (4 missed bumps across v1.9.5/.6/.7/.8).
+    Manual-install users via curl | bash got 8 versions stale. This guard
+    forces the default tag to track plugin.json on every release.
+    """
+    plugin = json.loads(PLUGIN_JSON.read_text())
+    expected_tag = f"v{plugin['version']}"
+
+    sh_text = (REPO_ROOT / "install.sh").read_text()
+    sh_match = re.search(
+        r'REPO_TAG="\$\{CLAUDE_SEO_TAG:-([^}]+)\}"', sh_text
+    )
+    assert sh_match, "install.sh has no recognizable REPO_TAG default"
+    sh_tag = sh_match.group(1)
+    assert sh_tag == expected_tag, (
+        f"install.sh default tag is {sh_tag} but plugin.json is at "
+        f"version {plugin['version']} (expected {expected_tag}). "
+        f"Bump install.sh's CLAUDE_SEO_TAG default on every release."
+    )
+
+    ps_text = (REPO_ROOT / "install.ps1").read_text()
+    ps_match = re.search(r"else\s*\{\s*'([^']+)'\s*\}", ps_text)
+    assert ps_match, "install.ps1 has no recognizable RepoTag default"
+    ps_tag = ps_match.group(1)
+    assert ps_tag == expected_tag, (
+        f"install.ps1 default tag is {ps_tag} but plugin.json is at "
+        f"version {plugin['version']} (expected {expected_tag}). "
+        f"Bump install.ps1's RepoTag default on every release."
+    )
+
+
 def test_canonical_math_adds_up():
     """The canonical phrasing's parenthetical breakdown must sum to the headline count."""
     plugin = json.loads(PLUGIN_JSON.read_text())


### PR DESCRIPTION
## Summary

Three drift fixes flagged during a stale-files audit, plus an extension of the v1.9.8 manifest CI guard to prevent recurrence.

### What was broken

| Artifact | Before | After |
|---|---|---|
| `install.sh:13` default `REPO_TAG` | `v1.9.0` (4 missed bumps) | `v1.9.8` |
| `install.ps1:90` default `$RepoTag` | `v1.9.0` (4 missed bumps) | `v1.9.8` |
| `pyproject.toml:3` version | `1.9.6` (2 missed bumps) | `1.9.8` |

**Impact**: anyone running the documented manual-install path (`curl -fsSL https://github.com/AgriciDaniel/claude-seo/raw/main/install.sh | bash`) got the April 14 release. They missed FLOW framework integration (v1.9.5), the security audit pass that closed 10 findings (v1.9.6), doc reconciliation + marketplace polish (v1.9.7), skill-count fix + manifest CI guard + glob-enumeration uninstall + Phase B bug fixes for Windows hook, OAuth refresh, missing imports, and None guards (v1.9.8).

Plugin-install users (`/plugin install claude-seo@agricidaniel-seo`) were unaffected because that path reads `plugin.json` directly.

### Why the CI guard didn't catch it

The v1.9.8 manifest consistency suite (`tests/test_manifest_consistency.py`) has a `test_version_triangulation` assertion, but it only covers `plugin.json` ↔ `CITATION.cff`. Both were correctly bumped to 1.9.8 at release. `pyproject.toml` and the install scripts were outside the test's scope, so their drift was invisible to CI.

### What this PR adds

Two new assertions extend the triangulation set:

- `test_pyproject_version_matches_plugin_json` — `pyproject.toml` version must equal `plugin.json` version.
- `test_install_scripts_default_tag_matches_plugin_version` — install.sh `REPO_TAG` and install.ps1 `$RepoTag` defaults must equal `v{plugin.json version}`.

Total assertions in the manifest consistency suite: **7 → 9**.

Both new tests verified with **negative-case smoke tests** (sed the value back to the broken state, run pytest, confirm the assertion fires with an actionable error message). Examples of the error messages:

```
AssertionError: plugin.json version is 1.9.8 but pyproject.toml has 1.9.6.
                Bump pyproject.toml on every release.
```

```
AssertionError: install.sh default tag is v1.9.0 but plugin.json is at
                version 1.9.8 (expected v1.9.8). Bump install.sh's
                CLAUDE_SEO_TAG default on every release.
```

### Doc + comment changes

- Inline comments in `install.sh:13` and `install.ps1:90` now state the default tag MUST be bumped on every release and reference the CI guard that enforces it.
- `CHANGELOG.md` gets an `[Unreleased]` section documenting all three fixes plus the test extension. (Not bumping plugin.json / CITATION.cff — these fixes will land under whatever the next tagged release ends up being.)

## Test plan

- [x] `python3 -m pytest tests/test_manifest_consistency.py -v` — 9/9 pass
- [x] `python3 -m pytest tests/ -v` — 24/24 pass (9 manifest + 15 sync_flow)
- [x] Negative test for `test_pyproject_version_matches_plugin_json` — fires correctly with clear message
- [x] Negative test for `test_install_scripts_default_tag_matches_plugin_version` — fires correctly with clear message
- [x] No em dashes in user-visible additions (CHANGELOG, install.sh, install.ps1 comments)
- [x] No drive-by changes; diff is 5 files, 96 insertions, 3 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)