### PR TITLE
fix(gsc): stop surfacing the deprecated Sitemaps API `indexed` field (always 0)

### DIFF
--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -25,6 +25,7 @@ You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 - GSC top queries/pages (28 days): `python scripts/gsc_query.py --property <prop> --json`
 - URL Inspection on homepage + key pages: `python scripts/gsc_inspect.py <url> --json`
 - GSC sitemap status: `python scripts/gsc_query.py sitemaps --property <prop> --json`
+  - **Indexation count comes ONLY from URL Inspection** (`gsc_inspect.py` `verdict`/`coverage_state`: PASS = "Submitted and indexed", NEUTRAL = "Discovered/Crawled – currently not indexed"). The Sitemaps API exposes only a `submitted` count; its old `indexed` field is deprecated and always 0. Never report "X of Y indexed" from the sitemap. Sanity-check: a "0 indexed" headline alongside any URL you found indexed is a contradiction; trust the per-URL data.
 
 ### Tier 2 (Full)
 - All Tier 1 checks

--- a/scripts/gsc_query.py
+++ b/scripts/gsc_query.py
@@ -237,7 +237,15 @@ def list_sitemaps(site_url: str) -> dict:
                 "type": sm.get("type"),
                 "warnings": sm.get("warnings", 0),
                 "errors": sm.get("errors", 0),
-                "contents": sm.get("contents", []),
+                # The Sitemaps API "indexed" field inside contents[] is
+                # deprecated and always returns "0" for every property. Strip
+                # it so downstream consumers cannot misread it as a real
+                # indexation count. For actual indexation status use the URL
+                # Inspection API (gsc_inspect.py): coverage_state / verdict.
+                "contents": [
+                    {"type": c.get("type"), "submitted": c.get("submitted")}
+                    for c in sm.get("contents", [])
+                ],
             })
     except Exception as e:
         result["error"] = f"Error listing sitemaps: {e}"

--- a/skills/seo-google/references/search-console-api.md
+++ b/skills/seo-google/references/search-console-api.md
@@ -135,6 +135,8 @@
 | `errors` | Error count |
 | `contents[]` | Array with `type` (web, image, video, news) and `submitted` count |
 
+> **Note:** `contents[].indexed` is deprecated and always returns `0` for every property — it is intentionally not listed above. Do not use it as an indexation count. Get real indexation status from the URL Inspection API (`indexStatusResult.verdict` / `coverageState`).
+
 ---
 
 ## Sites API


### PR DESCRIPTION
## Problem
`gsc_query.py sitemaps --json` passes the Search Console Sitemaps API `contents[]` array through verbatim. That array still carries the legacy `indexed` field, which Google **deprecated years ago and now returns `"0"` for every property**. A consumer reading the JSON sees `"indexed": "0"` and reasonably (but wrongly) reports "0 pages indexed" — even when the site has many indexed pages.

This bit a real audit: the `seo-google` agent reported "0 of 57 indexed" from this field while its own `gsc_inspect.py` URL-Inspection results (correctly) showed the homepage and many pages as **Submitted and indexed**. The GSC Coverage dashboard confirmed ~22 indexed. The contradiction came entirely from the deprecated field.

Notably the skill already knew better elsewhere: `references/search-console-api.md` documents `contents[]` as only `type` + `submitted` (it omits `indexed`), and `assets/templates/indexation-status-report.md` derives counts from URL Inspection verdicts. This PR makes the script and agent guidance consistent with that correct design.

## Fix
- **`scripts/gsc_query.py`** — in `list_sitemaps()`, project `contents[]` down to `{type, submitted}` and drop the deprecated `indexed` field, with a comment pointing to the URL Inspection API for real indexation status. `submitted` (a real value) is preserved.
- **`agents/seo-google.md`** — add a one-line rule: indexation count comes only from URL Inspection (`verdict`/`coverage_state`), never from the sitemap; plus a sanity-check note.
- **`references/search-console-api.md`** — add an explicit note that `contents[].indexed` is deprecated/always-0 and must not be used.

No behavior change for any field other than removing a value that is always `0`.

## Verification
```
# before: contents -> [{"type":"web","submitted":"57","indexed":"0"}]
# after:  contents -> [{"type":"web","submitted":"57"}]
python scripts/gsc_query.py sitemaps --property sc-domain:example.com --json
```
`python -c "import ast; ast.parse(open('scripts/gsc_query.py').read())"` passes.

## Refs
- Google Search Console Sitemaps API — `contents` documents `submitted` only; `indexed` is a legacy field that returns 0.
