### PR TITLE
docs: async collaboration workflow for Japan-Canada co-development

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,62 @@
+name: Task
+description: Development task for async collaboration
+title: "[Task] "
+labels: []
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What needs to be done and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - area:skill
+        - area:script
+        - area:agent
+        - area:docs
+        - area:infra
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - priority:high
+        - priority:med
+        - priority:low
+    validations:
+      required: true
+
+  - type: textarea
+    id: context_for_claude
+    attributes:
+      label: Claude Code Context
+      description: >
+        Background that Claude Code should read before starting work.
+        List relevant files, known patterns, prior decisions, or constraints.
+      placeholder: |
+        - Related files: skills/seo-foo/SKILL.md, scripts/bar.py
+        - Prior decision: ...
+        - Watch out for: validate_url() must be called before any HTTP request
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know this is done?
+      placeholder: |
+        - [ ] ...
+        - [ ] Tested with a real URL
+        - [ ] CHANGELOG.md updated
+    validations:
+      required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,3 +207,60 @@ After cutting a new release (git tag + `gh release create`), run:
 ```
 
 This generates a blog post on https://claude-seo.md/blog/, handles cover image generation, SEO metadata, FAQ schema, internal linking, sitemap/llms.txt updates, Vercel deployment, and Google indexing.
+
+---
+
+## Collaboration
+
+This repo is co-developed asynchronously across ~16 time zones.
+
+| Role | GitHub | Timezone |
+|------|--------|----------|
+| Repo owner | AgriciDaniel | Canada (UTC-7 to UTC-5) |
+| Collaborator | kota-takai | Japan (UTC+9) |
+
+### Branch & PR Rules
+
+- `main` is always in a working state — never push directly
+- All changes go through PRs: `feat/issue-{num}-{description}` or `fix/issue-{num}-{description}`
+- PRs are reviewed and merged by the **other** person (no self-merge)
+- Merge only when CI ✅ + Approve ✅
+
+### Session Start Protocol
+
+Before starting any work, run:
+
+```bash
+gh issue list --assignee @me --state open
+gh pr list --state open
+# For your assigned issues, check the latest handoff:
+gh issue view {number} --comments | grep -A 30 '\[HANDOFF\]' | tail -30
+```
+
+### Session End — Handoff Comment
+
+When ending a session, post a comment on the active Issue using this format:
+
+```
+[HANDOFF] YYYY-MM-DD  {Your name}
+
+### Done this session
+- path/to/file: what changed
+
+### In progress
+- Issue #{n}: brief description of where things stand
+  → specific blocker or next decision point (file:line if relevant)
+
+### Next steps
+- [ ] task 1
+- [ ] task 2
+
+### Notes for Claude Code
+- any non-obvious context the next session needs
+```
+
+### Known Patterns
+
+- `validate_url()` from `google_auth.py` must be called before any external HTTP request (SSRF guard)
+- Python scripts must output JSON and expose a CLI (`if __name__ == "__main__"`)
+- SKILL.md ≤ 500 lines; reference files ≤ 200 lines


### PR DESCRIPTION
## Summary

- **CLAUDE.md** に `Collaboration` セクションを追加。ブランチルール・PR ルール・セッション開始プロトコル・ハンドオフコメントテンプレートを記載。両者の Claude Code インスタンスが ~16h の時差をまたいでコンテキストを引き継げるようにする。
- **`.github/ISSUE_TEMPLATE/task.yml`** を新設。Claude Code が作業前に読むべき背景・関連ファイル・前提を書く `Claude Code Context` フィールドを含む。

## Type of Change

- [x] Documentation update

## Checklist

- [x] Tested with a real URL before submitting — N/A (docs only)
- [x] SKILL.md files stay under 500 lines (if modified) — not modified
- [x] Python scripts output JSON (if modified) — not modified
- [x] Reference files stay under 200 lines (if modified) — not modified
- [x] CHANGELOG.md updated with the change — docs-only, no version bump needed

## Notes for Reviewer (AgriciDaniel)

いくつか repo owner 側でお願いしたいことがあります：

1. **Collaborator 招待** — Write アクセスをもらえると、次回から直接 branch push + PR が出せます（今回はフォーク経由）。
2. **ラベル作成** — `area:skill` `area:script` `area:agent` `area:docs` `area:infra` / `priority:high` `priority:med` `priority:low` の 8 ラベルを追加してほしいです（GitHub UI または `gh label create`）。
3. **GitHub Projects ボード** — `Backlog` → `In Progress 🇯🇵` / `In Progress 🇨🇦` → `Review` → `Done` の Kanban を立ててもらえると、お互いの進捗が一目でわかります。

[NEEDS REVIEW] このワークフロー設計に合意できれば merge をお願いします。変えたい点があれば PR コメントで教えてください。