### PR TITLE
fix(drift): Windows + non-Latin-1 baseline portability (closes #114)

### DIFF
--- a/scripts/drift_baseline.py
+++ b/scripts/drift_baseline.py
@@ -20,6 +20,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse, urlunparse, urlencode
 
@@ -149,39 +150,62 @@ def fetch_page_data(url: str) -> dict:
     """
     result = {"status_code": None, "html": None, "parsed": None, "error": None}
 
-    # Step 1: Fetch the page via fetch_page.py
+    # Step 1: Fetch the page via fetch_page.py.
+    # Use a NamedTemporaryFile for the HTML payload instead of /dev/stdout,
+    # which is a POSIX-only file abstraction. On Windows Python, opening
+    # "/dev/stdout" raises FileNotFoundError inside fetch_page.py and the
+    # whole baseline fails before any HTML is captured.
     fetch_script = os.path.join(SCRIPTS_DIR, "fetch_page.py")
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".html")
+    os.close(tmp_fd)
     try:
-        proc = subprocess.run(
-            [sys.executable, fetch_script, url, "--output", "/dev/stdout"],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-    except subprocess.TimeoutExpired:
-        result["error"] = "Page fetch timed out after 60 seconds"
-        return result
+        try:
+            proc = subprocess.run(
+                [sys.executable, fetch_script, url, "--output", tmp_path],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            result["error"] = "Page fetch timed out after 60 seconds"
+            return result
 
-    if proc.returncode != 0:
-        error_msg = proc.stderr.strip() if proc.stderr else "Unknown fetch error"
-        result["error"] = f"Fetch failed: {error_msg}"
-        return result
+        if proc.returncode != 0:
+            error_msg = proc.stderr.strip() if proc.stderr else "Unknown fetch error"
+            result["error"] = f"Fetch failed: {error_msg}"
+            return result
 
-    html_content = proc.stdout
+        with open(tmp_path, "r", encoding="utf-8") as f:
+            html_content = f.read()
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
     # Extract status code from stderr output (fetch_page.py prints "Status: NNN")
     status_match = re.search(r"Status:\s*(\d+)", proc.stderr or "")
     result["status_code"] = int(status_match.group(1)) if status_match else 200
     result["html"] = html_content
 
-    # Step 2: Parse the HTML via parse_html.py
+    # Step 2: Parse the HTML via parse_html.py.
+    # Force utf-8 on the subprocess pipes so that html_content containing
+    # non-Latin-1 characters (Czech, German, Polish, etc. diacritics) does
+    # not raise UnicodeEncodeError when subprocess writes input= using
+    # Windows' default cp1252 codec. PYTHONIOENCODING is propagated to the
+    # child so its sys.stdin.read() decodes the bytes as utf-8 as well;
+    # without that the child silently mojibakes utf-8 as cp1252 (the title
+    # separator · becomes Â· in captured baselines).
     parse_script = os.path.join(SCRIPTS_DIR, "parse_html.py")
+    parse_env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
     try:
         proc = subprocess.run(
             [sys.executable, parse_script, "--url", url, "--json"],
             input=html_content,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            env=parse_env,
             timeout=30,
         )
     except subprocess.TimeoutExpired:

--- a/scripts/parse_html.py
+++ b/scripts/parse_html.py
@@ -225,6 +225,17 @@ def parse_html(html: str, base_url: Optional[str] = None) -> dict:
 
 
 def main():
+    # Force utf-8 on stdin/stdout. On Windows these default to cp1252 and
+    # any HTML piped in containing non-Latin-1 characters (Czech, German,
+    # Polish, etc. diacritics) is silently mis-decoded, corrupting parsed
+    # titles, headings, and word counts. Belt-and-braces with the
+    # PYTHONIOENCODING env var that drift_baseline.py sets on the
+    # subprocess, so this script is safe when invoked directly too.
+    if hasattr(sys.stdin, "reconfigure"):
+        sys.stdin.reconfigure(encoding="utf-8")
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     parser = argparse.ArgumentParser(description="Parse HTML for SEO analysis")
     parser.add_argument("file", nargs="?", help="HTML file to parse")
     parser.add_argument("--url", "-u", help="Base URL for resolving links")


### PR DESCRIPTION
## Summary

Fixes the three Windows-portability bugs documented in #114. Together they make drift baselines unusable on Windows for any site with non-Latin-1 content (Czech, German, Polish, Hungarian, etc. - any locale that lives outside the cp1252 range).

Filed as a single PR because they're in the same call chain (`drift_baseline.py` -> `parse_html.py`) and need to be fixed together; partial fixes either continue to fail or silently corrupt baselines.

## Bugs fixed

**1. `drift_baseline.py`: `/dev/stdout` not portable to Windows**
Replaced with `tempfile.NamedTemporaryFile`. The original code passed `/dev/stdout` as `--output` to `fetch_page.py`, which opens it via `open()` - works on POSIX, raises `FileNotFoundError` on Windows Python. Baselines aborted before any HTML was captured.

**2. `drift_baseline.py`: subprocess pipe defaulting to cp1252 on Windows**
Added `encoding="utf-8"` to the `parse_html.py` `subprocess.run()` call. Without it, writing `html_content` containing any non-Latin-1 character to the child's stdin raises `UnicodeEncodeError` (Czech `Č` triggered HTML parsing timeout after 30 seconds in our test).

**3. `parse_html.py`: child's `sys.stdin.read()` decoding utf-8 as cp1252**
Added `PYTHONIOENCODING=utf-8` on the subprocess from the parent side, plus `sys.stdin/stdout.reconfigure(encoding="utf-8")` at the top of `main()` in `parse_html.py` so the script is also safe when invoked directly (e.g. `cat foo.html | python parse_html.py`). Without these the child silently mojibaked utf-8 input as cp1252 (HTML title separator `·` became `Â·` in captured baselines, which would produce false drift signals on subsequent comparisons).

## Verification

Tested on Windows 11 Pro + Python 3.14 + Git Bash and PowerShell 5.1 against `https://shieldxx.net/` pages:

- Before fix: ` { "error": "Fetch failed: ... FileNotFoundError: [Errno 2] No such file or directory: '/dev/stdout'" } `
- After patch 1, before 2+3: ` { "error": "HTML parsing timed out after 30 seconds" } ` plus `UnicodeEncodeError: 'charmap' codec can't encode character 'Č'` in stderr
- After patch 2, before 3: baseline saves but title contains `Â·` mojibake instead of `·`
- After all three: baseline saves cleanly, `"title": "About David Kohout · Designer and 3D Artist · Shieldxx"` round-trips correctly with all Czech diacritics preserved

POSIX / macOS / Linux behaviour is unchanged - the temp file approach is a strict superset of `/dev/stdout` (avoids subprocess buffer-limit edge cases too), the `encoding` parameter is no-op on systems that already default to utf-8, and `sys.stdin.reconfigure()` is guarded by `hasattr` so older Python (<3.7) is unaffected.

## Out of scope

This PR addresses only the drift baseline chain. There are likely other Windows encoding pitfalls in scripts that fork subprocesses with HTML content (e.g. anywhere else that calls `parse_html.py` via subprocess) - I haven't audited the full plugin. Happy to follow up if you'd like.

## Environment

- Windows 11 Pro 10.0.26200
- Python 3.14.x (Windows-native, not WSL)
- Shells tested: Git Bash (MSYS), PowerShell 5.1
- claude-seo: v1.9.9 + current `main` at 7676024 (both affected)