### PR TITLE
chore(deps): batch v1.9.9 dependency floor bumps (#76, #77, #78, #79, #80)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,19 +5,19 @@
 beautifulsoup4>=4.12.0,<5.0.0     # No known CVEs
 requests>=2.32.4,<3.0.0           # CVE-2024-47081, CVE-2024-35195 fixes
 lxml>=6.0.2,<7.0.0                # CVE-2025-24928 + additional libxml2 security patches
-playwright>=1.56.0,<2.0.0         # CVE-2025-59288 fix (macOS)
+playwright>=1.59.0,<2.0.0         # CVE-2025-59288 fix (macOS)
 Pillow>=12.1.0,<13.0.0            # CVE-2025-48379 fix
 urllib3>=2.6.3,<3.0.0             # CRITICAL: CVE-2026-21441 (CVSS 8.9), CVE-2025-66418
 validators>=0.22.0,<1.0.0         # No known CVEs
 
 # Report generation (for seo-google PDF/Excel reports)
 matplotlib>=3.8.0,<4.0.0              # No known CVEs
-weasyprint>=61.0,<70.0                # No known CVEs
-openpyxl>=3.1.0,<4.0.0                # No known CVEs (Excel export)
+weasyprint>=68.1,<70.0                # No known CVEs
+openpyxl>=3.1.5,<4.0.0                # No known CVEs (Excel export)
 
 # Google API dependencies (for seo-google skill)
-google-api-python-client>=2.100.0,<3.0.0   # No known CVEs
+google-api-python-client>=2.196.0,<3.0.0   # No known CVEs
 google-auth>=2.20.0,<3.0.0                  # No known CVEs
-google-auth-oauthlib>=1.0.0,<2.0.0          # No known CVEs
+google-auth-oauthlib>=1.4.0,<2.0.0          # No known CVEs
 google-auth-httplib2>=0.2.0,<1.0.0           # No known CVEs
 google-analytics-data>=0.18.0,<1.0.0         # No known CVEs


### PR DESCRIPTION
## Summary

Batches the 5 open Dependabot floor bumps into one PR for the v1.9.9 release train. Single CI run, single merge, and smoke-tested together as a combination.

| Package | Floor before | Floor after | Dependabot PR |
|---|---|---|---|
| `playwright` | 1.56.0 | 1.59.0 | #80 |
| `weasyprint` | 61.0 | 68.1 | #78 |
| `openpyxl` | 3.1.0 | 3.1.5 | #76 |
| `google-api-python-client` | 2.100.0 | 2.196.0 | #77 |
| `google-auth-oauthlib` | 1.0.0 | 1.4.0 | #79 |

All bumps stay inside the existing upper bounds. No CVE-driven escalations.

## Smoke tests (all passed locally)

Isolated venv at `/tmp/v199-deps`, fresh install of the bumped `requirements.txt`:

- **google-auth-oauthlib 1.4.0**: `from google_auth_oauthlib.flow import InstalledAppFlow` resolves
- **openpyxl 3.1.5**: Full API surface we use (Workbook, Font, PatternFill, Alignment, Border, Side, get_column_letter) works
- **google-api-python-client 2.196.0**: `build()` + `BatchHttpRequest` import; metadata version `2.196.0`
- **weasyprint 68.1**: Generates a valid PDF 1.7 doc from a tiny HTML input
- **playwright 1.59.0**: `playwright install chromium` + headless screenshot of example.com produces an 18.9 KB PNG

## Caveats

- **`google-auth-oauthlib` 1.4.0 drops Python 3.9 support**. This repo's `pyproject.toml` requires Python `>=3.10` already, so no impact for our support matrix. Will be called out in v1.9.9 CHANGELOG for any external consumers still on 3.9.

## After merge

I'll close Dependabot PRs #76-80 with reference comments pointing to this PR.

## Test plan

- [x] Local smoke tests for all 5 packages
- [x] `requirements.txt` parses (verified by pip install succeeding)
- [x] No changes outside `requirements.txt`
- [x] Existing `pyproject.toml` `python = ">=3.10"` matches all 5 bumps' min Python

🤖 Part of the v1.9.9 release train.