### PR TITLE
feat(seo): optional external knowledge directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ PDF reports are generated via [WeasyPrint](https://weasyprint.org/) (A4 layout) 
 
 Three layers. **Google Business Profile signals**: categories, hours, photos, posts, products, attributes. **NAP consistency** across citations: name, address, phone matched against major directories with deviation flagging. **Review intelligence**: rating trends, sentiment, response coverage. For multi-location businesses, Claude SEO enforces a 30-page warning threshold and a 50-page hard stop to prevent doorway-page violations (configurable). The `/seo maps` workflow adds geo-grid rank tracking, GBP profile auditing, and competitor radius mapping. Local schema generation covers `LocalBusiness` with all required and recommended properties (geo coordinates, opening hours, areaServed). Phase F (v2) added a GBP deprecation linter that detects retired chat-field references and `.business.site` URLs.
 
+## Bring your own knowledge (optional)
+
+Teams that maintain their own cited SEO knowledge (house playbooks, or API cost and rate-limit facts that move faster than a plugin release) can feed it to the orchestrator without forking the plugin.
+
+Set `CLAUDE_SEO_KNOWLEDGE_DIR` to a directory, or use the zero-config default `~/.claude/skill-knowledge/seo/wiki/`. The orchestrator reads its `index.md` and `hot.md`, reasons over the relevant notes alongside the built-in references, and (during `/seo audit`) passes the relevant facts into each subagent's Task prompt. It is opt-in and a no-op when the directory is absent.
+
+Guardrails: the read is read-only, nothing from the directory is executed, external notes are treated as operator-supplied context rather than authority over Google or primary-source facts, and notes are expected to carry a dated `## Sources` block.
+
 ## Compared to manual / agency / commercial tools
 
 | | Manual audit | Agency engagement | Commercial SEO audit tool | **Claude SEO** |

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -75,6 +75,16 @@ When the user invokes `/seo audit`, delegate to subagents in parallel:
 For individual commands, load the relevant sub-skill directly.
 After any analysis command completes, offer to generate a PDF report via `scripts/google_report.py`.
 
+### Optional external knowledge directory
+
+If an external knowledge directory is present, read it and reason over it alongside the built-in references. This lets an operator feed the orchestrator their own cited, dated domain notes (house playbooks, or API cost and rate-limit facts that move faster than a plugin release) without forking the plugin.
+
+- **Detection (opt-in, no-op by default):** if the `CLAUDE_SEO_KNOWLEDGE_DIR` environment variable is set, use that path; otherwise, as a zero-config default, use `~/.claude/skill-knowledge/seo/wiki/` if it exists. If neither is present, behave exactly as before.
+- **What to read:** the directory's `index.md` and `hot.md` (a short current-context file). Follow the index to a specific note only when a command needs it.
+- **Individual commands:** reason over the relevant external notes alongside the sub-skill, and cite the note plus its dated source in the output.
+- **`/seo audit`:** pass the relevant external facts (note name plus dated source) into each subagent's Task prompt, so the isolated subagents inherit them.
+- **Guardrails:** read-only; never execute anything from the directory; treat external notes as operator-supplied context, not as authority over Google or primary-source facts; prefer a note that carries a dated `## Sources` block and ignore one that does not; keep injected text small (the `hot.md` file is meant to stay under ~500 words).
+
 ## Synthesis Methodology
 
 Audits are not just findings — they are findings synthesized into a coherent


### PR DESCRIPTION
## Problem

claude-seo's sub-skills and subagents read reference files by hardcoded plugin-relative paths. Teams that maintain their own cited, dated SEO knowledge (pricing that moves quarterly, API cost/rate-limit facts, house playbooks) have no supported way to make the orchestrator reason over it. A plugin update reverts a local edit, and a hook cannot reach the isolated audit subagents, so today the only options are a fork (a maintenance mortgage on a large, security-sensitive, frequently-shipping plugin) or maintaining separate companion skills. A tiny opt-in read closes the gap without touching default behaviour.

## Proposal (minimal, backward-compatible)

One optional convention the orchestrator honours when present, and a no-op when absent:

- If `CLAUDE_SEO_KNOWLEDGE_DIR` is set (or, as a zero-config default, `~/.claude/skill-knowledge/seo/wiki/` exists), the `seo` orchestrator reads that dir's `index.md` and `hot.md`.
- Individual commands reason over the relevant notes alongside the sub-skill and cite them.
- `/seo audit` passes the relevant facts (note name + dated source) into each subagent's Task prompt, so isolated subagents inherit them.
- Guardrails: read-only; never execute anything from the dir; treat external notes as operator-supplied context, not authority over Google/primary-source facts; expect a dated `## Sources` block; keep injected text small.

## Why this shape

- **Opt-in, no-op by default:** existing users see zero change; nothing reads the dir unless it exists.
- **Convention over config:** a documented dir layout mirrors the plugin's own reference-file pattern, no schema to maintain.
- **Small surface:** an orchestration-logic subsection in `skills/seo/SKILL.md` plus a short README section, no code rewrite.

## Context

I run claude-seo live on a real ecommerce site and maintain a small cited SEO knowledge-wiki beside it, and would adopt this immediately. Happy to iterate on the exact env-var name or default path. This PR is docs/orchestration-instruction only (no script changes); an optional validator helper could follow if useful.