### PR TITLE
release(v1.9.9): final 1.x patch - atomic version bump + release rollup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-seo",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors) covering technical SEO, content quality (E-E-A-T), content briefs, schema markup, image optimization, sitemap architecture, AI search optimization (GEO), local SEO, maps intelligence, semantic topic clustering, search experience optimization (SXO), SEO drift monitoring, e-commerce SEO, international SEO with cultural profiles, FLOW framework integration, Google API integration, PDF reporting, and strategic planning across all industries.",
   "author": {
     "name": "AgriciDaniel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,39 +5,140 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.9] - 2026-05-11
+
+Final 1.x patch release. v2 is in design; this release leaves the v1.x
+branch in a clean, well-documented, dependency-current state.
+
+Independently verified across 5 rounds of GPT-5.5 xhigh code review via
+the Codex CLI before each PR push. Issue #92 + issue #41 closed.
+
+### Highlights
+- Five top-level versions, 24 in-tree skills, 3 extension SKILL.md files,
+  and both install scripts triangulate to `1.9.9` atomically. CI guard
+  extended from 9 to 13 assertions covering the orchestrator SKILL.md,
+  per-skill `metadata.version`, marketplace.json metadata.description + author
+  parity, and Sub-Skills/Subagents list consistency with disk.
+- Five Dependabot dependency floor bumps merged as one batched PR after
+  isolated-venv smoke-testing of the full API surface we actually use.
+- Image audit now correctly detects JS lazy-loaders (Perfmatters, EWWW,
+  generic) rather than reporting "not lazy-loaded" on heavily-optimized
+  WordPress sites.
 
 ### Fixed
-- **`install.sh` and `install.ps1` default tag pinned to `v1.9.0`**, four
-  releases stale (v1.9.5/.6/.7/.8 all missed the bump). Anyone running
-  `curl -fsSL .../install.sh | bash` got the April 14 release, missing the
-  FLOW framework integration, the security audit pass, the doc reconciliation,
-  and the manifest CI guard plus all v1.9.8 Phase B bug fixes (Windows hook,
-  OAuth refresh, missing imports, None guards). Bumped both to `v1.9.8`.
-  Plugin-install users (`/plugin install claude-seo@agricidaniel-seo`) were
-  unaffected because that path reads plugin.json directly.
-- **`pyproject.toml` version stuck at `1.9.6`** while plugin.json and
-  CITATION.cff shipped at 1.9.8. The v1.9.8 manifest CI guard's
-  `test_version_triangulation` only covered plugin.json ↔ CITATION.cff;
-  pyproject.toml was outside scope so the drift slipped through. Bumped to
-  1.9.8 and extended the CI guard to cover it.
+
+- **Orchestrator drift in `skills/seo/SKILL.md`** (issue #92): line 9
+  `metadata.version: "1.9.6"` was stale; descriptive headline at lines 19-21
+  still claimed "21 specialized sub-skills"; Sub-Skills numbered list at
+  176-199 included `seo-firecrawl` (which is an extension, not in `skills/`)
+  and was missing `seo-content-brief` (the PR #56 contribution). Subagents
+  bullet list had the same drift pattern (included `seo-firecrawl`, no agent
+  file on disk; missing `seo-flow`, file exists). Reconciled. Numbered list
+  now reaches 24 (the orchestrator itself is the 25th in `skills/` but does
+  not orchestrate itself), `seo-firecrawl` moved to a new "Optional
+  Extensions" subsection, Subagents list now matches `agents/seo-*.md` set
+  exactly.
+- **`marketplace.json` drift** (issue #92): `metadata.description` was
+  missing the "sub-agents" count claim that `plugins[0].description` carried;
+  plugin entry had no `author` object despite v1.9.8 release notes claiming
+  one was added in commit `8514999` (verification showed it was not). Both
+  fixed. v1.9.8 entry in this CHANGELOG corrected to reflect what actually
+  shipped.
+- **`AGENTS.md:109`** said "17 subagents"; disk has 18. Fixed.
+- **`install.sh` and `install.ps1` default tag pinned to `v1.9.0`** across 4
+  missed release bumps (v1.9.5/.6/.7/.8). Anyone running
+  `curl -fsSL .../install.sh | bash` got the April 14 release, missing FLOW
+  integration, the security audit pass, doc reconciliation, the manifest CI
+  guard plus v1.9.8 Phase B bug fixes (Windows hook, OAuth refresh, missing
+  imports, None guards). Bumped to `v1.9.9` atomically with this release.
+- **`pyproject.toml`** had drifted to `1.9.6` while plugin.json + CITATION
+  shipped at 1.9.8. Bumped to 1.9.9 with the release.
+- **23 in-tree skill `metadata.version` fields** were stuck at `1.9.6`; 3
+  extension SKILL.md files were at `1.9.0`/`1.7.2`. All bumped to `1.9.9`.
+  `seo-content-brief` deliberately stays at `1.0.0` (community contribution,
+  CI allowlist).
+- **Image audit (issue #41)**: `scripts/parse_html.py` now classifies each
+  image's lazy-loading mechanism in a `lazy_method` field with five values:
+  `native | perfmatters | ewww | js-generic | none`. Sites running Perfmatters,
+  EWWW Image Optimizer, lazysizes, vanilla-lazyload, or jQuery lazy-loaders
+  are no longer mis-reported as "not lazy-loaded". `skills/seo-page/SKILL.md`
+  and `skills/seo-images/SKILL.md` are updated to consume the new field.
 
 ### Added
-- **`tests/test_manifest_consistency.py`** gains two new assertions:
-  - `test_pyproject_version_matches_plugin_json`: pyproject.toml version
-    must equal plugin.json version on every release.
-  - `test_install_scripts_default_tag_matches_plugin_version`: install.sh
-    `REPO_TAG` and install.ps1 `$RepoTag` defaults must equal
-    `v{plugin.json version}` on every release.
-  - Both tests verified with negative-case smoke tests (revert the value,
-    confirm the assertion fires with a clear actionable error message).
-  - Total assertions in the manifest consistency suite: 7 → 9.
+
+- **CI guard extension (9 -> 13 assertions)** in
+  `tests/test_manifest_consistency.py`:
+  - `test_orchestrator_sub_skills_list_matches_disk`: Sub-Skills list must
+    equal `set(skills/*) - {seo}`; no duplicates. Regex scoped to the
+    `## Sub-Skills` section via a new `_extract_section()` helper.
+  - `test_orchestrator_subagents_list_matches_disk`: Subagents bullet list
+    must equal `set(agents/seo-*.md)`; no duplicates. Bullet-anchored regex.
+  - `test_skill_metadata_versions_match_plugin_json`: every
+    `skills/*/SKILL.md` and `extensions/*/skills/*/SKILL.md` `metadata.version`
+    must equal `plugin.json` version, with `COMMUNITY_OVERRIDES` allowlist
+    `{"seo-content-brief": "1.0.0"}`. Scoped to YAML frontmatter only via
+    a new `_extract_frontmatter()` helper, so a fenced code example showing
+    `version: "..."` cannot satisfy the check.
+  - `test_marketplace_metadata_and_author_parity`: marketplace.json
+    `metadata.description` includes both counts and they match plugin.json;
+    plugin entry `author` parities plugin.json author for `name`, `email`,
+    AND `url`.
+- **`tests/test_lazy_detection.py`** (new): 11 unit tests covering all
+  `_detect_lazy_method()` branches plus an integration check on `parse_html()`.
+- **CI workflow** (`.github/workflows/ci.yml`): test job now installs
+  `beautifulsoup4` alongside `pytest`, required by the new lazy-detection
+  test that exercises real BeautifulSoup parsing.
 
 ### Changed
-- Inline comments in `install.sh:13` and `install.ps1:90` now state that the
-  default tag MUST be bumped on every release and reference the CI guard that
-  enforces it. This makes the release-checklist requirement obvious to anyone
-  reading the file.
+
+- **5 Python dependency floor bumps** (batched as a single PR after isolated-
+  venv smoke testing — see [PR #94]):
+
+  | Package | Floor before | Floor after | Source PR |
+  |---|---|---|---|
+  | `playwright` | 1.56.0 | 1.59.0 | #80 |
+  | `weasyprint` | 61.0 | 68.1 | #78 |
+  | `openpyxl` | 3.1.0 | 3.1.5 | #76 |
+  | `google-api-python-client` | 2.100.0 | 2.196.0 | #77 |
+  | `google-auth-oauthlib` | 1.0.0 | 1.4.0 | #79 |
+
+  All five upper bounds preserved. No CVE-driven escalations.
+
+  **Caveat**: `google-auth-oauthlib` 1.4.0 drops Python 3.9 support. This
+  repo's `pyproject.toml` requires Python `>=3.10` already, so no impact for
+  the declared support matrix. External consumers still on 3.9 should pin
+  `google-auth-oauthlib<1.4.0` themselves.
+
+### Deferred to v2
+
+The following items are out of scope for v1.9.9 to keep this a clean patch
+release. v2 will be a separate design conversation:
+
+- **#11** SPA / CSR audit support (7-phase implementation; PR #90 Limitations
+  section remains the patch-appropriate response)
+- **#51** Subagent research persistence (changes documented output contract
+  across 15 agent files; v2 will define a persistence convention shared by
+  `seo-audit`, `seo-drift`, `seo-cluster`)
+- **#61** `google_report.py --type full` audit-schema handling (no regression
+  baseline fixture corpus exists; v2 will ship one with the bug fix)
+- **#89** uv adoption (issue itself labels v2.x candidate; preserves
+  `requirements.txt` format as migration headroom)
+- **#53** seo-notebooklm skill (depends on unofficial wrapper, 536 lines of
+  unreviewed credential code; v2 will define an "experimental skills" tier)
+- **PR #46** path resolution + macOS SSL: `pip-system-certs` is a new
+  dependency that violates v1.9.9's no-new-deps non-goal. v2 will land the
+  full macOS support story.
+
+### Compatibility / migration
+
+- No breaking changes. Patch release per SemVer.
+- The orchestrator's Sub-Skills numbered list was renumbered (insertion of
+  `seo-content-brief`, removal of `seo-firecrawl`). Any downstream consumer
+  that referenced sub-skills by **index** rather than **name** would break;
+  grep found no such consumer in this repo, but third-party docs that
+  hard-coded "skill 21 is seo-firecrawl" would need updating.
+- `/seo audit` still does NOT persist subagent research/findings between
+  runs (this is the intentional v1.x contract; v2 will revisit per #51).
 
 ## [1.9.8] - 2026-05-09
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
 repository-code: 'https://github.com/AgriciDaniel/claude-seo'
 url: 'https://github.com/AgriciDaniel/claude-seo'
 license: MIT
-version: 1.9.8
+version: 1.9.9
 date-released: '2026-05-09'
 keywords:
   - seo

--- a/extensions/banana/skills/seo-image-gen/SKILL.md
+++ b/extensions/banana/skills/seo-image-gen/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Requires nanobanana MCP server"
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
+++ b/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 compatibility: "Requires DataForSEO MCP server"
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/extensions/firecrawl/skills/seo-firecrawl/SKILL.md
+++ b/extensions/firecrawl/skills/seo-firecrawl/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: "Requires Firecrawl MCP server"
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -89,7 +89,7 @@ $RepoUrl = "https://github.com/AgriciDaniel/claude-seo"
 # This default MUST be bumped on every release. CI guard
 # (tests/test_manifest_consistency.py) enforces this matches plugin.json.
 # Override: $env:CLAUDE_SEO_TAG = 'main'; .\install.ps1
-$RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v1.9.8' }
+$RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v1.9.9' }
 
 # Create directories
 New-Item -ItemType Directory -Force -Path $SkillDir | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ main() {
     # This default MUST be bumped on every release. CI guard
     # (tests/test_manifest_consistency.py) enforces this matches plugin.json.
     # Override: CLAUDE_SEO_TAG=main bash install.sh
-    REPO_TAG="${CLAUDE_SEO_TAG:-v1.9.8}"
+    REPO_TAG="${CLAUDE_SEO_TAG:-v1.9.9}"
 
     echo "════════════════════════════════════════"
     echo "║   Claude SEO - Installer             ║"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-seo"
-version = "1.9.8"
+version = "1.9.9"
 description = "Comprehensive SEO analysis skill for Claude Code"
 requires-python = ">=3.10"
 license = "MIT"

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Free: Common Crawl + verify always available. Optional: Moz API, Bing Webmaster (free signup). Premium: DataForSEO extension."
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-cluster/SKILL.md
+++ b/skills/seo-cluster/SKILL.md
@@ -14,7 +14,7 @@ license: MIT
 metadata:
   author: AgriciDaniel
   original_author: "Lutfiya Miller (Pro Hub Challenge Winner)"
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-competitor-pages/SKILL.md
+++ b/skills/seo-competitor-pages/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[url or generate] [competitor]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-content/SKILL.md
+++ b/skills/seo-content/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-dataforseo/SKILL.md
+++ b/skills/seo-dataforseo/SKILL.md
@@ -15,7 +15,7 @@ license: MIT
 compatibility: "Requires DataForSEO MCP server"
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-drift/SKILL.md
+++ b/skills/seo-drift/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 metadata:
   author: AgriciDaniel
   original_author: "Dan Colta (Pro Hub Challenge)"
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-ecommerce/SKILL.md
+++ b/skills/seo-ecommerce/SKILL.md
@@ -14,7 +14,7 @@ compatibility: "Enhanced with DataForSEO Merchant API (optional)"
 metadata:
   author: AgriciDaniel
   original_author: "Matej Marjanovic (Pro Hub Challenge)"
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-flow/SKILL.md
+++ b/skills/seo-flow/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[stage] [url|topic]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-geo/SKILL.md
+++ b/skills/seo-geo/SKILL.md
@@ -13,7 +13,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-google/SKILL.md
+++ b/skills/seo-google/SKILL.md
@@ -14,7 +14,7 @@ argument-hint: "[command] [url|property]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-hreflang/SKILL.md
+++ b/skills/seo-hreflang/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-image-gen/SKILL.md
+++ b/skills/seo-image-gen/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Requires nanobanana MCP server"
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-images/SKILL.md
+++ b/skills/seo-images/SKILL.md
@@ -12,7 +12,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-local/SKILL.md
+++ b/skills/seo-local/SKILL.md
@@ -15,7 +15,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-maps/SKILL.md
+++ b/skills/seo-maps/SKILL.md
@@ -16,7 +16,7 @@ license: MIT
 compatibility: "DataForSEO MCP for Tier 1+, Google Maps API for Tier 2"
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-page/SKILL.md
+++ b/skills/seo-page/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-plan/SKILL.md
+++ b/skills/seo-plan/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[business-type]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-programmatic/SKILL.md
+++ b/skills/seo-programmatic/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[url or plan]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-schema/SKILL.md
+++ b/skills/seo-schema/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-sitemap/SKILL.md
+++ b/skills/seo-sitemap/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[url or generate]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-sxo/SKILL.md
+++ b/skills/seo-sxo/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 metadata:
   author: AgriciDaniel
   original_author: "Florian Schmitz (Pro Hub Challenge)"
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[command] [url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "1.9.8"
+  version: "1.9.9"
   category: seo
 ---
 


### PR DESCRIPTION
## Summary

The release commit for v1.9.9. Atomic bump of all version-bearing artifacts from 1.9.8 to 1.9.9, plus the CHANGELOG `[1.9.9]` section rolling up the full v1.9.9 train (#93, #94, #95).

## Atomic version bumps (33 files, +160/-59)

All version-bearing artifacts move from 1.9.8 to 1.9.9 in one commit, because the existing CI guards (PR #91 + PR #93) triangulate them. Splitting would fail CI mid-merge.

- `.claude-plugin/plugin.json`
- `CITATION.cff`
- `pyproject.toml`
- `install.sh` `REPO_TAG` default -> `v1.9.9`
- `install.ps1` `$RepoTag` default -> `v1.9.9`
- `skills/seo/SKILL.md` `metadata.version` -> `1.9.9`
- 23 other in-tree `skills/*/SKILL.md` -> `1.9.9` (`seo-content-brief` stays at `1.0.0` per community allowlist)
- 3 `extensions/*/skills/*/SKILL.md` -> `1.9.9`

## What v1.9.9 contains (rolled up from CHANGELOG)

| PR | What | Closes |
|---|---|---|
| #93 | Orchestrator + marketplace + AGENTS.md drift cleanup + 4 new CI assertions (9 -> 13) | #92 |
| #94 | 5 Dependabot deps floor bumps batched (playwright, weasyprint, openpyxl, google-api-python-client, google-auth-oauthlib) | #76, #77, #78, #79, #80 |
| #95 | Perfmatters/EWWW/generic JS lazy-loader detection + 11 unit tests + consumer wiring | #41 |
| This PR | Atomic version bumps + CHANGELOG [1.9.9] | — |

## Tag-before-merge sequence (non-negotiable per Codex review)

After CI green on this PR, BEFORE merging:

```bash
git fetch origin
git tag v1.9.9 origin/release/v1.9.9
git push origin v1.9.9
git ls-remote --tags origin v1.9.9   # must resolve
```

This ensures `git clone --branch v1.9.9` works from `install.sh` for anyone running `curl | bash` during the merge window. Without this, the `v1.9.9` tag wouldn't exist until after PR merge, creating a brief outage for new manual installs.

Then merge with `--merge` (NOT `--squash`) so the tagged SHA lives on main's linear history.

## Test plan

- [x] `python3 -m pytest tests/` 39 passed locally (13 manifest + 15 sync_flow + 11 lazy detection)
- [x] Versions verified atomic via `grep` across all 5 top-level + 24 in-tree + 3 extensions
- [x] `seo-content-brief` correctly stays at `1.0.0` (community allowlist)
- [x] CHANGELOG [1.9.9] entry covers everything

## Independent review

5 rounds of Codex GPT-5.5 xhigh review across this v1.9.9 train (kernel discipline, safety/regression, plan v2, plan v3 go/no-go, PR #93 diff). Each round's findings folded back into the plan and the code before this commit.

🤖 Final 1.x patch. v2 is a separate design conversation.