### PR TITLE
feat: add authors and keywords to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ description = "Comprehensive SEO analysis skill for Claude Code"
 requires-python = ">=3.10"
 license = "MIT"
 readme = "README.md"
+authors = [
+  {name = "Daniel Agrici", email = "agricidaniel@gmail.com"}
+]
+keywords = ["seo", "claude-code", "ai-tools", "schema-markup", "e-e-a-t", "geo"]
 
 [project.urls]
 Homepage = "https://github.com/AgriciDaniel/claude-seo"


### PR DESCRIPTION
## Summary

- Adds `authors` field to `pyproject.toml`, consistent with `CITATION.cff`
- Adds `keywords` field mirroring the keywords already defined in `CITATION.cff`

Both fields were already specified in `CITATION.cff` but missing from `pyproject.toml`, which is the canonical source for PyPI-compatible tooling (pip, uv, build).

## Test plan

- Verify `cat pyproject.toml` shows the new fields
- No functional code changes, metadata only

Generated with Claude Code