### PR TITLE
Fix: OAuth token save crashes on Windows (os.fchmod is Unix-only)

### DIFF
--- a/scripts/google_auth.py
+++ b/scripts/google_auth.py
@@ -238,7 +238,8 @@ def _save_oauth_token(token_data: dict):
     # os.fdopen takes ownership of fd — it closes the fd whether the
     # write succeeds or raises, so there is no fd-leak path here.
     try:
-        os.fchmod(fd, 0o600)
+        if hasattr(os, "fchmod"):  # fchmod is Unix-only; absent on Windows
+            os.fchmod(fd, 0o600)
     except OSError:
         pass  # FS may not support fchmod (e.g. some Windows filesystems)
     with os.fdopen(fd, "w") as f:


### PR DESCRIPTION
## Problem
`_save_oauth_token()` in `scripts/google_auth.py` calls `os.fchmod(fd, 0o600)`. On Windows `os.fchmod` does **not exist**, so the call raises `AttributeError` — which is **not** caught by the surrounding `except OSError`. The exception propagates before `os.fdopen(...).write()` runs, leaving an **empty** `oauth-token.json` and making `--auth` fail on Windows.

Observed error during `google_auth.py --auth`:
```
Error exchanging authorization code: module 'os' has no attribute 'fchmod'
```
(token file ends up empty; refresh/login broken on Windows.)

## Fix
Guard the call with `hasattr(os, "fchmod")` so non-POSIX platforms simply skip it and proceed to write the token. POSIX behaviour is unchanged (fchmod still enforces 0o600), and `_chmod_quiet()` already set 0o600 on the file beforehand.

```python
try:
    if hasattr(os, "fchmod"):  # fchmod is Unix-only; absent on Windows
        os.fchmod(fd, 0o600)
except OSError:
    pass
```

Verified: `--auth` now writes a valid token with refresh_token on Windows 11 (Python 3.12); unchanged on POSIX.