### PR TITLE
fix(drift_baseline): cross-platform fetch -> parse handoff (Windows compatibility)

### DIFF
--- a/scripts/drift_baseline.py
+++ b/scripts/drift_baseline.py
@@ -149,54 +149,83 @@ def fetch_page_data(url: str) -> dict:
     """
     result = {"status_code": None, "html": None, "parsed": None, "error": None}
 
-    # Step 1: Fetch the page via fetch_page.py
+    # Fetch -> parse handoff via a tempfile.
+    #
+    # The previous pipeline (--output /dev/stdout, then piping HTML through
+    # stdin to parse_html) is Unix-biased and fails on Windows in three places:
+    #   1. /dev/stdout is not a valid path on Windows (FileNotFoundError).
+    #   2. subprocess.run(..., text=True) defaults to the system codec
+    #      (cp1252 on Windows), which UnicodeEncodeErrors on any non-Latin-1
+    #      character flowing through stdin.
+    #   3. Pipe-via-stdin can carry surrogate codepoints back into parse_html;
+    #      lxml strictly rejects surrogates.
+    #
+    # Writing fetch_page output to a tempfile and passing that path to
+    # parse_html (which already accepts a positional `file` argument) sidesteps
+    # all three. encoding="utf-8", errors="replace" on subprocess.run is
+    # defensive — on macOS / Linux it's a no-op, on Windows it forces the right
+    # codec.
+    import tempfile
     fetch_script = os.path.join(SCRIPTS_DIR, "fetch_page.py")
-    try:
-        proc = subprocess.run(
-            [sys.executable, fetch_script, url, "--output", "/dev/stdout"],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-    except subprocess.TimeoutExpired:
-        result["error"] = "Page fetch timed out after 60 seconds"
-        return result
-
-    if proc.returncode != 0:
-        error_msg = proc.stderr.strip() if proc.stderr else "Unknown fetch error"
-        result["error"] = f"Fetch failed: {error_msg}"
-        return result
-
-    html_content = proc.stdout
-
-    # Extract status code from stderr output (fetch_page.py prints "Status: NNN")
-    status_match = re.search(r"Status:\s*(\d+)", proc.stderr or "")
-    result["status_code"] = int(status_match.group(1)) if status_match else 200
-    result["html"] = html_content
-
-    # Step 2: Parse the HTML via parse_html.py
     parse_script = os.path.join(SCRIPTS_DIR, "parse_html.py")
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".html")
+    os.close(tmp_fd)
     try:
-        proc = subprocess.run(
-            [sys.executable, parse_script, "--url", url, "--json"],
-            input=html_content,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except subprocess.TimeoutExpired:
-        result["error"] = "HTML parsing timed out after 30 seconds"
-        return result
+        try:
+            proc = subprocess.run(
+                [sys.executable, fetch_script, url, "--output", tmp_path],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            result["error"] = "Page fetch timed out after 60 seconds"
+            return result
 
-    if proc.returncode != 0:
-        error_msg = proc.stderr.strip() if proc.stderr else "Unknown parse error"
-        result["error"] = f"Parse failed: {error_msg}"
-        return result
+        if proc.returncode != 0:
+            error_msg = proc.stderr.strip() if proc.stderr else "Unknown fetch error"
+            result["error"] = f"Fetch failed: {error_msg}"
+            return result
 
-    try:
-        result["parsed"] = json.loads(proc.stdout)
-    except json.JSONDecodeError as e:
-        result["error"] = f"Failed to parse JSON output: {e}"
+        # Extract status code from stderr output (fetch_page.py prints "Status: NNN")
+        status_match = re.search(r"Status:\s*(\d+)", proc.stderr or "")
+        result["status_code"] = int(status_match.group(1)) if status_match else 200
+
+        # Read the HTML once for hashing (errors="replace" scrubs invalid bytes).
+        with open(tmp_path, "r", encoding="utf-8", errors="replace") as f:
+            result["html"] = f.read()
+
+        # Parse the HTML via parse_html.py — pass the tempfile as a positional
+        # arg so we don't go through stdin (avoids the cp1252 + surrogate chain).
+        try:
+            proc = subprocess.run(
+                [sys.executable, parse_script, tmp_path, "--url", url, "--json"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            result["error"] = "HTML parsing timed out after 30 seconds"
+            return result
+
+        if proc.returncode != 0:
+            error_msg = proc.stderr.strip() if proc.stderr else "Unknown parse error"
+            result["error"] = f"Parse failed: {error_msg}"
+            return result
+
+        try:
+            result["parsed"] = json.loads(proc.stdout)
+        except json.JSONDecodeError as e:
+            result["error"] = f"Failed to parse JSON output: {e}"
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
     return result
 


### PR DESCRIPTION
## Summary

Three independent Unix-only assumptions in `drift_baseline.py`'s
`fetch_page_data()` make `drift baseline <url>` fail end-to-end on Windows.
Each fix uncovers the next:

1. **`--output /dev/stdout` is hard-coded** (line 156). Windows:

   ```
   FileNotFoundError: [Errno 2] No such file or directory: '/dev/stdout'
   ```

2. **`subprocess.run(input=..., text=True)` uses cp1252 on Windows** for the
   stdin encoding. Any non-Latin-1 char in the page HTML breaks the pipe to
   `parse_html.py`:

   ```
   UnicodeEncodeError: 'charmap' codec can't encode character '→' in position 10260
   ```

3. **lxml rejects surrogate codepoints** that flow back via the
   subprocess pipe after Windows' codec mishandling:

   ```
   UnicodeEncodeError: 'utf-8' codec can't encode character '\udc9d' in position 35624: surrogates not allowed
   ```

## Fix

Refactor the fetch → parse handoff to use a tempfile + `parse_html.py`'s
already-supported positional `file` argument, instead of piping HTML
through stdin:

- `tempfile.mkstemp()` for the fetch output (cross-platform — no
  `/dev/stdout`).
- Pass the tempfile path to `parse_html.py` as a positional arg, skipping
  the stdin pipe entirely.
- Defensive `encoding="utf-8", errors="replace"` on `subprocess.run` —
  no-op on macOS/Linux, forces the correct codec on Windows.
- `tempfile` cleaned up in a `finally` block.

No companion changes needed: `fetch_page.py` already supports
`--output <path>` and `parse_html.py` already accepts a positional `file`.

## Repro (on Windows)

Fresh Windows 11, Python 3.14, no virtualenv changes:

```powershell
git clone --depth 1 https://github.com/AgriciDaniel/claude-seo $env:USERPROFILE\.claude\skills\seo
pip install -r $env:USERPROFILE\.claude\skills\seo\requirements.txt
python $env:USERPROFILE\.claude\skills\seo\scripts\drift_baseline.py https://example.com
```

Each fix in this PR resolves the next failure mode in the same execution
path.

## Test coverage

Tested on:
- **Windows 11 / Python 3.14** (the affected environment) — now works
  end-to-end. Baseline captured against `https://archgyan.com` with title,
  canonical, meta, schema, h1/h2/h3 all populated correctly.
- **macOS / Linux** — refactor is a no-op behaviourally; `subprocess.run`
  with `encoding="utf-8"` matches the prior default on those platforms.

## Notes

- This is a downstream-discovered fix surfaced while running drift baselines
  on Archgyan (an architecture-education platform) on Windows 11.
- No new dependencies. Pure stdlib (`tempfile`).
- The patched function body lives entirely within `fetch_page_data()`; no
  signature changes, no behavioural changes on Unix.
