### PR TITLE
fix(drift): report real schema/OG diff values instead of placeholders

### DIFF
--- a/scripts/drift_compare.py
+++ b/scripts/drift_compare.py
@@ -89,7 +89,7 @@ def rule_01_schema_removed(baseline: dict, current: dict) -> dict:
     return _make_finding(
         "schema_removed", "CRITICAL", triggered,
         f"{len(old_schema)} schema block(s)",
-        "0 schema blocks",
+        f"{len(new_schema)} schema block(s)",
         "All structured data (JSON-LD) has been removed. Rich results will be lost. Restore immediately."
         if triggered else "Schema presence unchanged.",
     )
@@ -279,7 +279,7 @@ def rule_13_og_tags_removed(baseline: dict, current: dict) -> dict:
     return _make_finding(
         "og_tags_removed", "WARNING", triggered,
         list(old_og.keys()),
-        [],
+        list(new_og.keys()),
         "All Open Graph tags have been removed. Social sharing will show generic previews."
         if triggered else "OG tags presence unchanged.",
     )
@@ -314,7 +314,7 @@ def rule_15_schema_added(baseline: dict, current: dict) -> dict:
     triggered = len(old_schema) == 0 and len(new_schema) > 0
     return _make_finding(
         "schema_added", "INFO", triggered,
-        "0 schema blocks",
+        f"{len(old_schema)} schema block(s)",
         f"{len(new_schema)} schema block(s)",
         "New structured data added. Validate with /seo schema."
         if triggered else "No new schema added.",


### PR DESCRIPTION
### Problem
`rule_01_schema_removed`, `rule_13_og_tags_removed`, and `rule_15_schema_added` in `scripts/drift_compare.py` hardcode their `old_value`/`new_value` **display** fields. The `triggered`/severity logic is correct, but when a rule is **not** triggered the reported diff is misleading — e.g. `og_tags_removed` always prints `new_value=[]` even when OG tags are still present, and the schema rules always print `0 schema blocks` on their hardcoded side.

### Fix
Reference the same computed values used to derive `triggered`:

| Rule | Field | Before | After |
|---|---|---|---|
| `rule_01_schema_removed` | new_value | `"0 schema blocks"` | `f"{len(new_schema)} schema block(s)"` |
| `rule_13_og_tags_removed` | new_value | `[]` | `list(new_og.keys())` |
| `rule_15_schema_added` | old_value | `"0 schema blocks"` | `f"{len(old_schema)} schema block(s)"` |

Display-only correctness fix — no change to triggered/severity behavior. `py_compile` clean. Branched off current `main` (v2.2.0).

_Found while running a live `/seo drift compare` during a qualflare.com audit._

🤖 Generated with [Claude Code](https://claude.com/claude-code)