### PR TITLE
ci: run the portability suites on windows and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,42 @@ jobs:
             exit 1
           fi
           echo "Secret scan clean: no credentials detected in tracked files."
+
+  portability:
+    name: Portability (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Report both legs independently; a failure on one platform should not
+      # hide the result on the other.
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - name: Install pytest
+        # These three modules need nothing beyond pytest -- verified on a clean
+        # virtualenv. Keeping the install minimal keeps the job from failing for
+        # reasons that have nothing to do with portability.
+        run: pip install pytest
+
+      - name: Run the platform-sensitive suites
+        # Deliberately not `pytest tests/`. The full suite has 15 tests that
+        # assert POSIX semantics directly -- the executable bit via os.access
+        # X_OK in test_parasite_risk_and_extensions.py and
+        # test_runtime_installers.py, and chmod 0o600/0o644 token permissions in
+        # test_url_safety.py -- which cannot hold on Windows. The three modules
+        # below are the ones written to be platform-neutral, so they are the
+        # ones worth running here. Widening this list means teaching those 15
+        # tests to skip on non-POSIX first.
+        run: >
+          pytest
+          tests/test_portability.py
+          tests/test_cross_platform_hooks.py
+          tests/test_drift_portability.py
+          -v


### PR DESCRIPTION
## Summary

The repo ships `install.ps1` / `uninstall.ps1`, advertises a managed cross-platform runtime, and carries three modules written to pin cross-platform behaviour — `test_portability.py`, `test_cross_platform_hooks.py`, `test_drift_portability.py`. CI ran them on `ubuntu-latest` only, so a Windows or macOS regression could not be caught by the tests written to catch it.

Adds a `portability` job on `windows-latest` and `macos-latest` running those three modules. They need nothing beyond `pytest`, so the install step stays minimal.

Scope is narrow on purpose: `pytest tests/` cannot pass on Windows, because 15 tests assert POSIX semantics directly — `os.access(..., X_OK)` in `test_parasite_risk_and_extensions.py` and `test_runtime_installers.py`, and `chmod 0o600`/`0o644` in `test_url_safety.py`. Widening the job means teaching those tests to skip on non-POSIX first, which is a separate decision about what the suite should assert.

Verified in:
- Windows 11, Python 3.14, clean venv with `pytest` only — 15 passed
- macOS — not reproduced locally, wants a look on the first CI run; `fail-fast: false` is set so each platform reports independently
- YAML parses clean; the matrix resolves to `['windows-latest', 'macos-latest']`

Note: this and #184 both append a job to the end of `ci.yml`; whichever lands second needs a trivial rebase, which I am happy to do.

## Type of Change

- [ ] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [x] Other — CI coverage

## Checklist

- [ ] Tested with a real URL before submitting
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [ ] CHANGELOG.md updated with the change

CHANGELOG left out: I have three more small PRs open here and an entry in each would collide over the same section. Say the word and I will add one.

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
