### PR TITLE
fix(hooks): activate JSON-LD validator (python3 + canonical args + block)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python \"${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\" \"$FILE_PATH\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\" \"$FILE_PATH\"",
+            "exitCodes": { "2": "block" }
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,13 +1,18 @@
 {
+  "description": "JSON-LD schema validation after file edits",
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\" \"$FILE_PATH\"",
-            "exitCodes": { "2": "block" }
+            "command": "python3",
+            "args": [
+              "${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py",
+              "${tool_input.file_path}"
+            ],
+            "timeout": 30
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,8 +7,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
+            "command": "sh",
             "args": [
+              "-c",
+              "PY=\"${CLAUDE_SEO_PYTHON:-}\"; if [ -z \"$PY\" ]; then if command -v python3 >/dev/null 2>&1; then PY=python3; else PY=python; fi; fi; exec \"$PY\" \"$1\" \"$2\"",
+              "_",
               "${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py",
               "${tool_input.file_path}"
             ],

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -2,19 +2,25 @@
 """Post-edit schema validation hook for Claude Code.
 
 Validates JSON-LD schema after file edits. Returns exit code 2 to block
-if critical validation errors found.
+if critical validation errors found (exit 2 is blocking by default for
+PostToolUse — no `exitCodes` mapping is required).
 
-Hook configuration in ~/.claude/settings.json:
+Canonical plugin hook configuration (hooks/hooks.json):
 {
+  "description": "JSON-LD schema validation after file edits",
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ~/.claude/skills/seo/hooks/validate-schema.py \"$FILE_PATH\"",
-            "exitCodes": { "2": "block" }
+            "command": "python3",
+            "args": [
+              "${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py",
+              "${tool_input.file_path}"
+            ],
+            "timeout": 30
           }
         ]
       }
@@ -22,8 +28,9 @@ Hook configuration in ~/.claude/settings.json:
   }
 }
 
-Note: matcher filters by tool name only (Edit, Write). The script itself
-checks if the file contains schema markup before validating.
+Note: matcher filters by tool name (Edit, Write). The script itself checks
+if the file contains schema markup before validating, and exits 0 silently
+for any file that does not.
 """
 
 import json

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -15,8 +15,11 @@ Canonical plugin hook configuration (hooks/hooks.json):
         "hooks": [
           {
             "type": "command",
-            "command": "python3",
+            "command": "sh",
             "args": [
+              "-c",
+              "PY=\"${CLAUDE_SEO_PYTHON:-}\"; if [ -z \"$PY\" ]; then if command -v python3 >/dev/null 2>&1; then PY=python3; else PY=python; fi; fi; exec \"$PY\" \"$1\" \"$2\"",
+              "_",
               "${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py",
               "${tool_input.file_path}"
             ],
@@ -27,6 +30,17 @@ Canonical plugin hook configuration (hooks/hooks.json):
     ]
   }
 }
+
+The `sh -c` launcher resolves the Python interpreter at runtime to stay
+portable across platforms:
+
+- Honors `$CLAUDE_SEO_PYTHON` first, so pyenv/conda users (and Windows users
+  who hit the Microsoft Store `python3` stub) can pin a working interpreter
+  without patching the plugin.
+- Otherwise prefers `python3` (correct on macOS/Linux, where bare `python`
+  is often absent on Ubuntu 24.04+, recent Debian, Fedora).
+- Falls back to `python` (correct on stock Windows, where `python3` is
+  frequently the no-op Microsoft Store launcher).
 
 Note: matcher filters by tool name (Edit, Write). The script itself checks
 if the file contains schema markup before validating, and exits 0 silently


### PR DESCRIPTION
The `PostToolUse` JSON-LD schema validation hook produces zero coverage on stock installs: the validator never actually examines any file content. This PR fixes the underlying chain of three defects in `hooks/hooks.json` and updates the script's docstring to document the canonical hook shape.

## What changed

Two commits, layered by severity:

1. **`fix(hooks): use python3 and declare exitCodes mapping for blocking`** — preliminary fix targeting the symptoms first noticed. Replaces `python` with `python3` so the validator runs at all on distros without an unversioned `python` binary, and adds an `exitCodes` mapping to mirror what the script's docstring documented at the time.

2. **`fix(hooks): use canonical args substitution and remove dead env var`** — root-cause fix. Moves the hook to the canonical plugin format from the Claude Code hooks reference (`code.claude.com/docs/en/hooks`):

   - Replace the custom `$FILE_PATH` interpolation with the documented `${tool_input.file_path}` substitution inside an `args` array. `FILE_PATH` is not part of the hook environment, so the previous form silently expanded to the empty string.
   - Drop the `exitCodes` mapping introduced in the first commit. Exit 2 is blocking by default for `PostToolUse`, so the mapping is redundant.
   - Add a top-level `description` and a 30-second `timeout` as defensive defaults.
   - Update the docstring of `validate-schema.py` so future readers see the supported configuration.

## Why it matters

Three defects compounded into total silent failure:

1. **`python` does not exist on Ubuntu 24.04+, recent Debian, and recent Fedora.** The hook exited with code 127 ("command not found"), surfaced as a non-blocking warning.

2. **`exitCodes` was missing.** Even if the script had run, exit 2 would have come through as a warning rather than blocking the write.

3. **`$FILE_PATH` was never an environment variable.** With bug #1 fixed in isolation, the validator would have been invoked with the empty string as `argv[1]`, hit the `not os.path.isfile(filepath): sys.exit(0)` guard at `validate-schema.py:124`, and exited 0 silently — the validation pass would have remained invisible.

Each bug masks the next. Bug #1 prevented execution, hiding bug #2; bug #2's `exitCodes` workaround was itself moot, because bug #3 ensured the script always took the silent-no-op branch. The validator has had effectively zero coverage on stock installs.

## How to verify

On a stock install (Ubuntu 24.04 used for verification, Claude Code 2.1.x):

```bash
# Reproduce the silent-no-op behavior of the previous config:
FILE_PATH= python3 hooks/validate-schema.py "$FILE_PATH"; echo "exit=$?"
# exit=0  (no validation, no output)

# Confirm the script works correctly when given a real path:
cat > /tmp/bad.html <<'EOF'
<!DOCTYPE html><html><head><script type="application/ld+json">
{"@context":"https://schema.org","@type":"LocalBusiness","name":"[Business Name]"}
</script></head><body></body></html>
EOF
python3 hooks/validate-schema.py /tmp/bad.html; echo "exit=$?"
# 🛑 Schema validation ERRORS (blocking):
#   - Block 1: Contains placeholder text: [Business Name]
# exit=2
```

End-to-end behavior in a project that links the plugin: editing a file containing a placeholder JSON-LD block now blocks the write with the validator's error message, instead of letting the placeholder ship.
