### PR TITLE
fix(install.ps1): shim python3 on Windows when only py/python resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Skill-invoked `python3` calls failed on Windows without a `python3` on PATH (#138).** The PostToolUse hook resolves the interpreter dynamically (`CLAUDE_SEO_PYTHON` → `py -3` → `python3` → `python`, per `hooks/run-python-hook.js`), but SKILL.md/agent instructions invoke bundled scripts via the literal command `python3 scripts/<name>.py ...`. On Windows, `python3` is frequently absent even when `py -3` or `python` work, so those skill-driven calls failed even though Python was installed. `install.ps1` now probes for a working `python3` and, if none resolves, installs a `python3.bat` shim (forwarding to whichever interpreter it found) under `%USERPROFILE%\.claude\skills\seo\bin` and adds that directory to the current user's PATH, so future sessions resolve `python3` the same way the hook already does.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/install.ps1
+++ b/install.ps1
@@ -124,6 +124,39 @@ $RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v2.2.0' }
 New-Item -ItemType Directory -Force -Path $SkillDir | Out-Null
 New-Item -ItemType Directory -Force -Path $AgentDir | Out-Null
 
+# Skill/agent instructions invoke bundled scripts via the literal command
+# `python3 scripts/<name>.py ...` (see hooks/run-python-hook.js for why the
+# hook itself resolves the interpreter dynamically instead of hardcoding
+# this). On Windows, `python3` is frequently absent even when `py -3` or
+# `python` work, so those skill-driven calls fail even though Python is
+# installed. If a bare `python3` doesn't already resolve, install a shim
+# that forwards to whichever interpreter Resolve-Python found, and put it
+# on the current user's PATH so future Claude Code sessions pick it up.
+$python3Works = $null -ne (Test-PythonCandidate -Exe 'python3' -Args @())
+if (-not $python3Works) {
+    try {
+        $BinDir = "$SkillDir\bin"
+        New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+        $shimTarget = "$($python.Exe) $($python.Args -join ' ')".Trim()
+        Set-Content -Path "$BinDir\python3.bat" -Value "@echo off`r`n$shimTarget %*" -Encoding ASCII
+
+        $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+        $pathEntries = @()
+        if ($userPath) { $pathEntries = $userPath -split ';' }
+        if ($pathEntries -notcontains $BinDir) {
+            $newUserPath = if ($userPath) { "$userPath;$BinDir" } else { $BinDir }
+            [Environment]::SetEnvironmentVariable('PATH', $newUserPath, 'User')
+            Write-Host "[+] python3 not found; installed a shim at $BinDir\python3.bat (forwards to '$shimTarget') and added it to your PATH." -ForegroundColor Yellow
+            Write-Host "    Restart Claude Code (or open a new terminal) for skill-invoked scripts/*.py calls to pick it up." -ForegroundColor Yellow
+        } else {
+            Write-Host "[+] python3 shim already present at $BinDir\python3.bat" -ForegroundColor Green
+        }
+    } catch {
+        Write-Host "[!] Could not install a python3 shim automatically: $($_.Exception.Message)" -ForegroundColor Yellow
+        Write-Host "    Skill-invoked scripts/*.py calls that hardcode python3 may fail. Workaround: copy your python.exe to a python3.exe on PATH." -ForegroundColor Yellow
+    }
+}
+
 # Clone to temp directory
 $TempDir = Join-Path $env:TEMP "claude-seo-install"
 if (Test-Path $TempDir) {


### PR DESCRIPTION
hooks/run-python-hook.js resolves the Python interpreter dynamically (CLAUDE_SEO_PYTHON -> py -3 -> python3 -> python), but SKILL.md/agent instructions invoke bundled scripts via the literal command python3 scripts/<name>.py .... On Windows, python3 is frequently absent even when py -3 or python work (no shim, no Store alias), so those skill-driven calls fail even though Python is installed and the hook itself works fine. Fixes #138.

## Summary

The hook fix (#68/#102/#112) only covers `run-python-hook.js`, which is invoked by Claude Code's own hook mechanism through a fixed launcher. Skill-invoked scripts are different: the model reads the literal `python3 scripts/...` text in SKILL.md/agent bodies and runs it directly as a shell command — there's no equivalent programmatic launcher in that path across the ~50 call sites in `skills/**/*.md` and `agents/*.md`.

Rather than touching every call site (fragile, large surface area, no way to guarantee the model applies a "please substitute the interpreter" instruction consistently), this fix mirrors the reporter's own confirmed-working manual workaround ("created a python3.exe copy of python.exe in the Python install dir") but automates it safely at install time: `install.ps1` probes whether `python3` already resolves; if not, it writes a `python3.bat` shim that forwards to whichever interpreter `Resolve-Python` found (`py -3`, or `python`), places it under `%USERPROFILE%\.claude\skills\seo\bin` (avoids needing write access to the actual Python install directory, which may not be user-writable), and adds that directory to the current user's PATH so future Claude Code sessions pick it up. If the PATH/file write fails (e.g. a locked-down profile), it prints a clear warning with the manual workaround instead of failing the install.

**Caveat:** I don't have access to a Windows machine or PowerShell in this environment (`pwsh` isn't installed here and I couldn't get a cask installed without sudo). I verified the change by careful manual read-through against this file's existing conventions (e.g. matching the `$($python.Exe)` subexpression-interpolation style already used elsewhere in `install.ps1`, confirming `Test-PythonCandidate` is defined before this new call site, and tracing brace/quote balance by hand) rather than running it. Flagging this so a maintainer or the original reporter (who has the repro environment) can smoke-test on real Windows before merging.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — no Windows/PowerShell environment available here; see Summary for how this was verified instead, and please smoke-test on real Windows before merging.
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change