### PR TITLE
fix(bing_webmaster): repoint link discovery to real Bing API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **bing_webmaster.py links/counts/compare all failed (#153).** `get_link_details()` called `GetLinkDetails`, which does not exist in the Bing Webmaster API (confirmed against Microsoft's `IWebmasterApi` reference) and always 404s; `get_link_counts()` called `GetUrlTrafficInfo`, which 400s the way it was used. Both are now built on `GetLinkCounts` (site-wide, page-level inbound link counts) — `get_link_details()` additionally expands the site's most-linked pages into real referring links via `GetUrlLinks` (Bing has no single endpoint that returns site-wide links with source URLs), so `compare_links()`'s domain-gap analysis keeps working against genuine referrer data instead of silently returning empty sets. Added `tests/test_bing_webmaster.py` with mocked responses matching Microsoft's documented JSON shapes.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/scripts/bing_webmaster.py
+++ b/scripts/bing_webmaster.py
@@ -156,52 +156,85 @@ def _normalize_site_url(url: str) -> str:
     return url
 
 
-def get_link_details(site_url: str, api_key: str, page: int = 0) -> dict:
+def get_link_details(site_url: str, api_key: str, page: int = 0, max_pages_to_expand: int = 10) -> dict:
     """
     Get inbound link details for a verified site.
+
+    Bing's Webmaster API has no endpoint that returns site-wide inbound
+    links together with their source URLs (the documented `GetLinkDetails`
+    method does not exist; calling it 404s). This discovers which of the
+    site's pages have inbound links via `GetLinkCounts`, then expands the
+    most-linked pages into individual referring links via `GetUrlLinks`,
+    which requires a specific page URL per call.
 
     Args:
         site_url: Verified site URL.
         api_key: Bing API key.
-        page: Page number for pagination (0-based).
+        page: GetLinkCounts page number for page discovery (0-based).
+        max_pages_to_expand: How many of the site's most-linked pages to
+            fetch individual referring links for (bounds API call count;
+            each expansion is a separate rate-limited request).
 
     Returns:
         Standard response dict with link data.
     """
     normalized = _normalize_site_url(site_url)
-    endpoint = "GetLinkDetails"
-    params = {
-        "siteUrl": normalized,
-        "page": page,
-    }
+    counts_result = _bing_request("GetLinkCounts", api_key, {"siteUrl": normalized, "page": page})
 
-    result = _bing_request(endpoint, api_key, params)
+    if counts_result["status"] != "success":
+        return counts_result
 
-    if result["status"] == "success" and result["data"]:
-        raw_data = result["data"]
-        links = []
-        link_list = raw_data if isinstance(raw_data, list) else raw_data.get("d", raw_data.get("results", []))
-        if isinstance(link_list, list):
-            for item in link_list:
-                links.append({
-                    "source_url": item.get("SourceUrl", item.get("sourceUrl", "")),
-                    "target_url": item.get("TargetUrl", item.get("targetUrl", "")),
-                    "anchor_text": item.get("AnchorText", item.get("anchorText", "")),
-                    "date_discovered": item.get("DateDiscovered", item.get("dateDiscovered", "")),
-                })
-        result["data"] = {
+    raw = counts_result["data"] or {}
+    page_data = raw.get("d", raw) if isinstance(raw, dict) else {}
+    page_counts = page_data.get("Links", []) if isinstance(page_data, dict) else []
+    page_counts = sorted(page_counts, key=lambda item: item.get("Count", 0), reverse=True)
+    top_pages = page_counts[:max_pages_to_expand]
+
+    links = []
+    for entry in top_pages:
+        page_url = entry.get("Url", "")
+        if not page_url:
+            continue
+        detail_result = _bing_request(
+            "GetUrlLinks", api_key, {"siteUrl": normalized, "link": page_url, "page": 0}
+        )
+        if detail_result["status"] != "success" or not detail_result["data"]:
+            continue
+        raw_details = detail_result["data"]
+        detail_data = raw_details.get("d", raw_details) if isinstance(raw_details, dict) else {}
+        detail_list = detail_data.get("Details", []) if isinstance(detail_data, dict) else []
+        for item in detail_list:
+            links.append({
+                "source_url": item.get("Url", ""),
+                "target_url": page_url,
+                "anchor_text": item.get("AnchorText", ""),
+            })
+
+    return {
+        "status": "success",
+        "data": {
             "site_url": site_url,
             "page": page,
+            "pages_with_links_sampled": len(top_pages),
             "total_returned": len(links),
             "links": links,
-        }
-
-    return result
+            "note": (
+                f"Expanded the top {max_pages_to_expand} pages by inbound link count "
+                "(Bing has no site-wide links-with-sources endpoint)."
+            ),
+        },
+        "error": None,
+        "metadata": {
+            "source": "bing_webmaster",
+            "endpoint": "GetLinkCounts+GetUrlLinks",
+            "timestamp": counts_result["metadata"]["timestamp"],
+        },
+    }
 
 
 def get_link_counts(site_url: str, api_key: str) -> dict:
     """
-    Get total backlink and referring domain counts for a site.
+    Get total backlink and referring-page counts for a site.
 
     Args:
         site_url: Site URL to query.
@@ -211,25 +244,20 @@ def get_link_counts(site_url: str, api_key: str) -> dict:
         Standard response dict with count data.
     """
     normalized = _normalize_site_url(site_url)
-    endpoint = "GetUrlTrafficInfo"
-    params = {"siteUrl": normalized}
-
-    result = _bing_request(endpoint, api_key, params)
-
-    # Also get link details page 0 for basic counts
-    links_result = get_link_details(site_url, api_key, page=0)
+    result = _bing_request("GetLinkCounts", api_key, {"siteUrl": normalized, "page": 0})
 
     if result["status"] == "success":
         raw = result["data"] or {}
-        link_count = 0
-        if links_result["status"] == "success" and links_result["data"]:
-            link_count = links_result["data"].get("total_returned", 0)
+        page_data = raw.get("d", raw) if isinstance(raw, dict) else {}
+        page_links = page_data.get("Links", []) if isinstance(page_data, dict) else []
+        sampled_link_count = sum(item.get("Count", 0) for item in page_links)
 
         result["data"] = {
             "site_url": site_url,
-            "total_links_sample": link_count,
-            "traffic_info": raw,
-            "note": "Link counts are sampled from Bing's index. For comprehensive data, use Moz API or DataForSEO.",
+            "pages_with_links_sample": len(page_links),
+            "sampled_inbound_link_count": sampled_link_count,
+            "total_pages": page_data.get("TotalPages", 0) if isinstance(page_data, dict) else 0,
+            "note": "Sampled from page 0 of Bing's GetLinkCounts index. For comprehensive data, use Moz API or DataForSEO.",
         }
 
     return result
@@ -416,7 +444,8 @@ def main():
                     print(f"  {link.get('source_url', '?'):60s} [{anchor}]")
             elif args.command == "counts":
                 print(f"Bing Link Counts for: {data.get('site_url', target)}")
-                print(f"  Sample links found: {data.get('total_links_sample', 'N/A')}")
+                print(f"  Pages with links (sample): {data.get('pages_with_links_sample', 'N/A')}")
+                print(f"  Sampled inbound link count: {data.get('sampled_inbound_link_count', 'N/A')}")
             elif args.command == "compare":
                 print(f"Backlink Gap: {data.get('site_url', '')} vs {data.get('competitor_url', '')}")
                 print(f"  Your linking domains:       {data.get('your_linking_domains', 0)}")

--- a/tests/test_bing_webmaster.py
+++ b/tests/test_bing_webmaster.py
@@ -1,0 +1,128 @@
+"""Bing Webmaster API link discovery regressions (issue #153).
+
+GetLinkDetails does not exist in the Bing Webmaster API (confirmed against
+Microsoft's IWebmasterApi reference) and 404s. GetUrlTrafficInfo 400s when
+used the way the old get_link_counts() called it. These tests pin the
+replacement behavior: link discovery via GetLinkCounts, expanded into real
+referring links via GetUrlLinks, with response shapes matching Microsoft's
+documented JSON samples exactly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+
+_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import bing_webmaster  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = "{}"
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+# Matches Microsoft's documented GetLinkCounts JSON response sample exactly.
+LINK_COUNTS_RESPONSE = {
+    "d": {
+        "__type": "LinkCounts:#Microsoft.Bing.Webmaster.Api",
+        "Links": [
+            {"__type": "LinkCount:#Microsoft.Bing.Webmaster.Api", "Count": 14, "Url": "http://example.com/page1.html"},
+            {"__type": "LinkCount:#Microsoft.Bing.Webmaster.Api", "Count": 2, "Url": "http://example.com/page2.html"},
+        ],
+        "TotalPages": 1,
+    }
+}
+
+# Matches Microsoft's documented GetUrlLinks JSON response sample exactly.
+URL_LINKS_RESPONSE = {
+    "d": {
+        "__type": "LinkDetails:#Microsoft.Bing.Webmaster.Api",
+        "Details": [
+            {"__type": "LinkDetail:#Microsoft.Bing.Webmaster.Api", "AnchorText": "great tool", "Url": "http://referrer-a.com/post"},
+        ],
+        "TotalPages": 1,
+    }
+}
+
+
+def test_get_link_counts_sums_sampled_page_and_drops_traffic_info() -> None:
+    with patch.object(bing_webmaster, "_rate_limit"), \
+         patch.object(bing_webmaster.requests, "get", return_value=FakeResponse(LINK_COUNTS_RESPONSE)) as mocked_get:
+        result = bing_webmaster.get_link_counts("https://example.com/", "fake-key")
+
+    assert result["status"] == "success"
+    assert result["data"]["pages_with_links_sample"] == 2
+    assert result["data"]["sampled_inbound_link_count"] == 16
+    assert "traffic_info" not in result["data"]
+    called_url = mocked_get.call_args.args[0]
+    assert "GetLinkCounts" in called_url
+    assert "GetUrlTrafficInfo" not in called_url
+
+
+def test_get_link_details_expands_top_pages_via_get_url_links() -> None:
+    def fake_get(url, params=None, **kwargs):
+        if "GetLinkCounts" in url:
+            return FakeResponse(LINK_COUNTS_RESPONSE)
+        return FakeResponse(URL_LINKS_RESPONSE)
+
+    with patch.object(bing_webmaster, "_rate_limit"), \
+         patch.object(bing_webmaster.requests, "get", side_effect=fake_get):
+        result = bing_webmaster.get_link_details("https://example.com/", "fake-key", max_pages_to_expand=2)
+
+    assert result["status"] == "success"
+    links = result["data"]["links"]
+    assert len(links) == 2  # one GetUrlLinks result per expanded page
+    assert links[0] == {
+        "source_url": "http://referrer-a.com/post",
+        "target_url": "http://example.com/page1.html",
+        "anchor_text": "great tool",
+    }
+
+
+def test_get_link_details_never_calls_removed_or_broken_endpoints() -> None:
+    with patch.object(bing_webmaster, "_rate_limit"), \
+         patch.object(bing_webmaster.requests, "get", return_value=FakeResponse(LINK_COUNTS_RESPONSE)) as mocked_get:
+        bing_webmaster.get_link_details("https://example.com/", "fake-key", max_pages_to_expand=0)
+
+    for call in mocked_get.call_args_list:
+        called_url = call.args[0]
+        assert "GetLinkDetails" not in called_url
+        assert "GetUrlTrafficInfo" not in called_url
+
+
+def test_compare_links_computes_real_domain_gap_from_expanded_links() -> None:
+    def fake_get(url, params=None, **kwargs):
+        if "GetLinkCounts" in url:
+            return FakeResponse(LINK_COUNTS_RESPONSE)
+        site_url = (params or {}).get("siteUrl", "")
+        if "competitor" in site_url:
+            return FakeResponse({"d": {"Details": [{"AnchorText": "x", "Url": "http://only-competitor.com/a"}]}})
+        return FakeResponse({"d": {"Details": [{"AnchorText": "y", "Url": "http://only-you.com/b"}]}})
+
+    with patch.object(bing_webmaster, "_rate_limit"), \
+         patch.object(bing_webmaster.requests, "get", side_effect=fake_get):
+        result = bing_webmaster.compare_links("https://example.com/", "https://competitor.com/", "fake-key")
+
+    assert result["status"] == "success"
+    data = result["data"]
+    # Pre-fix: get_link_details() returned entries with no source_url, so
+    # both domain sets were always empty and this comparison was hollow.
+    assert data["your_linking_domains"] == 1
+    assert data["competitor_linking_domains"] == 1
+    assert data["gap_domains"] == ["only-competitor.com"]
+    assert data["unique_to_you"] == ["only-you.com"]


### PR DESCRIPTION
GetLinkDetails does not exist in the Bing Webmaster API (confirmed against Microsoft's IWebmasterApi reference) and always 404s. GetUrlTrafficInfo 400s the way get_link_counts() called it. All three CLI commands (links, counts, compare) failed even with a valid API key and a verified site. Fixes #153.

## Summary

Verified the root cause against Microsoft's official `IWebmasterApi` reference (learn.microsoft.com): `GetLinkDetails` is absent from the documented method list entirely — there is no such endpoint, which is why it 404s. The two real methods are `GetLinkCounts(siteUrl, page)` (site-wide, page-level inbound link counts — `{Url, Count}` per page, no source/referrer data) and `GetUrlLinks(siteUrl, link, page)` (real referring links with anchor text, but scoped to one specific page URL per call).

The issue's suggested fix — repoint `get_link_details()` straight to `GetLinkCounts` — would stop the 404, but `GetLinkCounts` has no source-URL field. `compare_links()` builds its domain-gap analysis by extracting `source_url` from each link entry; with `GetLinkCounts` alone, `source_url` would always be empty, so `compare_links()` would keep returning `status: success` while silently producing empty domain sets (gap/shared/unique all zero) — a passing-looking result with no real data behind it.

Implemented a two-tier fix instead:
- `get_link_counts()`: sums `Count` across `GetLinkCounts`'s page-0 sample. Drops `GetUrlTrafficInfo` entirely.
- `get_link_details()`: calls `GetLinkCounts` to discover the site's most-linked pages, then expands the top N (default 10, bounds API call count under the existing 1 req/sec rate limit) into real referring links via `GetUrlLinks` per page. `compare_links()` is unchanged but now receives genuine `source_url` data, so its domain-gap math actually works.

Added `tests/test_bing_webmaster.py` (mirrors `test_moz_api.py`'s mocking style) with fixture responses matching Microsoft's documented `GetLinkCounts`/`GetUrlLinks` JSON samples exactly — verifies both endpoints parse correctly, that `GetLinkDetails`/`GetUrlTrafficInfo` are never called, and that `compare_links()` produces a real non-empty gap instead of the hollow-zeros failure mode a naive repoint would hit. Full suite: 330 passed (326 existing + 4 new).

I don't have a live Bing Webmaster API key, so I couldn't reproduce the original reporter's live verification end-to-end; the fix is verified against Microsoft's official API documentation plus mocked unit tests covering the exact documented response shapes.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — no live Bing Webmaster API key available; verified against Microsoft's official API reference and mocked unit tests instead (see Summary).
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change