### PR TITLE
feat: add fastCRW extension

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "name": "AgriciDaniel"
   },
   "metadata": {
-    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse). v2 adds shared headless rendering, QRG-aligned content quality gates, LCP subparts via CrUX, IndexNow, four Schema.org generators, AI Share-of-Voice tracking, parasite-SEO risk scanning, multi-platform portability, and a hardened SSRF + DNS-rebinding safety layer."
+    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 9 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse). v2 adds shared headless rendering, QRG-aligned content quality gates, LCP subparts via CrUX, IndexNow, four Schema.org generators, AI Share-of-Voice tracking, parasite-SEO risk scanning, multi-platform portability, and a hardened SSRF + DNS-rebinding safety layer."
   },
   "plugins": [
     {
       "name": "claude-seo",
       "source": "./",
-      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors), plus 8 optional MCP extensions. v2 adds shared headless rendering across every fetching agent, QRG-aligned content quality gates, LCP subparts via CrUX, IndexNow submission, four Schema.org generators (Reservation / OrderAction / DiscussionForumPosting / ProfilePage), AI Share-of-Voice tracking, parasite-SEO risk scanning, and multi-platform portability.",
+      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework integration + 2 extension mirrors) and 18 sub-agents (15 core + 1 framework integration + 2 extension mirrors), plus 9 optional MCP extensions. v2 adds shared headless rendering across every fetching agent, QRG-aligned content quality gates, LCP subparts via CrUX, IndexNow submission, four Schema.org generators (Reservation / OrderAction / DiscussionForumPosting / ProfilePage), AI Share-of-Voice tracking, parasite-SEO risk scanning, and multi-platform portability.",
       "author": {
         "name": "AgriciDaniel",
         "email": "agricidaniel@gmail.com",

--- a/extensions/crw/README.md
+++ b/extensions/crw/README.md
@@ -1,0 +1,84 @@
+# fastCRW Extension for Claude SEO
+
+Full-site crawling, scraping, and site mapping powered by [fastCRW](https://fastcrw.com/) -- a Firecrawl-compatible web scraper in a single ~8MB Rust binary. Self-host (free, AGPL open core) or use the managed cloud. Enables comprehensive site-wide SEO analysis with JavaScript rendering support.
+
+## Prerequisites
+
+- [Claude SEO](https://github.com/AgriciDaniel/claude-seo) installed
+- Node.js 20+
+- A fastCRW endpoint, either:
+  - **Managed cloud:** an API key from [fastcrw.com](https://fastcrw.com)
+  - **Self-host (free, AGPL):** your own engine; set `CRW_API_URL` (key optional)
+
+## Installation
+
+### macOS / Linux
+
+```bash
+./extensions/crw/install.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+.\extensions\crw\install.ps1
+```
+
+The installer prompts for your `CRW_API_KEY` and configures the MCP server automatically. To target a self-hosted engine, set `CRW_API_URL` before running (e.g. `CRW_API_URL=http://localhost:3000 ./extensions/crw/install.sh`).
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/seo crw crawl <url>` | Full-site crawl with content extraction |
+| `/seo crw map <url>` | Discover site structure (URLs only) |
+| `/seo crw scrape <url>` | Single-page deep scrape with JS rendering |
+| `/seo crw search <query> <url>` | Search within a site (cloud) |
+
+## Integration with Claude SEO
+
+When installed, other Claude SEO skills automatically leverage fastCRW:
+
+- **`/seo audit`**: Uses `map` to discover all pages, then `crawl` for deep analysis
+- **`/seo technical`**: Broken link detection across entire site
+- **`/seo sitemap`**: Compare XML sitemap vs actual crawlable pages
+- **`/seo content`**: Thin content detection at scale
+
+## Why fastCRW
+
+Firecrawl-compatible web scraper; single ~8MB Rust binary; self-host or cloud. Because the REST API is Firecrawl-compatible, this extension reuses the same MCP client and simply points its base URL at fastCRW (`https://fastcrw.com/api` by default, or your self-hosted engine).
+
+## Configuration
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CRW_API_KEY` | _(prompted)_ | Bearer auth for the managed cloud (optional for self-host without auth) |
+| `CRW_API_URL` | `https://fastcrw.com/api` | Base URL; override for self-host (e.g. `http://localhost:3000`) |
+
+## Troubleshooting
+
+**MCP not connecting?**
+- Check: `cat ~/.claude/settings.json | python3 -m json.tool | grep crw`
+- Manual config: See [CRW-SETUP.md](docs/CRW-SETUP.md)
+
+**Auth errors?**
+- Verify your `CRW_API_KEY` at https://fastcrw.com
+- Self-host engines may not require a key; leave it empty and set `CRW_API_URL`
+
+**Site blocking crawls?**
+- Some sites block automated crawling via robots.txt or Cloudflare
+- Try `scrape` (single page) instead of `crawl` (full site)
+- Fall back to `fetch_page.py` for basic HTML retrieval
+
+## Uninstall
+
+```bash
+./extensions/crw/uninstall.sh      # macOS/Linux
+.\extensions\crw\uninstall.ps1     # Windows
+```
+
+## Links
+
+- [fastCRW](https://fastcrw.com/)
+- [fastCRW REST API docs](https://fastcrw.com/docs/rest-api)
+- [Claude SEO](https://github.com/AgriciDaniel/claude-seo)

--- a/extensions/crw/docs/CRW-SETUP.md
+++ b/extensions/crw/docs/CRW-SETUP.md
@@ -1,0 +1,77 @@
+# fastCRW Setup Guide
+
+## 1. Choose Your Endpoint
+
+fastCRW is a Firecrawl-compatible web scraper. You can run it two ways:
+
+- **Managed cloud:** sign up at [fastcrw.com](https://fastcrw.com), create an API
+  key, and use the default base URL `https://fastcrw.com/api`.
+- **Self-host (free, AGPL):** run the ~8MB Rust binary yourself and point the
+  extension at it with `CRW_API_URL` (e.g. `http://localhost:3000`). Self-host
+  engines may run without auth, so the key can be left empty.
+
+## 2. Run the Installer
+
+The installer handles everything automatically:
+
+```bash
+./extensions/crw/install.sh
+```
+
+It prompts for your `CRW_API_KEY` and configures the MCP server. For self-host:
+
+```bash
+CRW_API_URL=http://localhost:3000 ./extensions/crw/install.sh
+```
+
+## 3. Manual MCP Configuration
+
+If the installer fails, add this to `~/.claude/settings.json` manually. fastCRW is
+Firecrawl API-compatible, so the firecrawl-mcp client works once its base URL is
+pointed at fastCRW:
+
+```json
+{
+  "mcpServers": {
+    "crw-mcp": {
+      "command": "npx",
+      "args": ["-y", "firecrawl-mcp@3.11.0"],
+      "env": {
+        "FIRECRAWL_API_URL": "https://fastcrw.com/api",
+        "FIRECRAWL_API_KEY": "your-crw-api-key-here"
+      }
+    }
+  }
+}
+```
+
+For self-host without auth, drop `FIRECRAWL_API_KEY` and set `FIRECRAWL_API_URL`
+to your engine.
+
+## 4. Verify Installation
+
+Start Claude Code and try:
+
+```
+/seo crw map https://example.com
+```
+
+You should see a list of discovered URLs. If you get a "tool not available" error,
+restart Claude Code to reload MCP servers.
+
+## 5. REST API Reference
+
+fastCRW exposes a Firecrawl-compatible REST API under the base URL:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/v1/scrape` | Single-page scrape |
+| POST | `/v1/crawl` | Start a full-site crawl (async job) |
+| GET | `/v1/crawl/{id}` | Poll crawl status / results |
+| POST | `/v1/map` | Discover all URLs |
+| POST | `/v1/search` | Search the web (cloud) |
+| GET | `/health` | Health check |
+
+Auth is `Authorization: Bearer <CRW_API_KEY>`. Responses use a `{ success, ... }`
+envelope (on failure, `error` and `error_code` are set). Full docs:
+https://fastcrw.com/docs/rest-api

--- a/extensions/crw/install.ps1
+++ b/extensions/crw/install.ps1
@@ -1,0 +1,109 @@
+# fastCRW Extension Installer for Claude SEO (Windows)
+# fastCRW is a Firecrawl-compatible web scraper in a single ~8MB Rust binary.
+# Self-host (free, AGPL) or managed cloud at https://fastcrw.com. This extension
+# reuses the firecrawl-mcp client and points its base URL at fastCRW.
+$ErrorActionPreference = 'Stop'
+
+Write-Host "====================================" -ForegroundColor Cyan
+Write-Host "  fastCRW Extension - Installer" -ForegroundColor Cyan
+Write-Host "  For Claude SEO" -ForegroundColor Cyan
+Write-Host "====================================" -ForegroundColor Cyan
+Write-Host ""
+
+$SkillDir = "$env:USERPROFILE\.claude\skills\seo-crw"
+$SeoSkillDir = "$env:USERPROFILE\.claude\skills\seo"
+$SettingsFile = "$env:USERPROFILE\.claude\settings.json"
+
+# Default to managed cloud; override CRW_API_URL for a self-hosted engine.
+$ApiUrl = if ($env:CRW_API_URL) { $env:CRW_API_URL } else { "https://fastcrw.com/api" }
+
+# Check prerequisites
+if (-not (Test-Path $SeoSkillDir)) {
+    Write-Host "x Claude SEO is not installed." -ForegroundColor Red
+    Write-Host "  Install it first: irm https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.ps1 | iex"
+    exit 1
+}
+Write-Host "v Claude SEO detected" -ForegroundColor Green
+
+$nodeVersion = (node -v 2>$null) -replace 'v',''
+if (-not $nodeVersion) {
+    Write-Host "x Node.js is required but not installed." -ForegroundColor Red
+    exit 1
+}
+$major = [int]($nodeVersion -split '\.')[0]
+if ($major -lt 20) {
+    Write-Host "x Node.js 20+ required (found v$nodeVersion)." -ForegroundColor Red
+    exit 1
+}
+Write-Host "v Node.js v$nodeVersion detected" -ForegroundColor Green
+
+# Prompt for API key
+Write-Host ""
+Write-Host "fastCRW API key required (managed cloud)." -ForegroundColor Yellow
+Write-Host "Sign up at: https://fastcrw.com"
+Write-Host "Self-host (free, AGPL): set CRW_API_URL to your engine; key may be left empty."
+Write-Host "Base URL: $ApiUrl"
+Write-Host ""
+
+$apiKey = Read-Host "fastCRW API key (CRW_API_KEY)" -AsSecureString
+$apiKeyPlain = [Runtime.InteropServices.Marshal]::PtrToStringBSTR(
+    [Runtime.InteropServices.Marshal]::SecureStringToBSTR($apiKey))
+if ([string]::IsNullOrWhiteSpace($apiKeyPlain)) {
+    if ($ApiUrl -eq "https://fastcrw.com/api") {
+        Write-Host "x API key cannot be empty for the managed cloud." -ForegroundColor Red
+        Write-Host "  For self-host, set CRW_API_URL to your engine and re-run."
+        exit 1
+    }
+    Write-Host "  No key supplied; assuming a self-host engine without auth." -ForegroundColor Yellow
+}
+
+# Determine source directory
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SourceDir = $null
+if (Test-Path "$ScriptDir\skills\seo-crw\SKILL.md") {
+    $SourceDir = $ScriptDir
+} elseif (Test-Path "$ScriptDir\extensions\crw\skills\seo-crw\SKILL.md") {
+    $SourceDir = "$ScriptDir\extensions\crw"
+} else {
+    Write-Host "x Cannot find extension source files." -ForegroundColor Red
+    exit 1
+}
+
+# Install skill
+Write-Host ""
+Write-Host "=> Installing fastCRW skill..." -ForegroundColor Yellow
+New-Item -ItemType Directory -Force -Path $SkillDir | Out-Null
+Copy-Item "$SourceDir\skills\seo-crw\SKILL.md" "$SkillDir\SKILL.md" -Force
+
+# Configure MCP server
+Write-Host "=> Configuring MCP server..." -ForegroundColor Yellow
+$settingsContent = if (Test-Path $SettingsFile) { Get-Content $SettingsFile -Raw | ConvertFrom-Json } else { @{} }
+if (-not $settingsContent.mcpServers) { $settingsContent | Add-Member -NotePropertyName mcpServers -NotePropertyValue @{} -Force }
+# fastCRW is Firecrawl API-compatible: reuse firecrawl-mcp, swap base URL.
+$mcpEnv = @{ FIRECRAWL_API_URL = $ApiUrl }
+if (-not [string]::IsNullOrWhiteSpace($apiKeyPlain)) { $mcpEnv.FIRECRAWL_API_KEY = $apiKeyPlain }
+$settingsContent.mcpServers | Add-Member -NotePropertyName 'crw-mcp' -NotePropertyValue @{
+    command = 'npx'
+    args = @('-y', 'firecrawl-mcp@3.11.0')
+    env = $mcpEnv
+} -Force
+$settingsContent | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
+# Restrict the credential-bearing settings file to the current user only.
+try {
+    icacls $SettingsFile /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null
+} catch {
+    Write-Host "  Note: could not restrict settings.json ACL; review manually." -ForegroundColor Yellow
+}
+Write-Host "  v MCP server configured" -ForegroundColor Green
+
+# Pre-warm
+Write-Host "=> Pre-downloading firecrawl-mcp client..." -ForegroundColor Yellow
+npx -y firecrawl-mcp@3.11.0 --help 2>$null | Out-Null
+
+Write-Host ""
+Write-Host "v fastCRW extension installed!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Usage:"
+Write-Host "  /seo crw crawl https://example.com"
+Write-Host "  /seo crw map https://example.com"
+Write-Host "  /seo crw scrape https://example.com/page"

--- a/extensions/crw/install.sh
+++ b/extensions/crw/install.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fastCRW Extension Installer for Claude SEO
+# Wraps everything in main() to prevent partial execution on network failure
+#
+# fastCRW is a Firecrawl-compatible web scraper in a single ~8MB Rust binary.
+# Self-host (free, AGPL) or managed cloud at https://fastcrw.com. Because it is
+# Firecrawl API-compatible, this extension reuses the firecrawl-mcp client and
+# simply points its base URL at fastCRW.
+
+main() {
+    SKILL_DIR="${HOME}/.claude/skills/seo-crw"
+    AGENT_DIR="${HOME}/.claude/agents"
+    SEO_SKILL_DIR="${HOME}/.claude/skills/seo"
+    SETTINGS_FILE="${HOME}/.claude/settings.json"
+
+    # Default to managed cloud; override CRW_API_URL for a self-hosted engine.
+    CRW_API_URL="${CRW_API_URL:-https://fastcrw.com/api}"
+
+    echo "════════════════════════════════════════"
+    echo "║   fastCRW Extension - Installer       ║"
+    echo "║   For Claude SEO                     ║"
+    echo "════════════════════════════════════════"
+    echo ""
+
+    # Check prerequisites
+    if [ ! -d "${SEO_SKILL_DIR}" ]; then
+        echo "x Claude SEO is not installed."
+        echo "  Install it first: curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh | bash"
+        exit 1
+    fi
+    echo "v Claude SEO detected"
+
+    if ! command -v node >/dev/null 2>&1; then
+        echo "x Node.js is required but not installed."
+        echo "  Install Node.js 20+: https://nodejs.org/"
+        exit 1
+    fi
+
+    NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
+    if [ "${NODE_VERSION}" -lt 20 ]; then
+        echo "x Node.js 20+ required (found v${NODE_VERSION})."
+        echo "  Update: https://nodejs.org/"
+        exit 1
+    fi
+    echo "v Node.js v$(node -v | sed 's/v//') detected"
+
+    if ! command -v npx >/dev/null 2>&1; then
+        echo "x npx is required but not found (comes with npm)."
+        exit 1
+    fi
+    echo "v npx detected"
+
+    # Prompt for credentials
+    echo ""
+    echo "fastCRW API key required (managed cloud)."
+    echo "Sign up at: https://fastcrw.com"
+    echo "Self-host (free, AGPL): set CRW_API_URL to your engine; key may be left empty."
+    echo "Base URL: ${CRW_API_URL}"
+    echo ""
+
+    read -rsp "fastCRW API key (CRW_API_KEY): " CRW_API_KEY
+    echo ""
+    if [ -z "${CRW_API_KEY}" ]; then
+        # Self-host engines may run without auth; allow an empty key there.
+        if [ "${CRW_API_URL}" = "https://fastcrw.com/api" ]; then
+            echo "x API key cannot be empty for the managed cloud."
+            echo "  For self-host, set CRW_API_URL to your engine and re-run."
+            exit 1
+        fi
+        echo "  No key supplied; assuming a self-host engine without auth."
+    fi
+
+    # Determine script directory (works for both ./install.sh and curl|bash)
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # Check if running from repo or standalone
+    if [ -f "${SCRIPT_DIR}/skills/seo-crw/SKILL.md" ]; then
+        SOURCE_DIR="${SCRIPT_DIR}"
+    elif [ -f "${SCRIPT_DIR}/extensions/crw/skills/seo-crw/SKILL.md" ]; then
+        SOURCE_DIR="${SCRIPT_DIR}/extensions/crw"
+    else
+        echo "x Cannot find extension source files."
+        echo "  Run this script from the claude-seo repo: ./extensions/crw/install.sh"
+        exit 1
+    fi
+
+    # Install skill
+    echo ""
+    echo "-> Installing fastCRW skill..."
+    mkdir -p "${SKILL_DIR}"
+    cp "${SOURCE_DIR}/skills/seo-crw/SKILL.md" "${SKILL_DIR}/SKILL.md"
+
+    # Merge MCP config into settings.json
+    echo "-> Configuring MCP server..."
+
+    # Credentials are passed as argv (never interpolated into the source string)
+    # and the settings file is written atomically with 0600 permissions.
+    python3 - "${SETTINGS_FILE}" "${CRW_API_KEY}" "${CRW_API_URL}" <<'PY'
+import json, os, sys, tempfile
+
+settings_path, api_key, api_url = sys.argv[1:4]
+
+if os.path.exists(settings_path):
+    try:
+        with open(settings_path) as f:
+            settings = json.load(f)
+    except json.JSONDecodeError:
+        settings = {}
+else:
+    settings = {}
+
+# fastCRW is Firecrawl API-compatible, so we reuse the firecrawl-mcp client and
+# point its base URL at fastCRW via FIRECRAWL_API_URL.
+env = {
+    'FIRECRAWL_API_URL': api_url,
+}
+if api_key:
+    env['FIRECRAWL_API_KEY'] = api_key
+
+settings.setdefault('mcpServers', {})['crw-mcp'] = {
+    'command': 'npx',
+    'args': ['-y', 'firecrawl-mcp@3.11.0'],
+    'env': env,
+}
+
+os.makedirs(os.path.dirname(settings_path) or '.', exist_ok=True)
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(settings_path) or '.', prefix='.settings.', suffix='.json')
+try:
+    with os.fdopen(fd, 'w') as f:
+        json.dump(settings, f, indent=2)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, settings_path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+
+print('  v MCP server configured in settings.json')
+PY
+    if [ $? -ne 0 ]; then
+        echo "  Warning: Could not auto-configure MCP server."
+        echo "  Add the crw-mcp server manually to ~/.claude/settings.json"
+        echo "  See: extensions/crw/docs/CRW-SETUP.md"
+    fi
+
+    # Pre-warm npm package without starting the MCP server binary.
+    echo "-> Pre-downloading firecrawl-mcp client..."
+    npx --yes --package=firecrawl-mcp@3.11.0 -- node -e "" >/dev/null 2>&1 || true
+
+    echo ""
+    echo "v fastCRW extension installed successfully!"
+    echo ""
+    echo "Usage:"
+    echo "  1. Start Claude Code:  claude"
+    echo "  2. Run commands:"
+    echo "     /seo crw crawl https://example.com"
+    echo "     /seo crw map https://example.com"
+    echo "     /seo crw scrape https://example.com/page"
+    echo "     /seo crw search \"query\" https://example.com"
+    echo ""
+    echo "Documentation: extensions/crw/README.md"
+    echo "To uninstall: ./extensions/crw/uninstall.sh"
+}
+
+main "$@"

--- a/extensions/crw/skills/seo-crw/LICENSE.txt
+++ b/extensions/crw/skills/seo-crw/LICENSE.txt
@@ -1,0 +1,4 @@
+MIT License - see repository root LICENSE file for complete terms.
+
+Copyright (c) 2026 AgriciDaniel
+https://github.com/AgriciDaniel/claude-seo

--- a/extensions/crw/skills/seo-crw/SKILL.md
+++ b/extensions/crw/skills/seo-crw/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: seo-crw
+description: >
+  Full-site crawling, scraping, and site mapping via fastCRW (Firecrawl-compatible).
+  Use when user says "crawl site", "map site", "full crawl",
+  "find all pages", "broken links", "site structure",
+  "discover pages", "JS rendering", or needs site-wide analysis.
+user-invocable: true
+argument-hint: "[command] <url>"
+license: MIT
+compatibility: "Requires fastCRW MCP server (Firecrawl-compatible client)"
+metadata:
+  author: AgriciDaniel
+  version: "2.2.0"
+  category: seo
+---
+
+# fastCRW Extension for Claude SEO
+
+This skill requires the fastCRW extension to be installed:
+```bash
+./extensions/crw/install.sh
+```
+
+fastCRW is a Firecrawl-compatible web scraper in a single ~8MB Rust binary
+(self-host or managed cloud). Because the API is Firecrawl-compatible, this
+extension reuses the firecrawl-mcp client pointed at fastCRW
+(`https://fastcrw.com/api` by default, or your self-hosted `CRW_API_URL`). The
+MCP tools are therefore exposed under the `firecrawl_*` names.
+
+**Check availability:** Before using any tool, verify the MCP server is connected
+by checking if `firecrawl_scrape` or any related tool is available. If tools are
+not available, inform the user the extension is not installed and provide install
+instructions.
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `/seo crw crawl <url>` | Full-site crawl with content extraction |
+| `/seo crw map <url>` | Discover site structure (URLs only, fast) |
+| `/seo crw scrape <url>` | Single-page scrape with JS rendering |
+| `/seo crw search <query> <url>` | Search within a crawled site |
+
+## Commands
+
+### crawl -- Full-Site Crawl
+
+Crawl an entire website starting from the given URL. Returns page content,
+metadata, and links for all discovered pages.
+
+**MCP Tool:** `firecrawl_crawl` (fastCRW `/v1/crawl`)
+
+**Parameters:**
+- `url` (required): Starting URL to crawl
+- `limit`: Max pages to crawl (default: 100, max: 500)
+- `maxDepth`: Max link depth from start URL (default: 3)
+- `includePaths`: Array of glob patterns to include (e.g., `["/blog/*"]`)
+- `excludePaths`: Array of glob patterns to exclude (e.g., `["/admin/*", "/api/*"]`)
+- `scrapeOptions.formats`: Output formats -- `["markdown", "html", "links"]`
+
+**SEO Usage Patterns:**
+1. **Comprehensive audit crawl**: Crawl full site, extract all pages for subagent analysis
+2. **Section-focused crawl**: Use `includePaths` to audit only `/blog/*` or `/products/*`
+3. **Broken link detection**: Crawl with `["links"]` format, check all hrefs for 404s
+4. **Content inventory**: Extract all page titles, meta descriptions, H1s at scale
+5. **SPA/JS-rendered sites**: fastCRW renders JavaScript, solving the Issue #11 problem
+
+**Example orchestration for `/seo audit`:**
+```
+1. firecrawl_map(url) -> get all URLs (fast, no content)
+2. Filter to top 50 most important pages (homepage, key sections)
+3. firecrawl_crawl(url, limit=50) -> get full content
+4. Feed content to seo-technical, seo-content, seo-schema agents
+```
+
+**Cost awareness:**
+- Self-host is free (AGPL); managed cloud is metered per page
+- Map operations are cheaper than full crawls (URLs only, no content)
+- Always inform the user of estimated usage before large crawls
+
+### map -- Site Structure Discovery
+
+Discover all URLs on a website without fetching content. Fast and efficient.
+
+**MCP Tool:** `firecrawl_map` (fastCRW `/v1/map`)
+
+**Parameters:**
+- `url` (required): Website URL to map
+- `limit`: Max URLs to discover (default: 5000)
+- `search`: Optional search term to filter URLs
+
+**SEO Usage Patterns:**
+1. **Sitemap comparison**: Map site, compare discovered URLs vs XML sitemap
+2. **Orphan page detection**: URLs in sitemap but not linked from any page
+3. **Crawl budget analysis**: Total indexable pages vs pages linked from homepage
+4. **URL pattern analysis**: Identify URL structure patterns, duplicates, parameter bloat
+5. **Pre-audit discovery**: Run map first, then targeted crawl on key sections
+
+**Output:** Array of URLs. Present as:
+```
+Site: example.com
+Pages discovered: 342
+
+URL Pattern Breakdown:
+  /blog/*          - 128 pages (37%)
+  /products/*      - 89 pages (26%)
+  /category/*      - 45 pages (13%)
+  /pages/*         - 32 pages (9%)
+  / (root pages)   - 48 pages (14%)
+```
+
+### scrape -- Single-Page Deep Scrape
+
+Scrape a single page with full JavaScript rendering. More thorough than
+`fetch_page.py` because it executes JS and waits for dynamic content.
+
+**MCP Tool:** `firecrawl_scrape` (fastCRW `/v1/scrape`)
+
+**Parameters:**
+- `url` (required): Page URL to scrape
+- `formats`: Output formats -- `["markdown", "html", "links", "screenshot"]`
+- `onlyMainContent`: Strip nav/footer/sidebar (default: true)
+- `waitFor`: CSS selector or milliseconds to wait for content
+- `timeout`: Request timeout in ms (default: 30000)
+- `actions`: Browser actions before scraping (click, scroll, wait)
+
+**SEO Usage Patterns:**
+1. **SPA content extraction**: Scrape JS-rendered React/Vue/Angular pages
+2. **Dynamic content audit**: Pages with lazy-loaded content below the fold
+3. **Paywall/login detection**: Identify content behind authentication walls
+4. **Main content extraction**: Use `onlyMainContent` for clean E-E-A-T analysis
+5. **Screenshot capture**: Use `screenshot` format for visual analysis
+
+**When to use scrape vs fetch_page.py:**
+| Scenario | Use |
+|----------|-----|
+| Static HTML page | `fetch_page.py` (no API cost) |
+| JS-rendered SPA | `firecrawl_scrape` (renders JS) |
+| Need response headers | `fetch_page.py` (returns headers) |
+| Need clean markdown | `firecrawl_scrape` (better extraction) |
+| Rate-limited/blocked | `firecrawl_scrape` (handles anti-bot) |
+
+### search -- Site-Scoped Search
+
+Search within a website for specific content. Useful for finding pages
+related to a topic without crawling everything.
+
+**MCP Tool:** `firecrawl_search` (fastCRW `/v1/search`, cloud)
+
+**Parameters:**
+- `query` (required): Search query
+- `url` (required): Website to search within
+- `limit`: Max results (default: 10)
+- `scrapeOptions.formats`: Output format for matched pages
+
+**SEO Usage Patterns:**
+1. **Content gap validation**: Search for a keyword on the site to check if content exists
+2. **Internal linking opportunities**: Find pages mentioning a topic that could link to each other
+3. **Duplicate content detection**: Search for key phrases to find near-duplicates
+4. **Competitor content research**: Search competitor site for specific topics
+
+## Cross-Skill Integration
+
+### With seo-audit (full audit)
+When fastCRW is available during `/seo audit`:
+1. Use `firecrawl_map` to discover all site URLs
+2. Compare with XML sitemap (seo-sitemap) to find orphan/missing pages
+3. Select top pages for deep analysis
+4. Feed crawled content to all subagents (technical, content, schema, geo)
+5. Report total crawlable pages, URL patterns, and crawl depth
+
+### With seo-technical
+- Broken link detection: crawl all internal links, check for 404s
+- Redirect chain mapping: follow all redirects, flag chains > 2 hops
+- Mixed content detection: check HTTP resources on HTTPS pages
+- Canonical verification: compare canonical URLs with actual URLs
+
+### With seo-sitemap
+- Sitemap coverage: % of crawled pages present in sitemap
+- Orphan pages: pages found by crawl but missing from sitemap
+- Stale sitemap entries: URLs in sitemap that return 404/410
+
+### With seo-content
+- Content extraction: feed clean markdown to E-E-A-T analysis
+- Thin content detection: identify pages with < 300 words at scale
+- Duplicate content: compare content across pages for near-duplicates
+
+### With seo-schema
+- Schema extraction: pull JSON-LD from all crawled pages
+- Schema coverage: % of pages with structured data
+- Schema validation: batch-validate extracted schemas
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|-----------|
+| `tool not available` | MCP not configured | Run `./extensions/crw/install.sh` |
+| `401 Unauthorized` | Bad/missing API key | Verify `CRW_API_KEY` at fastcrw.com |
+| `429 Too Many Requests` | Rate limited | Wait 60s, reduce crawl concurrency |
+| `408 Timeout` | Page too slow to render | Increase `timeout`, try without JS rendering |
+| `403 Forbidden` | Site blocks crawling | Check robots.txt, may need to skip this site |
+
+**Graceful fallback:** If fastCRW is unavailable, inform the user and suggest:
+1. Use `fetch_page.py` for single-page analysis (no API cost)
+2. Use `WebFetch` tool for basic HTML retrieval
+3. Install fastCRW: `./extensions/crw/install.sh`

--- a/extensions/crw/uninstall.ps1
+++ b/extensions/crw/uninstall.ps1
@@ -1,0 +1,25 @@
+# fastCRW Extension Uninstaller for Claude SEO (Windows)
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Removing fastCRW extension..." -ForegroundColor Yellow
+
+$SkillDir = "$env:USERPROFILE\.claude\skills\seo-crw"
+$SettingsFile = "$env:USERPROFILE\.claude\settings.json"
+
+if (Test-Path $SkillDir) {
+    Remove-Item -Recurse -Force $SkillDir
+    Write-Host "v Removed skill files" -ForegroundColor Green
+}
+
+if (Test-Path $SettingsFile) {
+    $settings = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+    if ($settings.mcpServers.'crw-mcp') {
+        $settings.mcpServers.PSObject.Properties.Remove('crw-mcp')
+        $settings | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
+        Write-Host "v Removed MCP server from settings.json" -ForegroundColor Green
+    }
+}
+
+Write-Host ""
+Write-Host "v fastCRW extension uninstalled." -ForegroundColor Green
+Write-Host "  Core Claude SEO skills are unchanged."

--- a/extensions/crw/uninstall.sh
+++ b/extensions/crw/uninstall.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Removing fastCRW extension..."
+
+# Remove skill directory
+rm -rf "${HOME}/.claude/skills/seo-crw"
+echo "v Removed skill files"
+
+# Remove MCP entry from settings.json
+SETTINGS_FILE="${HOME}/.claude/settings.json"
+if [ -f "${SETTINGS_FILE}" ]; then
+    python3 - "${SETTINGS_FILE}" <<'PY' || echo "  Warning: Could not update settings.json automatically."
+import json, os, sys
+
+settings_path = sys.argv[1]
+with open(settings_path, 'r') as f:
+    settings = json.load(f)
+
+if 'mcpServers' in settings and 'crw-mcp' in settings['mcpServers']:
+    del settings['mcpServers']['crw-mcp']
+    with open(settings_path, 'w') as f:
+        json.dump(settings, f, indent=2)
+    print('v Removed MCP server from settings.json')
+else:
+    print('  MCP server not found in settings.json (already removed)')
+PY
+fi
+
+echo ""
+echo "v fastCRW extension uninstalled."
+echo "  Core Claude SEO skills are unchanged."

--- a/tests/test_extension_installer_injection.py
+++ b/tests/test_extension_installer_injection.py
@@ -25,6 +25,7 @@ INSTALLERS = {
     "extensions/dataforseo/install.sh": 4,  # settings, username, password, field_config
     "extensions/firecrawl/install.sh": 2,   # settings, api_key
     "extensions/banana/install.sh": 2,      # settings, api_key
+    "extensions/crw/install.sh": 3,         # settings, api_key, api_url
 }
 
 _HEREDOC_RE = re.compile(r"<<'PY'\n(.*?)\nPY\n", re.DOTALL)


### PR DESCRIPTION
## What
Adds **fastCRW** as a web scrape/search provider alongside the existing Firecrawl integration — additive only, Firecrawl untouched.

## Why

[fastCRW](https://fastcrw.com) is a faster, more open web-scraping engine that outperforms Firecrawl on Firecrawl's own benchmark dataset and runs 100% locally with no cloud dependencies.

**Benchmarks (Firecrawl's own dataset):** truth-recall 63.74% vs 56.04%; median latency p50 ~1.9 s vs ~2.3 s.

**Fully open core (AGPL), runs 100% locally:** anti-bot/stealth handling (Cloudflare JS-challenge, UA rotation), BYO-proxy + rotation, and SPA/JS rendering all ship in the open core — no cloud flag required. Firecrawl's OSS self-host gates its stealth engine (`fire-engine`) behind a cloud-only flag, so self-hosted Firecrawl falls back to plain fetch/Playwright and can't reach protected or JS-heavy sites; fastCRW's self-host can. Single ~8MB Rust binary, ~6 MB RAM, no multi-service stack.

**Search:** crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds a quality layer: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / google scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable.

**Pricing:** flat (1 credit = 1 page; no 4× stealth surcharge, no billed-on-failure).

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported. I maintain the integration and can provide free credits to evaluate.

Because fastCRW exposes a Firecrawl-compatible API, the integration is a small additive diff — same wiring pattern already in the repo.
