### PR TITLE
fix: Windows compatibility for drift scripts and installer

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -67,6 +67,8 @@ The installer creates a venv at `~/.claude/skills/seo/.venv/`. If that fails, in
 ```bash
 # Option A: Use the venv
 ~/.claude/skills/seo/.venv/bin/pip install -r ~/.claude/skills/seo/requirements.txt
+# On Windows the venv layout differs — use Scripts/ instead of bin/:
+#   ~/.claude/skills/seo/.venv/Scripts/pip install -r ~/.claude/skills/seo/requirements.txt
 
 # Option B: User-level install
 pip install --user -r ~/.claude/skills/seo/requirements.txt

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,6 +42,8 @@ As of v1.2.0, dependencies are installed in a venv. Try:
 ```bash
 # Use the venv pip
 ~/.claude/skills/seo/.venv/bin/pip install -r ~/.claude/skills/seo/requirements.txt
+# On Windows the venv layout differs — use Scripts/ instead of bin/:
+~/.claude/skills/seo/.venv/Scripts/pip install -r ~/.claude/skills/seo/requirements.txt
 ```
 
 If the venv doesn't exist, install with `--user`:

--- a/install.sh
+++ b/install.sh
@@ -127,10 +127,15 @@ main() {
     # Install Python dependencies (venv preferred, --user fallback)
     echo "→ Installing Python dependencies..."
     VENV_DIR="${SKILL_DIR}/.venv"
+    VENV_BIN="${VENV_DIR}/bin"
     if python3 -m venv "${VENV_DIR}" 2>/dev/null; then
-        "${VENV_DIR}/bin/pip" install --quiet -r "${TEMP_DIR}/claude-seo/requirements.txt" 2>/dev/null && \
+        # Windows venvs (Git Bash / MSYS) use Scripts/ instead of bin/
+        if [ -d "${VENV_DIR}/Scripts" ]; then
+            VENV_BIN="${VENV_DIR}/Scripts"
+        fi
+        "${VENV_BIN}/pip" install --quiet -r "${TEMP_DIR}/claude-seo/requirements.txt" 2>/dev/null && \
             echo "  ✓ Installed in venv at ${VENV_DIR}" || \
-            echo "  ⚠  Venv pip install failed. Run: ${VENV_DIR}/bin/pip install -r ${SKILL_DIR}/requirements.txt"
+            echo "  ⚠  Venv pip install failed. Run: ${VENV_BIN}/pip install -r ${SKILL_DIR}/requirements.txt"
     else
         pip install --quiet --user -r "${TEMP_DIR}/claude-seo/requirements.txt" 2>/dev/null || \
         echo "  ⚠  Could not auto-install. Run: pip install --user -r ${SKILL_DIR}/requirements.txt"
@@ -138,8 +143,8 @@ main() {
 
     # Optional: Install Playwright browsers (for screenshot analysis)
     echo "→ Installing Playwright browsers (optional, for visual analysis)..."
-    if [ -f "${VENV_DIR}/bin/playwright" ]; then
-        "${VENV_DIR}/bin/python" -m playwright install chromium 2>/dev/null || \
+    if [ -f "${VENV_BIN}/playwright" ] || [ -f "${VENV_BIN}/playwright.exe" ]; then
+        "${VENV_BIN}/python" -m playwright install chromium 2>/dev/null || \
         echo "  ⚠  Playwright install failed. Visual analysis will use WebFetch fallback."
     else
         python3 -m playwright install chromium 2>/dev/null || \

--- a/scripts/drift_baseline.py
+++ b/scripts/drift_baseline.py
@@ -20,6 +20,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse, urlunparse, urlencode
 
@@ -150,24 +151,33 @@ def fetch_page_data(url: str) -> dict:
     result = {"status_code": None, "html": None, "parsed": None, "error": None}
 
     # Step 1: Fetch the page via fetch_page.py
+    # Use a temp file for output: /dev/stdout does not exist on Windows.
     fetch_script = os.path.join(SCRIPTS_DIR, "fetch_page.py")
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".html", delete=False, encoding="utf-8"
+    )
+    tmp.close()
     try:
         proc = subprocess.run(
-            [sys.executable, fetch_script, url, "--output", "/dev/stdout"],
+            [sys.executable, fetch_script, url, "--output", tmp.name],
             capture_output=True,
             text=True,
             timeout=60,
         )
     except subprocess.TimeoutExpired:
         result["error"] = "Page fetch timed out after 60 seconds"
+        os.unlink(tmp.name)
         return result
 
     if proc.returncode != 0:
         error_msg = proc.stderr.strip() if proc.stderr else "Unknown fetch error"
         result["error"] = f"Fetch failed: {error_msg}"
+        os.unlink(tmp.name)
         return result
 
-    html_content = proc.stdout
+    with open(tmp.name, encoding="utf-8") as f:
+        html_content = f.read()
+    os.unlink(tmp.name)
 
     # Extract status code from stderr output (fetch_page.py prints "Status: NNN")
     status_match = re.search(r"Status:\s*(\d+)", proc.stderr or "")
@@ -175,11 +185,16 @@ def fetch_page_data(url: str) -> dict:
     result["html"] = html_content
 
     # Step 2: Parse the HTML via parse_html.py
+    # Pass HTML via temp file: large stdin pipes deadlock on Windows.
     parse_script = os.path.join(SCRIPTS_DIR, "parse_html.py")
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".html", delete=False, encoding="utf-8"
+    )
+    tmp.write(html_content)
+    tmp.close()
     try:
         proc = subprocess.run(
-            [sys.executable, parse_script, "--url", url, "--json"],
-            input=html_content,
+            [sys.executable, parse_script, "--url", url, "--json", tmp.name],
             capture_output=True,
             text=True,
             timeout=30,
@@ -187,6 +202,8 @@ def fetch_page_data(url: str) -> dict:
     except subprocess.TimeoutExpired:
         result["error"] = "HTML parsing timed out after 30 seconds"
         return result
+    finally:
+        os.unlink(tmp.name)
 
     if proc.returncode != 0:
         error_msg = proc.stderr.strip() if proc.stderr else "Unknown parse error"

--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -31,6 +31,14 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 from url_safety import URLSafetyError, safe_requests_session, validate_url_strict  # noqa: E402
 
+# Windows consoles and pipes default to a legacy code page (e.g. cp1252), so
+# printing fetched page content raises UnicodeEncodeError on the first
+# character outside that code page. Force UTF-8 output instead.
+if sys.platform == "win32":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
 
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "


### PR DESCRIPTION
## Summary

Three Windows incompatibilities discovered while running a real `/seo drift` + audit workflow on Windows 11 (Git Bash, CPython 3.13):

### 1. `drift_baseline.py` used `/dev/stdout`, which does not exist on Windows

`fetch_page_data()` invoked `fetch_page.py --output /dev/stdout` to capture HTML. On Windows there is no `/dev/stdout`, so every drift baseline/compare failed immediately. Fixed by writing to a `tempfile.NamedTemporaryFile` and reading it back (always cleaned up, including on the timeout/error paths).

### 2. `drift_baseline.py` piped large HTML to `parse_html.py` via stdin — deadlocks on Windows

`subprocess.run(..., input=html_content)` deadlocks on Windows once the payload exceeds the pipe buffer (reproduced with a ~368 KB page). Fixed by writing the HTML to a temp file and passing the path — `parse_html.py` already accepts a positional file argument, so no changes needed there. `drift_compare.py` imports `fetch_page_data` from `drift_baseline.py`, so it inherits both fixes.

### 3. `install.sh` assumed the Unix venv layout (`.venv/bin/`)

Windows venvs put executables in `Scripts/`, not `bin/`, so `"${VENV_DIR}/bin/pip" install ...` and the Playwright probe silently failed with only a warning — the skill then crashed later at runtime with `ModuleNotFoundError`. Fixed by detecting `Scripts/` vs `bin/` (an `if` block rather than a bare `[ -d ] && ...` list, which would abort under the script's `set -e` when false). The Playwright file test also probes `playwright.exe`, since Git Bash auto-appends `.exe` on execution but not for `[ -f ]`. Added the `Scripts/` path to INSTALLATION.md and TROUBLESHOOTING.md.

### Bonus: `fetch_page.py` crashed with `UnicodeEncodeError` printing page content

Windows consoles and pipes default to a legacy code page (cp1252), so printing fetched HTML without `--output` crashed on the first non-cp1252 character (e.g. `→`). Fixed by reconfiguring stdout/stderr to UTF-8 on `win32`.

## Test plan

All verified on Windows 11 (Git Bash, Python 3.13.13):

- [x] `drift_baseline.py <url> --skip-cwv` runs end-to-end against a 368 KB page (over the old deadlock threshold) and stores the baseline
- [x] `drift_compare.py <url> --skip-cwv` evaluates all 17 rules against that baseline
- [x] `fetch_page.py <url>` (no `--output`) prints 368 KB of HTML to a cp1252 pipe without error; confirmed the same interpreter previously raised `UnicodeEncodeError` printing `→` to a pipe
- [x] install.sh venv block tested standalone: venv lands in `Scripts/`, detection picks it, `"$VENV_BIN/pip" --version` resolves `pip.exe`
- [x] `bash -n install.sh` and `py_compile` on both Python files pass
- [x] No behavior change on Unix: `VENV_BIN` defaults to `bin/`, the UTF-8 reconfigure is gated on `sys.platform == "win32"`, and temp files replace `/dev/stdout`/stdin equivalently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
