### PR TITLE
fix(drift): Windows portability for drift_baseline (path + UTF-8)

### DIFF
--- a/scripts/drift_baseline.py
+++ b/scripts/drift_baseline.py
@@ -29,6 +29,11 @@ from urllib.parse import parse_qs, urlparse, urlunparse, urlencode
 SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPTS_DIR)
 
+# Run child scripts (fetch/parse/pagespeed) in UTF-8 mode so page content with
+# non-ASCII or invalid bytes does not crash on Windows consoles defaulting to
+# cp1252. Without this, lone surrogates / undecodable bytes break the pipeline.
+_UTF8_ENV = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
+
 from google_auth import validate_url  # noqa: E402
 
 DB_DIR = os.path.expanduser("~/.cache/claude-seo/drift")
@@ -153,9 +158,12 @@ def fetch_page_data(url: str) -> dict:
     fetch_script = os.path.join(SCRIPTS_DIR, "fetch_page.py")
     try:
         proc = subprocess.run(
-            [sys.executable, fetch_script, url, "--output", "/dev/stdout"],
+            [sys.executable, fetch_script, url],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=_UTF8_ENV,
             timeout=60,
         )
     except subprocess.TimeoutExpired:
@@ -182,6 +190,9 @@ def fetch_page_data(url: str) -> dict:
             input=html_content,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=_UTF8_ENV,
             timeout=30,
         )
     except subprocess.TimeoutExpired:
@@ -213,6 +224,9 @@ def fetch_cwv_data(url: str) -> dict | None:
             [sys.executable, psi_script, url, "--psi-only", "--strategy", "mobile", "--json"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=_UTF8_ENV,
             timeout=180,
         )
     except subprocess.TimeoutExpired:

--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -148,6 +148,14 @@ def fetch_page(
 
 
 def main():
+    # Force UTF-8 stdout/stderr so page content with non-ASCII characters
+    # (e.g. U+25BC) doesn't crash on Windows consoles defaulting to cp1252.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except (AttributeError, ValueError):
+            pass
+
     parser = argparse.ArgumentParser(description="Fetch a web page for SEO analysis")
     parser.add_argument("url", help="URL to fetch")
     parser.add_argument("--output", "-o", help="Output file path")


### PR DESCRIPTION
Fixes #124. Related to #114 / #115.

`drift_baseline.py` is unusable on Windows because of a Linux-only path and cp1252 console encoding. This makes the drift pipeline UTF-8 safe.

### Heads-up on overlap with #115
This targets the same root causes as #115 (thanks @Shieldxx). I am opening it as an **alternative implementation** with one extra hardening, and I am happy for the maintainer to merge whichever fits best, cherry-pick, or close this as duplicate. The meaningful difference:

- #115 uses **strict** UTF-8 (`encoding="utf-8"` + `reconfigure`), which covers valid non-cp1252 characters.
- This PR adds `errors="replace"` and full UTF-8 mode, which **also survives stray invalid bytes**. Our repro hit a page with a raw `0x8f` byte that became a lone surrogate `\udc8f` and crashed lxml in `parse_html.py` (`surrogates not allowed`) — a failure mode strict UTF-8 does not catch.

### Changes
- `drift_baseline.py`: remove `--output /dev/stdout` (fetch_page already prints to stdout when omitted; `open('/dev/stdout')` raises `FileNotFoundError` on Windows). Run the fetch/parse/pagespeed subprocesses with `env=_UTF8_ENV` (`PYTHONUTF8=1` + `PYTHONIOENCODING=utf-8`) and decode their output with `encoding="utf-8", errors="replace"`.
- `fetch_page.py`: guarded `sys.stdout/stderr.reconfigure(encoding="utf-8")` so standalone fetches do not crash on non-ASCII content.

### Testing
Captured baselines for 15 live URLs (homepage, service hubs, location pages) on **Windows 11 / Python 3.13** with plain `python` and no env vars. All 15 succeed; before this change, every one failed. Includes a page with `▼` (U+25BC) and a stray `0x8f` byte.

`tests/test_portability.py` passes (10/10). `py_compile` clean on both files.

Verified on Windows only (the platform where it was broken). I could not run Linux/macOS here, so cross-platform safety is established by reasoning rather than a live run: every addition is either a no-op where UTF-8 is already the default (`PYTHONUTF8`/`PYTHONIOENCODING`, the stdout reconfigure) or a safety net that never triggers on valid output (`errors="replace"`). No behavior change expected on Linux/macOS, where UTF-8 is already standard.

Note: dropping `--output /dev/stdout` also removes a latent `Saved to /dev/stdout` line that the old code mixed into captured HTML on POSIX, so Unix baselines get slightly cleaner too.
