### PR TITLE
fix(tests): stop module-level sys.exit from aborting the whole pytest session

### DIFF
--- a/tests/test_gsc_pagination.py
+++ b/tests/test_gsc_pagination.py
@@ -6,8 +6,16 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+# gsc_query calls sys.exit(1) at import time when google-api-python-client is
+# missing. Under pytest that SystemExit escapes collection as an INTERNALERROR
+# and aborts the whole session, so no test in tests/ runs. Skip this module
+# instead when the optional Google stack is absent.
+pytest.importorskip("googleapiclient")
 
 import gsc_query  # noqa: E402
 

--- a/tests/test_gsc_query.py
+++ b/tests/test_gsc_query.py
@@ -7,11 +7,19 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPTS = REPO_ROOT / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
+
+# gsc_query calls sys.exit(1) at import time when google-api-python-client is
+# missing. Under pytest that SystemExit escapes collection as an INTERNALERROR
+# and aborts the whole session, so no test in tests/ runs. Skip this module
+# instead when the optional Google stack is absent.
+pytest.importorskip("googleapiclient")
 
 import gsc_query  # noqa: E402
 

--- a/tests/test_gsc_totals_aggregate.py
+++ b/tests/test_gsc_totals_aggregate.py
@@ -9,8 +9,16 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+# gsc_query calls sys.exit(1) at import time when google-api-python-client is
+# missing. Under pytest that SystemExit escapes collection as an INTERNALERROR
+# and aborts the whole session, so no test in tests/ runs. Skip this module
+# instead when the optional Google stack is absent.
+pytest.importorskip("googleapiclient")
 
 import gsc_query  # noqa: E402
 

--- a/tests/test_sitemap_discovery.py
+++ b/tests/test_sitemap_discovery.py
@@ -6,8 +6,14 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+# sitemap_discovery imports lxml at module scope. Without it the collection
+# error interrupts the whole pytest session, so skip this module instead.
+pytest.importorskip("lxml")
 
 import sitemap_discovery as discovery  # noqa: E402
 


### PR DESCRIPTION
## Summary

`scripts/gsc_query.py` calls `sys.exit(1)` at module scope when `google-api-python-client` is missing. Three test modules import it at module scope, so pytest raises `SystemExit` during collection, which becomes an `INTERNALERROR` and aborts the whole session — not three modules, all of them. `tests/test_sitemap_discovery.py` does the same via `lxml`.

Adds a `pytest.importorskip()` guard to the four affected modules. The scripts are untouched, so their CLI error messages stay as they are.

```bash
pip install pytest beautifulsoup4
pytest tests/ -q
```

Before: `INTERNALERROR ... SystemExit: 1`, `no tests ran`, exit 3.
After: `371 passed`.

Verified in:
- Windows 11, Python 3.14, clean venv, `pytest` + `beautifulsoup4` only — 371 passed, 4 skipped (15 pre-existing failures are POSIX permission assertions that cannot hold on NTFS, untouched here)
- Same checkout with the full `requirements.txt` — the four modules execute, 24 passed, so nothing is silently skipped where the dependency exists
- Your CI on `main` @`09d37c7` — green, confirming those 15 pass on Linux

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change

CHANGELOG left out: I have three more small PRs open here and an entry in each would collide over the same section. Say the word and I will add one.

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
