### PR TITLE
docs: add missing content-brief and flow commands to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ integration + 2 extension mirrors), and 50 Python execution scripts.
 | `/seo page <url>` | Deep single-page analysis |
 | `/seo technical <url>` | Technical SEO audit (9 categories) |
 | `/seo content <url>` | E-E-A-T and content quality analysis |
+| `/seo content-brief <topic>` | Detailed content brief: keywords, outline, internal links |
 | `/seo schema <url>` | Schema.org detection, validation, generation |
 | `/seo sitemap <url>` | XML sitemap analysis or generation |
 | `/seo images <url>` | Image SEO: on-page audit, SERP analysis, file optimization |
@@ -87,6 +88,7 @@ integration + 2 extension mirrors), and 50 Python execution scripts.
 | `/seo dataforseo [cmd]` | Live SEO data via DataForSEO (extension) |
 | `/seo image-gen [use-case]` | AI image generation for SEO assets (extension) |
 | `/seo firecrawl [cmd] <url>` | Full-site crawling and site mapping (extension) |
+| `/seo flow [stage]` | FLOW framework prompts (CC BY 4.0, evidence-led) |
 
 ## Using with Cursor / Cursor Cloud
 


### PR DESCRIPTION
## Summary
- AGENTS.md's Quick Reference table was missing `/seo content-brief` and `/seo flow`, both of which are documented in README.md and back real skills (`skills/seo-content-brief`, `skills/seo-flow`).
- Adds the two missing rows so AGENTS.md (used by Cursor/Antigravity) stays in parity with README.md.

## Test plan
- [x] Confirmed both commands exist in README.md''s Commands table
- [x] Confirmed backing skill directories exist (`skills/seo-content-brief/`, `skills/seo-flow/`)
- [x] Diff is a documentation-only, additive change (no code/behavior affected)