### PR TITLE
fix: use model: primary instead of hardcoded model: sonnet in all agent files

### DIFF
--- a/agents/seo-backlinks.md
+++ b/agents/seo-backlinks.md
@@ -1,7 +1,7 @@
 ---
 name: seo-backlinks
 description: Backlink profile analyst using free and paid sources. Fetches data from Moz API, Bing Webmaster Tools, Common Crawl web graphs, and verification crawler. Merges multi-source data with confidence-weighted scoring.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep
 ---

--- a/agents/seo-cluster.md
+++ b/agents/seo-cluster.md
@@ -4,7 +4,7 @@ description: >
   Semantic topic clustering analysis using SERP overlap methodology. Expands seed
   keywords, performs pairwise SERP comparison, classifies intent, designs
   hub-and-spoke content architecture, and generates internal link matrices.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: WebSearch, WebFetch, Read, Write, Bash, Glob, Grep
 ---

--- a/agents/seo-content.md
+++ b/agents/seo-content.md
@@ -1,7 +1,7 @@
 ---
 name: seo-content
 description: Content quality reviewer. Evaluates E-E-A-T signals, readability, content depth, AI citation readiness, and thin content detection.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write, Grep
 ---

--- a/agents/seo-dataforseo.md
+++ b/agents/seo-dataforseo.md
@@ -1,7 +1,7 @@
 ---
 name: seo-dataforseo
 description: DataForSEO data analyst. Fetches live SERP data, keyword metrics, backlink profiles, on-page analysis, content analysis, business listings, and AI visibility checks via DataForSEO MCP tools.
-model: sonnet
+model: primary
 maxTurns: 25
 tools: Read, Bash, Write, Glob, Grep
 ---

--- a/agents/seo-drift.md
+++ b/agents/seo-drift.md
@@ -4,7 +4,7 @@ description: >
   SEO drift analysis agent. Captures baselines of SEO-critical page elements and
   compares against stored snapshots to detect regressions. Reports changes with
   severity classification. Only spawned when a drift baseline exists for the URL.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write, Glob, Grep
 ---

--- a/agents/seo-ecommerce.md
+++ b/agents/seo-ecommerce.md
@@ -4,7 +4,7 @@ description: >
   E-commerce SEO analyst. Validates product schema, analyzes Google Shopping and
   Amazon marketplace visibility, identifies pricing gaps, and recommends product
   page optimizations. Spawned when e-commerce site detected during audits.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep
 ---

--- a/agents/seo-flow.md
+++ b/agents/seo-flow.md
@@ -1,7 +1,7 @@
 ---
 name: seo-flow
 description: FLOW framework prompt analyst. Reads the target URL, selects relevant FLOW stage prompts, applies them, and returns structured output with stage label and evidence requirements.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, WebFetch, Glob, Grep
 ---

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -1,7 +1,7 @@
 ---
 name: seo-geo
 description: GEO and AI search specialist. Analyzes AI crawler accessibility, llms.txt compliance, passage-level citability, brand mention signals, and platform-specific optimization for Google AI Overviews, ChatGPT, Perplexity, and Bing Copilot.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -1,7 +1,7 @@
 ---
 name: seo-google
 description: Google SEO API analyst. Fetches CWV field data via CrUX, indexation status via GSC, and organic traffic via GA4 for enriched audit data.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 ---

--- a/agents/seo-image-gen.md
+++ b/agents/seo-image-gen.md
@@ -1,7 +1,7 @@
 ---
 name: seo-image-gen
 description: SEO image analyst. Audits existing OG/social preview images, identifies missing or low-quality images, and creates an image generation plan with prompts for key pages. Does NOT auto-generate images.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Glob, Grep
 ---

--- a/agents/seo-local.md
+++ b/agents/seo-local.md
@@ -1,7 +1,7 @@
 ---
 name: seo-local
 description: Local SEO specialist. Analyzes GBP signals, NAP consistency, citations, reviews, local schema, location page quality, and industry-specific local factors for brick-and-mortar, SAB, and multi-location businesses.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---

--- a/agents/seo-maps.md
+++ b/agents/seo-maps.md
@@ -1,7 +1,7 @@
 ---
 name: seo-maps
 description: Maps intelligence specialist. Geo-grid rank tracking, GBP profile auditing, review intelligence, cross-platform NAP verification, and competitor radius mapping via DataForSEO and free APIs.
-model: sonnet
+model: primary
 maxTurns: 25
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -1,7 +1,7 @@
 ---
 name: seo-performance
 description: Performance analyzer. Measures and evaluates Core Web Vitals and page load performance.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write
 ---

--- a/agents/seo-schema.md
+++ b/agents/seo-schema.md
@@ -1,7 +1,7 @@
 ---
 name: seo-schema
 description: Schema markup expert. Detects, validates, and generates Schema.org structured data in JSON-LD format.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write
 ---

--- a/agents/seo-sitemap.md
+++ b/agents/seo-sitemap.md
@@ -1,7 +1,7 @@
 ---
 name: seo-sitemap
 description: Sitemap architect. Validates XML sitemaps, generates new ones with industry templates, and enforces quality gates for location pages.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write, Glob
 ---

--- a/agents/seo-sxo.md
+++ b/agents/seo-sxo.md
@@ -4,7 +4,7 @@ description: >
   Search Experience Optimization analyst. Performs SERP backwards analysis to detect
   page-type mismatches, derives user stories from intent signals, and scores pages
   from multiple persona perspectives. Identifies why well-optimized content fails to rank.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: Read, Bash, WebFetch, WebSearch, Glob, Grep, Write
 ---

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -1,7 +1,7 @@
 ---
 name: seo-technical
 description: Technical SEO specialist. Analyzes crawlability, indexability, security, URL structure, mobile optimization, Core Web Vitals, and JavaScript rendering.
-model: sonnet
+model: primary
 maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 ---

--- a/agents/seo-visual.md
+++ b/agents/seo-visual.md
@@ -1,7 +1,7 @@
 ---
 name: seo-visual
 description: Visual analyzer. Captures screenshots, tests mobile rendering, and analyzes above-the-fold content using Playwright.
-model: sonnet
+model: primary
 maxTurns: 15
 tools: Read, Bash, Write
 ---


### PR DESCRIPTION
## Problem

All 18 agent files hardcode `model: sonnet` in their frontmatter. This resolves to `claude-sonnet-5`, which may not be available to all users — causing the agent to fail immediately with:

> Agent terminated early due to an API error: There's an issue with the selected model (claude-sonnet-5).

## Fix

Changed `model: sonnet` → `model: primary` in all 18 agent files under `agents/`:

- `agents/seo-technical.md`
- `agents/seo-content.md`
- `agents/seo-schema.md`
- `agents/seo-sitemap.md`
- `agents/seo-performance.md`
- `agents/seo-visual.md`
- `agents/seo-geo.md`
- `agents/seo-local.md`
- `agents/seo-maps.md`
- `agents/seo-google.md`
- `agents/seo-backlinks.md`
- `agents/seo-cluster.md`
- `agents/seo-sxo.md`
- `agents/seo-drift.md`
- `agents/seo-ecommerce.md`
- `agents/seo-flow.md`
- `agents/seo-image-gen.md`
- `agents/seo-dataforseo.md`

`model: primary` adapts to whatever model the user has selected, making the plugin portable across different Claude Code installations and model configurations.

## Impact

- ✅ Fixes the immediate `claude-sonnet-5` not found error
- ✅ Respects the user's chosen model
- ✅ More portable across Claude Code installations
- ✅ No functional change for users who do have sonnet available — `primary` resolves to the same model
- ✅ Aligns with the project's cross-platform goals (documented in `AGENTS.md`)

## Testing

Verified by launching a `seo-technical` agent against a live URL — it completed successfully with `model: primary` after failing with `model: sonnet`.