### PR TITLE
fix(ci): do not swallow requirements install failure in v2 audit

### DIFF
--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -84,9 +84,14 @@ jobs:
           python-version: "3.10"
 
       - name: Install pytest + test deps
+        # Must not be tolerated with `|| true`: several test modules import
+        # scripts that call sys.exit(1) at module scope when a dependency is
+        # missing, so a swallowed install failure resurfaces later as an opaque
+        # pytest INTERNALERROR instead of the pip error that caused it. Matches
+        # ci.yml, which installs the same set without a fallback.
         run: |
           pip install pytest beautifulsoup4
-          pip install -r requirements.txt || true
+          pip install -r requirements.txt
 
       - name: Run pytest
         run: pytest tests/ -v


### PR DESCRIPTION
## Summary

`v2.yml`, job `full_pytest`, installs the runtime with `pip install -r requirements.txt || true`. A failed install stays invisible; the run then dies later as `INTERNALERROR ... SystemExit: 1` / `no tests ran`, because several test modules import scripts that exit at module scope when a dependency is absent. The log never mentions pip.

Drops the `|| true`, matching `ci.yml`, which installs the same set without a fallback.

Verified in:
- YAML parses clean (`yaml.safe_load`) on Windows 11, Python 3.14
- Not exercisable from a PR: the workflow is `workflow_dispatch` / `workflow_call` only, so it wants a manual run from the Actions tab

Two adjacent things I left alone: the header comment still says *"Until the v2 branch is pushed"*, and `secret_scan` is byte-identical to `secret-scan` in `ci.yml`. Happy to open follow-ups.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change

CHANGELOG left out: I have three more small PRs open here and an entry in each would collide over the same section. Say the word and I will add one.

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
