### PR TITLE
fix: handle Windows Store Python alias in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -10,14 +10,20 @@ Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
 function Resolve-Python {
-    $pythonCmd = Get-Command -Name python -ErrorAction SilentlyContinue
-    if ($null -ne $pythonCmd) {
-        return @{ Exe = 'python'; Args = @() }
-    }
-
     $pyCmd = Get-Command -Name py -ErrorAction SilentlyContinue
     if ($null -ne $pyCmd) {
-        return @{ Exe = 'py'; Args = @('-3') }
+        try {
+            $ver = & py -3 --version 2>&1
+            if ($LASTEXITCODE -eq 0) { return @{ Exe = 'py'; Args = @('-3') } }
+        } catch {}
+    }
+
+    $pythonCmd = Get-Command -Name python -ErrorAction SilentlyContinue
+    if ($null -ne $pythonCmd) {
+        try {
+            $ver = & python --version 2>&1
+            if ($LASTEXITCODE -eq 0) { return @{ Exe = 'python'; Args = @() } }
+        } catch {}
     }
 
     return $null


### PR DESCRIPTION
## Problem

On Windows, `python.exe` in `WindowsApps` is a Microsoft Store redirect stub. `Get-Command -Name python` finds it and `Resolve-Python` returns it immediately without testing whether execution actually works — which then fails with:

`[x] Python is installed but could not be executed.`

This affects any Windows user who has Python installed via the Microsoft Store (a common default).

## Fix

- Check `py -3` first (Python Launcher — always reliable on Windows)
- Verify execution actually succeeds before returning the command
- Fall back to `python` only if `py` is unavailable and `python` executes successfully

## Tested

Windows 11 with Python 3.14.4 (Microsoft Store install) — installer now completes successfully.