### PR TITLE
fix(security): move API key from URL query string to X-Goog-Api-Key header

### DIFF
--- a/scripts/crux_history.py
+++ b/scripts/crux_history.py
@@ -84,7 +84,8 @@ def query_history(
 
     try:
         resp = requests.post(
-            f"{CRUX_HISTORY_ENDPOINT}?key={api_key}",
+            CRUX_HISTORY_ENDPOINT,
+            headers={"X-Goog-Api-Key": api_key},
             json=body,
             timeout=30,
         )

--- a/scripts/nlp_analyze.py
+++ b/scripts/nlp_analyze.py
@@ -97,7 +97,8 @@ def analyze_text(
 
     try:
         resp = requests.post(
-            f"{NLP_ENDPOINT}?key={key}",
+            NLP_ENDPOINT,
+            headers={"X-Goog-Api-Key": key},
             json=body,
             timeout=30,
         )

--- a/scripts/pagespeed_check.py
+++ b/scripts/pagespeed_check.py
@@ -341,7 +341,8 @@ def query_crux(
 
     try:
         resp = requests.post(
-            f"{CRUX_ENDPOINT}?key={api_key}",
+            CRUX_ENDPOINT,
+            headers={"X-Goog-Api-Key": api_key},
             json=body,
             timeout=30,
         )


### PR DESCRIPTION
## Note on disclosure path

`SECURITY.md` directs security findings to a GitHub Security Advisory or direct maintainer contact. I tried both routes first — Private Vulnerability Reporting is not enabled on this repo (so the Advisory UI doesn't accept external reports), and your GitHub profile email is private (no published contact). Given the bug's actual severity (key only ever appears in the user's own stdout — see "Severity" below), public disclosure via this PR seemed the pragmatic path. Happy to take this PR down and re-disclose privately if you prefer to enable PVR first, or share a private channel.

## Summary

Three scripts construct API request URLs as `f"{ENDPOINT}?key={api_key}"`. On request failure, `requests.exceptions.HTTPError`'s `str(e)` includes the full URL — which means **the API key ends up embedded in the error message string** that the scripts print to stdout/stderr and store in `result["error"]`.

Reproduced in real use: when running `crux_history.py` against a site lacking CrUX data and the CrUX History API is not yet enabled, the script returns:

```json
{
  "error": "CrUX History API request failed: 403 Client Error: Forbidden for url: https://chromeuxreport.googleapis.com/v1/records:queryHistoryRecord?key=AIzaSyXXXXXX..."
}
```

The same pattern is present in `nlp_analyze.py` and the CrUX call inside `pagespeed_check.py`.

## Fix

Moves the API key from the URL query string to the `X-Goog-Api-Key` request header. This header is supported by all three Google APIs in use here (per [Google's API key documentation](https://cloud.google.com/docs/authentication/api-keys#using-with-rest-api)). The URL is now constant; the key never enters `Response.url` and therefore never appears in error message strings.

Three files affected:

| File | Line | Before | After |
|---|---|---|---|
| `scripts/crux_history.py` | 86-90 | `f"{ENDPOINT}?key={key}"` | header `X-Goog-Api-Key` |
| `scripts/nlp_analyze.py` | 99-103 | same | same |
| `scripts/pagespeed_check.py` | 343-347 | same (CrUX call) | same |

The PSI call in `pagespeed_check.py` at line 126 already uses `requests.get(..., params={...})` and was not affected by this issue.

## Severity assessment

**Low–medium.** The key is exposed only to:
- The user running the script locally (they already own the key)
- Anywhere the user's stdout/stderr is captured: CI/CD logs, screen-shared sessions, terminal recordings, pasted into AI chats for debugging, etc.

There is no third-party server that receives the key as a side effect. The blast radius is "user inadvertently shares their own output."

Mitigated in practice by API key restrictions (recommended in your README), but a defense-in-depth fix at the script level is appropriate.

## Verification

Tested all three scripts against known-good URLs after the change:

- `nlp_analyze.py --text "Kenya is a country in East Africa." --features entities --json`
  → 3 entities returned, no error
- `pagespeed_check.py https://web.dev --crux-only --json`
  → metrics + collection_period returned, no error
- `crux_history.py https://web.dev --json`
  → 25 collection_periods returned, no error

Also confirmed no `?key=` patterns remain anywhere in `scripts/*.py` (grep -n returned no matches).

## Optional follow-ups (not done in this PR)

- The same pattern could apply to any future scripts hitting an API key auth endpoint. Worth considering a small helper in `google_auth.py` (e.g. `def api_key_headers(key): return {"X-Goog-Api-Key": key}`) so future contributors don't reintroduce the leak.
- Existing error messages in the affected scripts are now clean, but if you'd like belt-and-suspenders, a sanitizer in `_handle_request_error` that strips any remaining `AIzaSy*` substrings would catch any regressions.

Happy to do either as a separate PR if of interest.