### PR TITLE
fix: broken skill references, stale README/doc figures, Windows & CI portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ MIT License. See [LICENSE](LICENSE) for details.
 
 ## Contributing
 
-Contributions welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting PRs. The project enforces a per-PR audit gate covering manifest consistency (14 assertions), the test suite (326 passing), and an 8-dimension security review before any merge to `main`.
+Contributions welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting PRs. The project enforces a per-PR audit gate covering manifest consistency (15 assertions), the test suite (326 passing), and an 8-dimension security review before any merge to `main`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Most SEO tools treat AI search as a separate optimization discipline. Claude SEO
 
 ## Community Contributors
 
-v1.9.0 includes contributions from the [AI Marketing Hub](https://www.skool.com/ai-marketing-hub) Pro Hub Challenge:
+The following community contributions, first shipped in v1.9.0, came from the [AI Marketing Hub](https://www.skool.com/ai-marketing-hub) Pro Hub Challenge:
 
 | Contributor | Contribution |
 |------------|-------------|

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ v2.0.0 is the largest release in the plugin's history. Six build phases, all shi
 - **Phase E: AI search reframing and 5 new MCP extensions.** Ahrefs, SE Ranking (AI Share-of-Voice), Profound (LLM citation tracker), Bing Webmaster plus IndexNow, Unlighthouse. Plus the parasite-SEO risk scanner per Google's November 2024 [site reputation abuse policy](https://developers.google.com/search/blog/2024/11/site-reputation-abuse-update).
 - **Phase F: Local, international, and privacy polish.** Google Business Profile deprecation linter (chat field, `.business.site` URLs, Q&A), DMA consent-mode-v2 click-through diagnostic, machine-translation QA flag per January 2025 QRG.
 
-Test coverage: 248 → 271 (a 5.4× increase over the v1.9.9 baseline). 83 SSRF and DNS-rebinding bypass tests close the full obfuscated-IPv4, FQDN-trailing-dot, and redirect-rebinding bypass classes. Full migration notes and breaking changes: [docs/MIGRATION-v1-to-v2.md](docs/MIGRATION-v1-to-v2.md).
+Test coverage: 326 tests (an 8.4× increase over the v1.9.9 baseline of 39). 83 SSRF and DNS-rebinding bypass tests close the full obfuscated-IPv4, FQDN-trailing-dot, and redirect-rebinding bypass classes. Full migration notes and breaking changes: [docs/MIGRATION-v1-to-v2.md](docs/MIGRATION-v1-to-v2.md).
 
 ## Limitations
 

--- a/agents/seo-backlinks.md
+++ b/agents/seo-backlinks.md
@@ -66,8 +66,8 @@ across remaining factors. Always note which factors were scored and which were s
 
 ## Cross-Skill Delegation
 
-- For toxic link patterns beyond basic Moz Spam Score, load `references/backlink-quality.md`
-- For anchor text industry benchmarks, load `references/backlink-quality.md`
+- For toxic link patterns beyond basic Moz Spam Score, load `skills/seo/references/backlink-quality.md`
+- For anchor text industry benchmarks, load `skills/seo/references/backlink-quality.md`
 - Do NOT duplicate seo-content analysis. Recommend `/seo content <url>` for E-E-A-T.
 - Do NOT duplicate seo-technical analysis. Recommend `/seo technical <url>` for crawlability.
 

--- a/data/google-updates.json
+++ b/data/google-updates.json
@@ -33,7 +33,7 @@
       "notes": "Helpful Content System merged into core ranking; new spam policies for scaled content, site reputation, and expired domain abuse."
     },
     {
-      "date": "2024-03-05",
+      "date": "2024-03-12",
       "name": "INP replaces FID",
       "kind": "cwv",
       "source": "https://web.dev/articles/inp",

--- a/docs/WORKFLOW-public-private.md
+++ b/docs/WORKFLOW-public-private.md
@@ -150,12 +150,12 @@ upgrade.
 | Letting `aimh/main` lag behind `origin/main` | Always push to `aimh` first, then `origin` on release |
 | Confusing `aimh/v2` with `origin/v2` | `origin` should never have an unreleased `v2` branch |
 
-## State at the time of writing (2026-05-25)
+## State at the time of writing (2026-06-20)
 
-- v2.0.0 is **released to public**. Latest tag on both remotes: `v2.0.0`.
+- v2.2.0 is **released to public**. Latest tag on both remotes: `v2.2.0`.
 - `aimh/main` = shared canonical (public-first README, private marketplace name).
 - `origin/main` = `aimh/main` + the public-branding commit (public marketplace name).
-- `v2.0.0` tag points at each repo's own HEAD: `origin`'s tag includes the
+- The latest release tag points at each repo's own HEAD: `origin`'s tag includes the
   branding commit, `aimh`'s does not (see "Public-branding divergence" above).
 - `aimh/v2` tracks the shared canonical for ongoing v2.x work.
 

--- a/scripts/google_report.py
+++ b/scripts/google_report.py
@@ -28,15 +28,20 @@ try:
     import matplotlib.pyplot as plt
     import matplotlib.patches as mpatches
     import numpy as np
-except ImportError:
-    print("Error: matplotlib required. Install with: pip install matplotlib", file=sys.stderr)
-    sys.exit(1)
+    _MISSING_DEP = None
+except Exception:
+    # Broad except: a broken numpy ABI surfaces as ImportError, missing native
+    # libs as OSError — any failure means charts are unavailable, not a crash.
+    matplotlib = plt = mpatches = np = None
+    _MISSING_DEP = "matplotlib required. Install with: pip install matplotlib"
 
 try:
     from weasyprint import HTML
-except ImportError:
-    print("Error: weasyprint required. Install with: pip install weasyprint", file=sys.stderr)
-    sys.exit(1)
+except Exception:
+    # WeasyPrint raises OSError (not ImportError) when its native libs are absent.
+    HTML = None
+    if _MISSING_DEP is None:
+        _MISSING_DEP = "weasyprint required. Install with: pip install weasyprint"
 
 
 # ─── Brand Colors ────────────────────────────────────────────────────────────
@@ -112,7 +117,8 @@ def _setup_matplotlib():
     })
 
 
-_setup_matplotlib()
+if plt is not None:
+    _setup_matplotlib()
 
 
 # ─── Chart Functions ─────────────────────────────────────────────────────────
@@ -2600,6 +2606,12 @@ def main():
     parser.add_argument("--json", "-j", action="store_true", help="Output metadata as JSON")
 
     args = parser.parse_args()
+
+    # Hard-fail at run time (not import time) when the report toolchain is absent,
+    # so importing this module for tests/inspection never aborts collection.
+    if _MISSING_DEP is not None:
+        print(f"Error: {_MISSING_DEP}", file=sys.stderr)
+        sys.exit(1)
 
     # Load data
     if args.data:

--- a/scripts/seo_updates.py
+++ b/scripts/seo_updates.py
@@ -6,10 +6,9 @@ Reads ``data/google-updates.json`` and surfaces filtered views of the
 confirmed Google ranking / spam / QRG / product / schema updates
 since March 2024. Every entry cites a Google-owned URL.
 
-The companion file lists *unverified* third-party claims separately
-(e.g. the gap-analysis-flagged "March 2026 core update"). Those entries
-are explicitly NOT used to drive recommendations until they are
-confirmed against ``status.search.google.com``.
+The companion file can list *unverified* third-party claims separately.
+Those entries are explicitly NOT used to drive recommendations until they
+are confirmed against ``status.search.google.com``.
 
 Usage::
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -118,7 +118,7 @@ Analyze:
 - Links from thin content pages (<100 words)
 - Excessive links from a single domain (>50 backlinks from 1 domain)
 
-Load `references/backlink-quality.md` for the full 30 toxic patterns and disavow criteria.
+Load `skills/seo/references/backlink-quality.md` for the full 30 toxic patterns and disavow criteria.
 
 ### 5. Top Pages by Backlinks
 

--- a/skills/seo-schema/SKILL.md
+++ b/skills/seo-schema/SKILL.md
@@ -37,7 +37,7 @@ metadata:
 
 ## Schema Type Status (as of May 2026)
 
-Read `references/schema-types.md` for the full list. Key rules:
+Read `skills/seo/references/schema-types.md` for the full list. Key rules:
 
 ### ACTIVE (recommend freely):
 Organization, LocalBusiness, SoftwareApplication, WebApplication, Product (with Certification markup as of April 2025), ProductGroup, Offer, Service, Article, BlogPosting, NewsArticle, Review, AggregateRating, BreadcrumbList, WebSite, WebPage, Person, ProfilePage, ContactPage, VideoObject, ImageObject, Event, JobPosting, Course, DiscussionForumPosting

--- a/skills/seo-sxo/references/page-type-taxonomy.md
+++ b/skills/seo-sxo/references/page-type-taxonomy.md
@@ -80,8 +80,7 @@ moderate ad density.
 
 **Content structure:** Problem statement > Solution overview > How it works > Feature deep-dives > Social proof > CTA > FAQ.
 
-**Required elements:** FAQPage or HowTo schema combined with product schema,
-both educational and commercial CTAs, clear value proposition.
+**Required elements:** Product/Service schema combined with educational and commercial CTAs and a clear value proposition. A FAQ section still aids AI/entity signals, but FAQPage no longer yields a rich result (retired May 7 2026) and HowTo rich results were removed (Sept 2023) — don't treat either as a SERP-feature lever.
 
 **Common mismatches:**
 - Pure Blog Post missing product integration (severity: HIGH)

--- a/skills/seo-sxo/references/wireframe-templates.md
+++ b/skills/seo-sxo/references/wireframe-templates.md
@@ -47,7 +47,7 @@ Missing from SERP expectations:
 <section class="how-it-works"> 3-step process with numbered icons </section>
 <section class="testimonial"> Quote + photo + name + title + company </section>
 <section class="pricing"> 2-3 tiers, recommended highlighted, annual toggle </section>
-<section class="faq"> 5-7 PAA questions, FAQPage schema </section>
+<section class="faq"> 5-7 PAA questions, FAQPage schema (AI/entity signal; no rich result since May 2026) </section>
 <section class="final-cta"> Repeat hero CTA with urgency </section>
 ```
 

--- a/tests/test_google_report_full_audit.py
+++ b/tests/test_google_report_full_audit.py
@@ -6,6 +6,13 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
+# Report generation needs the chart/PDF toolchain; skip cleanly where it is
+# unavailable (e.g. a Windows env with a NumPy-incompatible matplotlib) rather
+# than aborting collection for the whole suite.
+pytest.importorskip("matplotlib")
+pytest.importorskip("weasyprint")
 
 _SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
 if _SCRIPTS not in sys.path:

--- a/tests/test_manifest_consistency.py
+++ b/tests/test_manifest_consistency.py
@@ -48,7 +48,7 @@ def _extract_count(text: str, unit: str) -> int:
 
 def test_plugin_json_skill_count_matches_disk():
     """plugin.json description's 'N sub-skills' claim must equal skills/ dir count."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     claimed = _extract_count(plugin["description"], "sub-skills")
     actual = _count_skill_dirs()
     assert claimed == actual, (
@@ -60,13 +60,13 @@ def test_plugin_json_skill_count_matches_disk():
 
 def test_plugin_json_description_fits_registry_limit():
     """plugin.json description must stay below the Claude plugin registry limit."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     assert len(plugin["description"]) < 500
 
 
 def test_plugin_json_subagent_count_matches_disk():
     """plugin.json description's 'N sub-agents' claim must equal agents/ count."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     claimed = _extract_count(plugin["description"], "sub-agents")
     actual = _count_agent_files()
     assert claimed == actual, (
@@ -78,8 +78,8 @@ def test_plugin_json_subagent_count_matches_disk():
 
 def test_marketplace_json_skill_count_matches_plugin_json():
     """marketplace.json plugin entry must claim the same skill count as plugin.json."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
-    marketplace = json.loads(MARKETPLACE_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    marketplace = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
     plugin_count = _extract_count(plugin["description"], "sub-skills")
     market_count = _extract_count(
         marketplace["plugins"][0]["description"], "sub-skills"
@@ -93,8 +93,8 @@ def test_marketplace_json_skill_count_matches_plugin_json():
 
 def test_marketplace_json_subagent_count_matches_plugin_json():
     """marketplace.json plugin entry must claim the same sub-agent count as plugin.json."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
-    marketplace = json.loads(MARKETPLACE_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    marketplace = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
     plugin_count = _extract_count(plugin["description"], "sub-agents")
     market_count = _extract_count(
         marketplace["plugins"][0]["description"], "sub-agents"
@@ -108,12 +108,12 @@ def test_marketplace_json_subagent_count_matches_plugin_json():
 
 def test_canonical_phrasing_in_user_visible_docs():
     """README, CLAUDE.md, AGENTS.md must reference the canonical sub-skills count."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     canonical_count = _extract_count(plugin["description"], "sub-skills")
     target_phrase = f"{canonical_count} sub-skills"
     for filename in ["README.md", "CLAUDE.md", "AGENTS.md"]:
         path = REPO_ROOT / filename
-        head = "\n".join(path.read_text().splitlines()[:120])
+        head = "\n".join(path.read_text(encoding="utf-8").splitlines()[:120])
         assert target_phrase in head, (
             f"{filename} does not reference '{target_phrase}' in its first "
             f"120 lines. Update it to match plugin.json's canonical phrasing."
@@ -122,8 +122,8 @@ def test_canonical_phrasing_in_user_visible_docs():
 
 def test_version_triangulation():
     """plugin.json version must equal CITATION.cff version."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
-    citation_text = CITATION_CFF.read_text()
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    citation_text = CITATION_CFF.read_text(encoding="utf-8")
     citation_match = re.search(r"^version:\s*(\S+)", citation_text, re.MULTILINE)
     assert citation_match, "CITATION.cff has no 'version:' line"
     plugin_version = plugin["version"]
@@ -141,8 +141,8 @@ def test_pyproject_version_matches_plugin_json():
     1.9.8. The original triangulation test only covered CITATION.cff,
     so pyproject.toml drift slipped past CI. This guard closes that gap.
     """
-    plugin = json.loads(PLUGIN_JSON.read_text())
-    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text()
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     pyproject_match = re.search(
         r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE
     )
@@ -163,10 +163,10 @@ def test_install_scripts_default_tag_matches_plugin_version():
     Manual-install users via curl | bash got 8 versions stale. This guard
     forces the default tag to track plugin.json on every release.
     """
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     expected_tag = f"v{plugin['version']}"
 
-    sh_text = (REPO_ROOT / "install.sh").read_text()
+    sh_text = (REPO_ROOT / "install.sh").read_text(encoding="utf-8")
     sh_match = re.search(
         r'REPO_TAG="\$\{CLAUDE_SEO_TAG:-([^}]+)\}"', sh_text
     )
@@ -178,7 +178,7 @@ def test_install_scripts_default_tag_matches_plugin_version():
         f"Bump install.sh's CLAUDE_SEO_TAG default on every release."
     )
 
-    ps_text = (REPO_ROOT / "install.ps1").read_text()
+    ps_text = (REPO_ROOT / "install.ps1").read_text(encoding="utf-8")
     ps_match = re.search(r"else\s*\{\s*'([^']+)'\s*\}", ps_text)
     assert ps_match, "install.ps1 has no recognizable RepoTag default"
     ps_tag = ps_match.group(1)
@@ -204,7 +204,7 @@ def test_orchestrator_sub_skills_list_matches_disk():
     specialized" claims and the list included seo-firecrawl (extension-only). This
     guard closes that gap.
     """
-    text = (REPO_ROOT / "skills" / "seo" / "SKILL.md").read_text()
+    text = (REPO_ROOT / "skills" / "seo" / "SKILL.md").read_text(encoding="utf-8")
     section = _extract_section(text, "Sub-Skills")
     listed_list = re.findall(r"^\d+\.\s+\*\*(seo-[a-z-]+)\*\*", section, re.MULTILINE)
     assert len(listed_list) == len(set(listed_list)), (
@@ -234,7 +234,7 @@ def test_orchestrator_subagents_list_matches_disk():
     the Subagents list was missing seo-flow (file on disk) and included seo-firecrawl
     (no agent file on disk).
     """
-    text = (REPO_ROOT / "skills" / "seo" / "SKILL.md").read_text()
+    text = (REPO_ROOT / "skills" / "seo" / "SKILL.md").read_text(encoding="utf-8")
     section = _extract_section(text, "Subagents")
     listed_list = re.findall(r"^- `(seo-[a-z-]+)`", section, re.MULTILINE)
     assert len(listed_list) == len(set(listed_list)), (
@@ -279,7 +279,7 @@ def test_skill_metadata_versions_match_plugin_json():
     # Each entry: skill name -> expected literal version string.
     COMMUNITY_OVERRIDES = {"seo-content-brief": "1.0.0"}
 
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     expected_default = plugin["version"]
     errors = []
 
@@ -289,7 +289,7 @@ def test_skill_metadata_versions_match_plugin_json():
     for skill_md in candidates:
         skill_name = skill_md.parent.name
         rel = skill_md.relative_to(REPO_ROOT)
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         frontmatter = _extract_frontmatter(text)
         if not frontmatter:
             errors.append(f"{rel} has no YAML frontmatter block")
@@ -317,8 +317,8 @@ def test_marketplace_metadata_and_author_parity():
     guard so marketplace.json metadata.description + plugin entry author stay in sync
     with plugin.json.
     """
-    plugin = json.loads(PLUGIN_JSON.read_text())
-    mp = json.loads(MARKETPLACE_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
+    mp = json.loads(MARKETPLACE_JSON.read_text(encoding="utf-8"))
 
     desc = mp["metadata"]["description"]
     desc_sub_skills = re.search(r"(\d+)\s+sub-skills", desc)
@@ -365,7 +365,7 @@ def test_marketplace_metadata_and_author_parity():
 
 def test_canonical_math_adds_up():
     """The canonical phrasing's parenthetical breakdown must sum to the headline count."""
-    plugin = json.loads(PLUGIN_JSON.read_text())
+    plugin = json.loads(PLUGIN_JSON.read_text(encoding="utf-8"))
     desc = plugin["description"]
     headline_match = re.search(r"(\d+)\s+sub-skills\s+\(([^)]+)\)", desc)
     assert headline_match, (
@@ -415,7 +415,7 @@ def test_reference_files_have_at_least_one_link():
     # Reference files can cite each other (e.g. via [[wikilink]]).
     search_paths += ref_files
 
-    text_by_path = {p: p.read_text() for p in search_paths}
+    text_by_path = {p: p.read_text(encoding="utf-8") for p in search_paths}
 
     orphans = []
     for ref in ref_files:


### PR DESCRIPTION
## Summary

Three small, self-contained fix commits found while auditing the v2.2.0 tree. No changes to SEO logic or command surface — these correct broken reference paths, stale documentation figures, and two portability issues (Windows, and when the optional report toolchain is absent). Linux CI masks the Windows issues, so these are easy to miss.

## Commits

### 1. Broken skill reference paths — `34554b0`
Three skills/agents told the model to read `references/*.md` via bare paths that don't resolve from a sub-skill's location (same broken-reference class the v2.2.0 changelog closed for `/seo local` and `/seo maps`):
- `skills/seo-schema/SKILL.md` → `references/schema-types.md`
- `skills/seo-backlinks/SKILL.md` → `references/backlink-quality.md` (line 263 of the *same* file already uses the correct path)
- `agents/seo-backlinks.md` (×2)

All repointed to the resolvable `skills/seo/references/...` location. Left `skills/seo/SKILL.md`'s relative `references/schema-types.md` untouched — it's the orchestrator and resolves correctly.

Also in this commit:
- `data/google-updates.json`: the `INP replaces FID` entry was dated `2024-03-05` (copied from the adjacent core-update entry); corrected to `2024-03-12`, the canonical date used in 11+ other files.
- `README.md`: test-coverage line `248 -> 271 (a 5.4x increase)` contradicted the `326` badge; updated to `326`.

### 2. Windows-portable manifest tests + stale figures — `ee23fa1`
- `tests/test_manifest_consistency.py`: added `encoding="utf-8"` to all 23 `read_text()` calls. 6 guards crashed with `UnicodeDecodeError` under Windows cp1252 (skill-version, install-tag, orchestrator sub-skill/agent lists, canonical-phrasing, reference-link). Verified: 6 failed / 9 passed -> 15 passed.
- `README.md`: "manifest consistency (14 assertions)" -> "15" (15 `test_` functions on disk).
- `docs/WORKFLOW-public-private.md`: refreshed the stale `v2.0.0` "state at the time of writing" block to `v2.2.0`; made the tag-mechanism line version-agnostic.
- `skills/seo-sxo/references/{page-type-taxonomy,wireframe-templates}.md`: corrected FAQPage/HowTo guidance the v2.1.0 FAQ sweep missed (FAQ rich results retired May 7 2026; HowTo removed Sept 2023) — kept FAQ as an AI/entity signal, dropped the "Required"/rich-result framing.

### 3. Import-safe `google_report.py` — `4415b6b`
`scripts/google_report.py` called `sys.exit(1)` at import when matplotlib/weasyprint were unavailable, aborting collection of the entire test suite (one collection error -> Interrupted). Fixed:
- Optional imports degrade to `None` (broad `except`: a broken numpy ABI surfaces as `ImportError`, missing native libs as `OSError`).
- The module-level `_setup_matplotlib()` call is guarded with `if plt is not None`.
- The hard-fail moved into `main()`, so `--help` and importing the module work without the toolchain.
- `tests/test_google_report_full_audit.py`: `importorskip` so the test skips cleanly where the toolchain is absent.

Plus minor: `scripts/seo_updates.py` docstring dropped a now-promoted "unverified" example; README Community Contributors reworded to past-tense.

## Testing
- `python -m pytest tests/test_manifest_consistency.py` -> 15 passed (was 6 failed / 9 passed on Windows).
- Full suite now collects and runs to completion (previously aborted at collection on a box without a working matplotlib). Remaining failures on my Windows machine are environment-only (bash installers, executable bits, POSIX file permissions, network) and pass on Linux CI. No new failures introduced.
