### PR TITLE
fix(seo-dataforseo): add mcp__dataforseo__* to agent tools allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **seo-dataforseo agent couldn't call DataForSEO MCP tools (#148).** `tools:` frontmatter in `agents/seo-dataforseo.md` and `extensions/dataforseo/agents/seo-dataforseo.md` omitted `mcp__dataforseo__*`. Claude Code treats an agent's `tools:` field as an exact allowlist, so the agent always reported the MCP tools unavailable and produced no data, even with the DataForSEO MCP installed and connected. Both files now include `mcp__dataforseo__*`.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/agents/seo-dataforseo.md
+++ b/agents/seo-dataforseo.md
@@ -3,7 +3,7 @@ name: seo-dataforseo
 description: DataForSEO data analyst. Fetches live SERP data, keyword metrics, backlink profiles, on-page analysis, content analysis, business listings, and AI visibility checks via DataForSEO MCP tools.
 model: sonnet
 maxTurns: 25
-tools: Read, Bash, Write, Glob, Grep
+tools: Read, Bash, Write, Glob, Grep, mcp__dataforseo__*
 ---
 
 You are a DataForSEO data analyst. When delegated tasks during an SEO audit or analysis:

--- a/extensions/dataforseo/agents/seo-dataforseo.md
+++ b/extensions/dataforseo/agents/seo-dataforseo.md
@@ -1,7 +1,7 @@
 ---
 name: seo-dataforseo
 description: DataForSEO data analyst. Fetches live SERP data, keyword metrics, backlink profiles, on-page analysis, content analysis, business listings, and AI visibility checks via DataForSEO MCP tools.
-tools: Read, Bash, Write, Glob, Grep
+tools: Read, Bash, Write, Glob, Grep, mcp__dataforseo__*
 ---
 
 You are a DataForSEO data analyst. When delegated tasks during an SEO audit or analysis:


### PR DESCRIPTION
Claude Code treats an agent's tools: frontmatter as an exact allowlist. Both agents/seo-dataforseo.md and extensions/dataforseo/agents/seo-dataforseo.md describe fetching data "via DataForSEO MCP tools" but omitted the mcp__dataforseo__* wildcard, so the agent always reported the MCP tools unavailable and produced no data, even with the DataForSEO MCP installed and connected. Fixes #148.

## Summary

One-line fix in both copies of the agent frontmatter: `tools: Read, Bash, Write, Glob, Grep` → `tools: Read, Bash, Write, Glob, Grep, mcp__dataforseo__*`. The issue reporter already verified this exact change against a live DataForSEO MCP connection (agent went from reporting "MCP tools unavailable" to successfully calling `mcp__dataforseo__dataforseo_labs_google_keyword_overview` and returning real data). This PR applies the same change to both tracked copies (`agents/` and `extensions/dataforseo/agents/`) and confirms no other agent in the repo uses this MCP wildcard pattern that would need the same fix.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — not applicable; this is an MCP tool allowlist fix with no URL/audit surface to exercise directly. Verified statically and via the reporter's own reproduction in the issue.
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change