### PR TITLE
feat(seo): add /seo setup for post-plugin-install provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`/seo setup` command (#137).** `/plugin install` installs skills, agents, and hooks but never runs `pip install -r requirements.txt` or `playwright install chromium`, unlike the manual installers — so a fresh plugin install was non-functional until the user discovered and ran provisioning manually. `/seo setup` locates the right `requirements.txt` (`${CLAUDE_PLUGIN_ROOT}` for plugin installs, `~/.claude/skills/seo` for manual ones), installs dependencies and Chromium, and is now proactively suggested whenever a script fails with `ModuleNotFoundError`/`ImportError` or a Playwright missing-browser error. README's plugin-install section now notes the extra step.
+
 ## [2.2.0] - 2026-06-12
 
 Security, cross-platform, and data-accuracy release. Folds the v2.1.0 currency content into the first public ship and closes the full open-issue and PR backlog. No breaking changes.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The fastest path. One-time marketplace add, then plugin install:
 /plugin install claude-seo@agricidaniel-claude-seo
 ```
 
+> **One more step:** unlike the manual installers below, `/plugin install` does not run
+> `pip install -r requirements.txt` or `playwright install chromium` for you. Run
+> `/seo setup` once after installing to provision both — otherwise scripts like
+> `render_page.py` will fail with `ModuleNotFoundError` or a missing-Chromium error.
+
 ### Manual Install (Unix / macOS / Linux)
 
 ```bash

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -52,6 +52,33 @@ extension is also installable (see "Optional Extensions" below).
 | `/seo dataforseo [command]` | Live SEO data via DataForSEO (extension) |
 | `/seo image-gen [use-case] <description>` | AI image generation for SEO assets (extension) |
 | `/seo flow [stage] [url\|topic]` | FLOW framework: evidence-led prompts for Find, Leverage, Optimize, Win, or Local stages |
+| `/seo setup` | Install/verify Python dependencies and Playwright Chromium (required after `/plugin install`; manual installs do this automatically) |
+
+## Setup
+
+Manual installs (`install.sh` / `install.ps1`) run `pip install -r requirements.txt` and
+`playwright install chromium` automatically. **`/plugin install` does not** — it installs
+the skills, agents, and hooks but never provisions Python dependencies or the Chromium
+browser, so every sub-skill that shells out to a script (`render_page.py`,
+`pagespeed_check.py`, `capture_screenshot.py`, and others) fails until this is run once.
+
+`/seo setup` provisions them:
+
+1. Locate `requirements.txt`: prefer `${CLAUDE_PLUGIN_ROOT}/requirements.txt` if that
+   variable is set and the file exists (plugin install); otherwise fall back to
+   `~/.claude/skills/seo/requirements.txt` (manual install). If neither exists, tell the
+   user their install looks incomplete and point them at `install.sh` / `install.ps1`.
+2. Install dependencies: if `~/.claude/skills/seo/.venv` exists, use
+   `~/.claude/skills/seo/.venv/bin/pip install -r <requirements.txt path>` (matches
+   `install.sh`'s convention); otherwise `python3 -m pip install --user -r <requirements.txt path>`.
+3. Install the Chromium browser: `python3 -m playwright install chromium`.
+4. Confirm success: `python3 -c "import playwright, trafilatura, lxml; print('ok')"`.
+5. Report what was installed/upgraded and any failures plainly — don't silently swallow
+   pip or Playwright errors.
+
+Proactively suggest `/seo setup` whenever a `scripts/*.py` call fails with
+`ModuleNotFoundError`, `ImportError`, or a Playwright "Executable doesn't exist" error —
+this is the signature of an unprovisioned `/plugin install`, not a code bug.
 
 ## Orchestration Logic
 
@@ -269,3 +296,4 @@ For parallel analysis during audits:
 | URL unreachable | Report the error and suggest the user verify the URL. Do not attempt to guess site content. |
 | Sub-skill fails during audit | Report partial results from successful sub-skills. Clearly note which sub-skill failed and why. Suggest re-running the failed sub-skill individually. |
 | Ambiguous business type detection | Present the top two detected types with supporting signals. Ask the user to confirm before proceeding with industry-specific recommendations. |
+| Script fails with `ModuleNotFoundError`/`ImportError`, or Playwright reports "Executable doesn't exist" | Dependencies were never provisioned — common after `/plugin install`, which does not run `pip install` or `playwright install`. Run `/seo setup`. |


### PR DESCRIPTION
/plugin install claude-seo@agricidaniel-claude-seo installs skills, agents, commands, and hooks, but unlike install.sh/install.ps1 it never runs pip install -r requirements.txt or playwright install chromium. Every sub-skill that shells out to a script (render_page.py, pagespeed_check.py, capture_screenshot.py, etc.) failed at runtime on a fresh plugin install until the user discovered and ran provisioning manually. Fixes #137.

## Summary

Went with the issue's option (b) — bootstrap it — implemented as a documented `/seo setup` command rather than a silent SessionStart hook. Reasoning: automatically running `pip install`/`playwright install` on every session start without the user asking for it would silently mutate their Python environment, which felt like the wrong default for a hook that fires on every session. A command the user explicitly invokes (matching the repo's existing `/seo backlinks setup` pattern) keeps that as a deliberate action while still solving the "fresh install is silently non-functional" problem, since `seo/SKILL.md`'s Error Handling table now proactively points the model at `/seo setup` the moment a script fails with `ModuleNotFoundError`/`ImportError` or a Playwright missing-browser error — so the user gets the fix suggested right at the point of failure rather than needing to discover it themselves.

Changes:
- `skills/seo/SKILL.md`: new `/seo setup` command in the Quick Reference table, a `## Setup` section describing exactly what it does (locate `requirements.txt` via `${CLAUDE_PLUGIN_ROOT}` for plugin installs or `~/.claude/skills/seo` for manual ones, install deps into the existing venv if `install.sh` created one else `--user`, install Chromium, confirm via import check), and a new Error Handling row.
- `README.md`: the plugin-install section now notes the extra step is required, addressing the issue's evidence point that the README presented `/plugin install` as complete with no such note.

I couldn't test this end-to-end (would require actually running `/plugin install` in a fresh Claude Code environment and invoking `/seo setup`, which isn't available in this session) — this is a documented/model-interpreted command, not code with an automated test surface. Verified the `requirements.txt` packages referenced in the confirmation import check (`playwright`, `trafilatura`, `lxml`) actually match `requirements.txt`, and that the `${CLAUDE_PLUGIN_ROOT}` convention matches what `hooks/hooks.json` already uses for the plugin-install path.

## Type of Change

- [ ] Bug fix
- [x] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — not applicable; this is a documented setup command with no URL/audit surface, and I don't have a fresh /plugin install environment to exercise it end-to-end. See Summary for how it was verified instead.
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change