### PR TITLE
fix: extract JSON-LD blocks in full before --json truncation

### DIFF
--- a/agents/seo-schema.md
+++ b/agents/seo-schema.md
@@ -66,9 +66,11 @@ Provide:
 - Missing opportunities
 - Generated JSON-LD for implementation
 
-## Fetching pages (v2.0.0)
+## Fetching pages (v2.1.0)
 
-Use `python3 scripts/render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py` — never call `requests.get` directly on user-supplied URLs.
+Use `python3 scripts/render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py` — never call `requests.get` directly on user-supplied URLs.
+
+**`structured_data_blocks` is your primary source for detection.** It is extracted from the full, untruncated HTML before the `content`/`raw_content` fields get character-capped, so it always contains every JSON-LD block on the page — you do not need `--output` or a full-HTML re-fetch just to rule out a block hidden past the truncation cutoff. Each entry is `{"valid": true, "data": {...parsed JSON-LD...}}` or, for malformed markup, `{"valid": false, "raw": "...", "error": "..."}` — treat invalid entries as validation findings, not missing data. Only fall back to `--output` / `render_page.render_page()` for full raw/rendered HTML when you specifically need to compare `raw_content` vs `content` for SPA client-side-injection detection (see below), not for routine JSON-LD presence checks.
 
 ## Persistence Contract
 

--- a/scripts/render_page.py
+++ b/scripts/render_page.py
@@ -133,6 +133,36 @@ _TAG_STRIP = re.compile(r"<[^>]+>")
 _WHITESPACE = re.compile(r"\s+")
 
 
+_JSON_LD_BLOCK = re.compile(
+    r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _extract_json_ld(html: Optional[str]) -> list[dict]:
+    """Pull every JSON-LD script block out of full HTML, in full.
+
+    Runs on the untruncated content so the --json summary's character
+    limit (see _cli) can never silently hide a structured-data block from
+    a schema-focused agent. Malformed blocks are still reported (as raw
+    text) rather than dropped, so a schema agent can flag invalid JSON-LD
+    instead of missing it entirely.
+    """
+    if not html:
+        return []
+    blocks: list[dict] = []
+    for raw in _JSON_LD_BLOCK.findall(html):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            parsed = json.loads(raw)
+            blocks.append({"valid": True, "data": parsed})
+        except json.JSONDecodeError as exc:
+            blocks.append({"valid": False, "raw": raw, "error": str(exc)})
+    return blocks
+
+
 def _is_spa(raw_html: Optional[str]) -> bool:
     """Heuristic SPA detector. Conservative: any positive signal flips True."""
     if not raw_html:
@@ -377,6 +407,12 @@ def _cli() -> None:
 
     if args.json:
         summary = dict(res)
+        # Structured-data blocks (JSON-LD) are extracted from the full,
+        # untruncated content BEFORE truncation below, so a schema check
+        # never has to re-fetch full HTML just to rule out a block that
+        # got cut off by the character limit. See _extract_json_ld().
+        full_content = summary.get("content") or summary.get("raw_content") or ""
+        summary["structured_data_blocks"] = _extract_json_ld(full_content)
         # JSON-safe truncation so the CLI is usable from agents without
         # piping megabytes of HTML across stdio.
         for field, limit in (


### PR DESCRIPTION
## Problem

  `render_page.py --json` truncates `content`/`raw_content` at 500/200 characters for CLI usability. That truncation is purely character-based, with no awareness of document structure — on any real page, it
  can (and does) cut off before a `<script type="application/ld+json">` block.

  `seo-schema` (and any other schema-focused check) has no way to distinguish "no JSON-LD on this page" from "JSON-LD exists but got truncated." The only way to be certain is a full HTML re-fetch
  (`--output` + read, or `--mode always`), which on a real page can mean pulling tens of thousands of characters into the agent's context just to answer a yes/no structured-data question.

  Measured on a real page (a Next.js SSR homepage, ~81KB of raw HTML): the full-HTML fallback path costs **81,157 characters** for something a targeted extraction could answer in **~6,000**.

  ## Fix

  `_extract_json_ld()` runs on the **full, untruncated** content *before* the truncation loop and pulls out every `<script type="application/ld+json">` block, in full, regardless of where it falls in the
  document. The result is added to the `--json` summary as a new `structured_data_blocks` field:

  ```json
  "structured_data_blocks": [
    { "valid": true, "data": { "@context": "...", "@type": "Person", ... } },
    { "valid": false, "raw": "...", "error": "Expecting ',' delimiter: line 3 column 12" }
  ]
  ```

  Malformed blocks are kept (not dropped) as `{valid: false, raw, error}` so a schema agent can flag broken markup as a finding instead of silently missing it.

  `seo-schema`'s "Fetching pages" instructions are updated to treat `structured_data_blocks` as the primary detection source, only falling back to full HTML for the SPA client-side-injection comparison
  (`raw_content` vs `content`) that a different check already needs.

  ## Measured before/after
  
  Same subagent (`seo-schema`), same real page, one run per branch, both asked to report their own fetch methodology:

  | | Before (main) | After (this patch) |
  |---|---|---|
  | Subagent tokens | 27,957 | 26,198 |
  | Tool calls | 9 | 6 |
  | Network requests to the audited page | 3 | 1 |
  | Certainty on JSON-LD presence | Yes, via a self-written extraction workaround | Yes, directly from the summary |

  The token delta is modest here (~6%) because the unpatched agent happened to improvise an efficient workaround on its own (write full HTML to a file, extract just the `<script>` blocks with its own
  script) rather than reading the raw 81KB into context. That's not guaranteed behavior — a different model, a smaller agent, or a future revision could just as easily `Read()` the full file instead. The
  patch makes the efficient path the *only* path, removes the need for that improvisation, and consistently cuts network requests to the audited site from 3 to 1.

  ## Scope

  Two files:
  - `scripts/render_page.py`: add `_extract_json_ld()` + `structured_data_blocks` in the `--json` output path. No change to `render_page()`'s return shape or to non-JSON CLI output.
  - `agents/seo-schema.md`: fetching-instructions update pointing at the new field.

  No other agents or skills touched. Backward compatible.
Adds structured_data_blocks to the --json summary: every JSON-LD script tag extracted from the full, untruncated content before the truncation loop runs. Valid blocks are parsed; malformed ones are kept as {valid: false, raw, error} so a schema agent can flag broken markup instead of silently missing it. Measured on morgandutemple.fr: 9,032 chars total JSON output vs 81,157 chars for the full HTML this previously required for certainty -- same detection guarantee, ~89% less content into the agent's context.

Updates seo-schema's fetching instructions to use this field as the primary detection source instead of routinely falling back to full HTML.

## Summary

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change
