### PR TITLE
fix(install): mirror shared scripts/ into every sub-skill directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Sub-skill `scripts/*.py` path resolution (#161).** Skill/agent instructions invoke shared scripts (e.g. `render_page.py`) via the relative path `scripts/<name>.py`, which only resolves when the working directory is the invoked skill's own directory. Sub-skills (`seo-audit`, `seo-technical`, etc.) install to their own directory under `~/.claude/skills/<name>/`, separate from the main `seo` skill directory where the shared scripts actually live, so the relative path failed with `[Errno 2] No such file or directory` whenever a sub-skill ran directly. Both installers (`install.sh`, `install.ps1`) now mirror the shared `scripts/` directory into every sub-skill's install directory.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/install.ps1
+++ b/install.ps1
@@ -186,6 +186,20 @@ try {
         $SkillScripts = "$SkillDir\scripts"
         New-Item -ItemType Directory -Force -Path $SkillScripts | Out-Null
         Copy-Item -Recurse -Force "$ScriptsPath\*" $SkillScripts
+
+        # Sub-skills (seo-audit, seo-technical, etc.) install to their own
+        # directory, not $SkillDir. Skill/agent instructions reference
+        # shared scripts via the relative path `scripts\<name>.py`, which
+        # only resolves if the working directory is the invoked skill's own
+        # directory. Mirror the shared scripts into every sub-skill's
+        # directory so that path resolves no matter which skill is active.
+        if (Test-Path $SkillsPath) {
+            Get-ChildItem -Directory $SkillsPath | Where-Object { $_.Name -ne 'seo' } | ForEach-Object {
+                $subScripts = "$env:USERPROFILE\.claude\skills\$($_.Name)\scripts"
+                New-Item -ItemType Directory -Force -Path $subScripts | Out-Null
+                Copy-Item -Recurse -Force "$ScriptsPath\*" $subScripts
+            }
+        }
     }
 
     # Copy hooks

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,20 @@ main() {
     if [ -d "${TEMP_DIR}/claude-seo/scripts" ]; then
         mkdir -p "${SKILL_DIR}/scripts"
         cp -r "${TEMP_DIR}/claude-seo/scripts/"* "${SKILL_DIR}/scripts/"
+
+        # Sub-skills (seo-audit, seo-technical, etc.) install to their own
+        # directory, not ${SKILL_DIR}. Skill/agent instructions reference
+        # shared scripts via the relative path `scripts/<name>.py`, which
+        # only resolves if the working directory is the invoked skill's own
+        # directory. Mirror the shared scripts into every sub-skill's
+        # directory so that path resolves no matter which skill is active.
+        for skill_dir in "${TEMP_DIR}/claude-seo/skills"/*/; do
+            skill_name=$(basename "${skill_dir}")
+            [ "${skill_name}" = "seo" ] && continue
+            target="${HOME}/.claude/skills/${skill_name}/scripts"
+            mkdir -p "${target}"
+            cp -r "${TEMP_DIR}/claude-seo/scripts/"* "${target}/"
+        done
     fi
 
     # Copy hooks


### PR DESCRIPTION
Sub-skills (seo-audit, seo-technical, etc.) install to their own directory under ~/.claude/skills/<name>/, separate from the main seo skill directory where shared scripts (render_page.py, google_auth.py, etc.) actually live. Skill/agent instructions reference these via the relative path scripts/<name>.py, which only resolves when the working directory is the skill's own directory — so any sub-skill invoking a shared script directly failed with "No such file or directory". Fixes #161.

## Summary

Root cause: `install.sh`/`install.ps1` copy shared `scripts/*.py` only into the main `seo` skill directory, but 24 sub-skills each install into their own separate directory with no `scripts/` of their own. Any SKILL.md that runs `python3 scripts/render_page.py ...` (or any other shared script) fails when that sub-skill is the one actually invoked, since the working directory is the sub-skill's own directory, not the main `seo` directory.

Fix: both installers now also copy the shared `scripts/` directory into every sub-skill's install directory (skipping `seo`, which already has them from the main copy step). Verified by simulating the loop against the local repo tree: all 24 sub-skill directories receive `scripts/render_page.py` and the rest of the shared scripts.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change