### PR TITLE
fix(seo-image-gen): point script calls at extensions/banana/scripts/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **seo-image-gen banana script paths (#163).** `presets.py`, `cost_tracker.py`, and `generate.py` were invoked as `scripts/*.py` or `~/.claude/skills/seo-image-gen/scripts/*.py`, neither of which exists. `install.sh` places the banana extension's scripts under `extensions/banana/scripts/` inside the main `seo` skill directory; call sites now point there.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/skills/seo-image-gen/SKILL.md
+++ b/skills/seo-image-gen/SKILL.md
@@ -82,7 +82,7 @@ For every generation request:
 
 If the user mentions a brand or has SEO presets configured:
 ```bash
-python3 scripts/presets.py list
+python3 extensions/banana/scripts/presets.py list
 ```
 Load matching preset and apply as defaults. Also check `references/seo-image-presets.md`
 for SEO-specific preset templates.
@@ -120,7 +120,7 @@ After every successful generation, guide the user on:
 
 Image generation costs money. Be transparent:
 - Show estimated cost before generating (especially for batch)
-- Log every generation: `python3 scripts/cost_tracker.py log --model MODEL --resolution RES --prompt "brief"`
+- Log every generation: `python3 extensions/banana/scripts/cost_tracker.py log --model MODEL --resolution RES --prompt "brief"`
 - Run `cost_tracker.py summary` if user asks about usage
 
 Approximate costs (gemini-3.1-flash):
@@ -146,7 +146,7 @@ Approximate costs (gemini-3.1-flash):
 | API key invalid | New key at https://aistudio.google.com/apikey |
 | Rate limited (429) | Wait 60s, retry. Free tier: ~10 RPM / ~500 RPD |
 | `IMAGE_SAFETY` | Rephrase prompt - see `references/prompt-engineering.md` Safety section |
-| MCP unavailable | Fall back: `python3 scripts/generate.py --prompt "..." --aspect-ratio "16:9"` |
+| MCP unavailable | Fall back: `python3 extensions/banana/scripts/generate.py --prompt "..." --aspect-ratio "16:9"` |
 | Extension not installed | Show install instructions: `./extensions/banana/install.sh` |
 
 ## Cross-Skill Integration

--- a/skills/seo-image-gen/references/seo-image-presets.md
+++ b/skills/seo-image-gen/references/seo-image-presets.md
@@ -123,7 +123,7 @@ preset format (see `references/presets.md` for schema details).
 
 Users can create their own presets:
 ```bash
-python3 ~/.claude/skills/seo-image-gen/scripts/presets.py create my-brand
+python3 ~/.claude/skills/seo/extensions/banana/scripts/presets.py create my-brand
 ```
 
 This creates `~/.banana/presets/my-brand.json` with the full schema.


### PR DESCRIPTION
presets.py, cost_tracker.py, and generate.py live under extensions/banana/scripts/ per install.sh, not scripts/ or ~/.claude/skills/seo-image-gen/scripts/ as previously referenced. Fixes #163.

## Summary

`seo-image-gen`'s SKILL.md and references/seo-image-presets.md invoked the banana extension's scripts at paths that resolve in no install layout. `install.sh` copies extension scripts to `${SKILL_DIR}/extensions/<ext>/scripts/` (i.e. `~/.claude/skills/seo/extensions/banana/scripts/`), and `seo-image-gen` has no `scripts/` directory of its own. Fixed the 4 affected call sites (3 in SKILL.md, 1 in references/seo-image-presets.md) to point at the actual install location. Verified against a real `install.sh` install: `python3 extensions/banana/scripts/presets.py list` now resolves and runs from the skill directory.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change