### PR TITLE
chore(public): rebrand marketplace to agricidaniel-claude-seo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "ai-marketing-hub-claude-seo",
+  "name": "agricidaniel-claude-seo",
   "owner": {
-    "name": "AI Marketing Hub"
+    "name": "AgriciDaniel"
   },
   "metadata": {
     "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 7 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse). v2 adds shared headless rendering, QRG-aligned content quality gates, LCP subparts via CrUX, IndexNow, four Schema.org generators, AI Share-of-Voice tracking, parasite-SEO risk scanning, multi-platform portability, and a hardened SSRF + DNS-rebinding safety layer."


### PR DESCRIPTION
Public-only branding commit (lives on origin/main, not aimh). Sets the marketplace name + owner to the public identity so /plugin marketplace add AgriciDaniel/claude-seo installs claude-seo@agricidaniel-claude-seo with no ai-marketing-hub slug on the public repo. Private keeps its own name for the Pro early-access marketplace. See docs/WORKFLOW-public-private.md.

## Summary

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [x] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change
