### PR TITLE
Force UTF-8 stdout so validate-schema hook doesn't crash on Windows (cp1252)

### DIFF
--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -122,6 +122,15 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
 
 
 def main():
+    # Windows consoles default to cp1252, which cannot encode the status emoji
+    # (U+1F6D1 / U+26A0) printed below -> UnicodeEncodeError crashes the hook the
+    # moment it actually finds a schema issue. Force UTF-8 so it reports cleanly.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
     if len(sys.argv) < 2:
         sys.exit(0)
 


### PR DESCRIPTION
## Problem

On Windows the console defaults to **cp1252**, which can't encode the status emoji (`U+1F6D1` and `U+26A0`) that `hooks/validate-schema.py` prints when it finds schema issues. The moment the validator detects a placeholder or a deprecated `@type` in an HTML file's JSON-LD, it crashes:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f6d1' in position 0: character maps to <undefined>
```

So on Windows the `PostToolUse` hook exits `1` with a traceback exactly when it should be cleanly **blocking** the edit (exit `2`), and the findings never reach the user. Every `Write`/`Edit` that trips the emoji path fails this way.

## Fix

Reconfigure `stdout`/`stderr` to UTF-8 at the top of `main()`, guarded in `try/except` so it's a harmless no-op on streams that don't support it. No other behavior change.

## Testing

Windows 11 + Python 3.12, against an HTML file whose JSON-LD contains `[Business Name]`, `[Phone]`, and `@type: HowTo`.

**Before:** `UnicodeEncodeError`, exit 1.

**After** (exit 2, cleanly blocking):

```
Schema validation ERRORS (blocking):
  - Block 1: Contains placeholder text: [Business Name]
  - Block 1: Contains placeholder text: [Phone]
  - Block 1: @type 'HowTo' is deprecated September 2023
```

Clean and non-HTML files still exit 0 silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
