### PR TITLE
fix(seo-technical,seo-sitemap): discover sitemap beyond /sitemap.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Sitemap discovery only checked `/sitemap.xml` (#142).** `seo-audit`/`seo-technical` reported "no sitemap found" for sites whose sitemap lives at a non-default path (e.g. `/sitemap_index.xml`, the Yoast/RankMath/All in One SEO default on WordPress). Crawlability checks and `seo-sitemap` Mode 1 now fetch `/robots.txt` for an authoritative `Sitemap:` directive first, then probe `/sitemap.xml`, `/sitemap_index.xml`, `/sitemap-index.xml`, and `/wp-sitemap.xml` before reporting a sitemap missing.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -9,7 +9,7 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 You are a Technical SEO specialist. When given a URL or set of URLs:
 
 1. Fetch the page(s) and analyze HTML source
-2. Check robots.txt and sitemap availability
+2. Check robots.txt and sitemap availability: fetch `/robots.txt` first — a `Sitemap:` directive there is authoritative and may point to a non-default filename or path. If robots.txt has no `Sitemap:` line, probe common locations in order until one resolves: `/sitemap.xml`, `/sitemap_index.xml` (Yoast/RankMath/All in One SEO default on WordPress), `/sitemap-index.xml`, `/wp-sitemap.xml` (WordPress core, no SEO plugin). Only report "no sitemap found" after robots.txt has no directive and all of the above 404 or fail to parse as XML.
 3. Analyze meta tags, canonical tags, and security headers
 4. Evaluate URL structure and redirect chains
 5. Assess mobile-friendliness from HTML/CSS analysis

--- a/skills/seo-sitemap/SKILL.md
+++ b/skills/seo-sitemap/SKILL.md
@@ -17,6 +17,13 @@ metadata:
 
 ## Mode 1: Analyze Existing Sitemap
 
+### Discovery
+
+Before concluding a sitemap doesn't exist:
+1. Fetch `/robots.txt` and check for a `Sitemap:` directive — this is authoritative and may point to a non-default filename or path (multiple `Sitemap:` lines are valid for split sitemaps).
+2. If robots.txt has no `Sitemap:` line, probe common locations in order: `/sitemap.xml`, `/sitemap_index.xml` (Yoast/RankMath/All in One SEO default on WordPress), `/sitemap-index.xml`, `/wp-sitemap.xml` (WordPress core, no SEO plugin).
+3. Only report "no sitemap found" once robots.txt has no directive and every location above returns non-200 or fails to parse as XML.
+
 ### Validation Checks
 - Valid XML format
 - URL count <50,000 per file (protocol limit)
@@ -101,7 +108,7 @@ metadata:
 ## Error Handling
 
 - **URL unreachable**: Report the HTTP status code and suggest checking if the site is live
-- **No sitemap found**: Check common locations (/sitemap.xml, /sitemap_index.xml, robots.txt reference) before reporting "not found"
+- **No sitemap found**: Follow the Discovery steps above (robots.txt directive, then common locations) before reporting "not found"
 - **Invalid XML format**: Report specific parsing errors with line numbers
 - **Rate limiting detected**: Back off and report partial results with a note about retry timing
 

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 ### 1. Crawlability
 - robots.txt: exists, valid, not blocking important resources
-- XML sitemap: exists, referenced in robots.txt, valid format
+- XML sitemap: fetch `/robots.txt` first — a `Sitemap:` directive there is authoritative and may live at a non-default path. If none is declared, probe common locations in order before concluding no sitemap exists: `/sitemap.xml`, `/sitemap_index.xml` (Yoast/RankMath/All in One SEO default on WordPress), `/sitemap-index.xml`, `/wp-sitemap.xml` (WordPress core). Validate format on whichever resolves.
 - Noindex tags: intentional vs accidental
 - Crawl depth: important pages within 3 clicks of homepage
 - JavaScript rendering: check if critical content requires JS execution


### PR DESCRIPTION
/seo audit and /seo technical only checked the default /sitemap.xml path and reported "no sitemap found" for sites using a non-default location, most commonly WordPress sites running Yoast, RankMath, or All in One SEO, whose sitemap lives at /sitemap_index.xml. Fixes #142.

## Summary

Crawlability checks (`agents/seo-technical.md`, `skills/seo-technical/SKILL.md`) and `seo-sitemap`'s Mode 1 (`skills/seo-sitemap/SKILL.md`) now fetch `/robots.txt` for an authoritative `Sitemap:` directive first — this is the sitemap protocol's canonical discovery mechanism and can point at any path. If robots.txt has no directive, the instructions now probe `/sitemap.xml`, `/sitemap_index.xml` (Yoast/RankMath/All in One SEO default), `/sitemap-index.xml`, and `/wp-sitemap.xml` (WordPress core) in order before concluding no sitemap exists. `seo-sitemap`'s Error Handling section, which already told the model to check alternates but only as a reactive fallback after already concluding "not found," now points at the new Discovery section instead of duplicating a stale list.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change