### PR TITLE
chore(ci): audit requirements.txt with pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,28 @@ jobs:
             exit 1
           fi
           echo "Secret scan clean: no credentials detected in tracked files."
+
+  dep-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Audit requirements.txt against the PyPI advisory database
+        # requirements.txt documents CVE floors per dependency in comments, but
+        # nothing verified them; this closes that loop. Because the pins are
+        # bounded ranges rather than exact versions, pip-audit resolves the
+        # newest allowed release, so a newly published advisory can turn this
+        # job red without a commit to the repo. That is the intended signal:
+        # it means a floor in requirements.txt needs raising. To land an
+        # unavoidable advisory in the meantime, add
+        # `--ignore-vuln GHSA-xxxx-xxxx-xxxx` with a comment naming the reason.
+        run: pip-audit -r requirements.txt --progress-spinner off


### PR DESCRIPTION
## Summary

`requirements.txt` records a CVE floor per dependency in comments (`CVE-2024-47081`, `CVE-2025-24928`, `GHSA-mf9v-mfxr-j63j`, …), but nothing checked them. Dependabot raises update PRs; it does not audit the resolved set.

Adds a `dep-audit` job running `pip-audit` against the PyPI advisory database.

One consequence worth deciding on deliberately: the pins are bounded ranges, so `pip-audit` resolves the newest allowed release and a newly published advisory can fail this job with no commit to the repo. That is the intended signal — a floor needs raising — but it can land on an unrelated PR. The step comment documents `--ignore-vuln` for an advisory with no fix yet; `continue-on-error: true` is a one-word change if you would rather have it non-blocking.

Verified in:
- Windows 11, Python 3.14, clean venv: `pip-audit -r requirements.txt` → `No known vulnerabilities found`, exit 0, so the job is green on the first run
- YAML parses clean; jobs resolve to `lint`, `test`, `secret-scan`, `dep-audit`

Note: this and #185 both append a job to the end of `ci.yml`; whichever lands second needs a trivial rebase, which I am happy to do.

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [x] Other — CI / supply-chain check

## Checklist

- [ ] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change

CHANGELOG left out: I have three more small PRs open here and an entry in each would collide over the same section. Say the word and I will add one.

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
