### PR TITLE
docs(contributing): document GitHub Codespaces / Dev Containers as Option B

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,30 @@ Use [GitHub Discussions](https://github.com/AgriciDaniel/claude-seo/discussions)
 
 ### Development Setup
 
+#### Option A: Local install
+
 ```bash
 git clone https://github.com/YOUR_USERNAME/claude-seo.git
 cd claude-seo
 bash install.sh
 ```
+
+#### Option B: GitHub Codespaces / VS Code Dev Containers
+
+A `.devcontainer/devcontainer.json` is included so you can develop without any
+local setup. Two paths:
+
+- **GitHub Codespaces**: click **Code -> Codespaces -> Create codespace on
+  main** on the repo's GitHub page. You get a fully provisioned Python 3.12
+  environment with `requirements.txt` installed and Playwright + Chromium
+  ready, in about 60 seconds.
+- **VS Code Remote Containers**: with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+  installed, clone the repo locally then run **Dev Containers: Reopen in
+  Container** from the command palette.
+
+Both paths use the same image (`mcr.microsoft.com/devcontainers/python:3.12`)
+and post-create command (`pip install -r requirements.txt && playwright
+install chromium`). No additional setup needed for either.
 
 ### Guidelines
 


### PR DESCRIPTION
## Summary

Post-v1.9.9 cleanup. Two small fixes, one in this PR, one already applied via GitHub API.

### In this PR (1 file, +19 / -0)

`CONTRIBUTING.md` Development Setup section now splits into:
- **Option A: Local install** (unchanged, what was already there)
- **Option B: GitHub Codespaces / VS Code Dev Containers** (new)

The repo has shipped `.devcontainer/devcontainer.json` since v1.4.0-era but no doc referenced it. Contributors who would have wanted a one-click Codespaces dev environment had no signal it existed. This makes the existing config earn its keep.

### Already applied (via `gh api -X PATCH`)

GitHub repo **About** description was stale: "19 sub-skills, 12 subagents, 3 extensions". That's 8 versions out of date. Corrected to "25 sub-skills + 18 sub-agents" matching current v1.9.9 reality. Verified live on the repo page.

### Why both at once

User flagged both in a single screenshot review of the post-v1.9.9 repo state. Minimum diff, single PR, single CI run. Topics + homepage already correct, no other About fields needed editing.

### Test plan

- [x] `python3 -m pytest tests/` 39 passed (docs-only change, no functional impact)
- [x] No em dashes added in user-visible material
- [x] GitHub About description verified post-API-call: `gh api repos/AgriciDaniel/claude-seo --jq '.description'` returns the new text

🤖 Post-release cleanup. Repo is otherwise at v1.9.9 baseline.