### PR TITLE
Add MiniMax image generation to the Banana REST fallback

### DIFF
--- a/extensions/banana/scripts/generate.py
+++ b/extensions/banana/scripts/generate.py
@@ -7,6 +7,12 @@ Uses only Python stdlib (no pip dependencies).
 Usage:
     generate.py --prompt "a cat in space" [--aspect-ratio 16:9] [--resolution 1K]
                 [--model MODEL] [--api-key KEY] [--thinking LEVEL] [--image-only]
+
+    generate.py --provider minimax --prompt "a cat in space" [--region global_en|cn_zh]
+                [--model image-01|image-01-live] [--aspect-ratio 16:9 | --width W --height H]
+                [--response-format url|base64] [--seed N] [--count N]
+                [--prompt-optimizer|--no-prompt-optimizer] [--subject-reference SRC]
+                [--api-key KEY]
 """
 
 import argparse
@@ -28,6 +34,21 @@ API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "2:3", "3:2",
                 "4:5", "5:4", "1:4", "4:1", "1:8", "8:1", "21:9"}
 VALID_RESOLUTIONS = {"512", "1K", "2K", "4K"}
+
+# MiniMax image_generation direct REST fallback.
+MINIMAX_DEFAULT_MODEL = "image-01"
+MINIMAX_MODELS = {"image-01", "image-01-live"}
+MINIMAX_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/image_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/image_generation",
+}
+MINIMAX_DEFAULT_REGION = "global_en"
+MINIMAX_RESPONSE_FORMATS = {"url", "base64"}
+MINIMAX_IMAGE_MIME = {
+    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".webp": "image/webp", ".gif": "image/gif",
+}
+
 _GOOGLE_API_KEY_PREFIX = "AI" + "za"
 _GOOGLE_API_KEY_RE = re.compile(_GOOGLE_API_KEY_PREFIX + r"[0-9A-Za-z_-]+")
 _GOOGLE_KEY_QUERY_RE = re.compile(r"([?&])key=[^&\s'\"<>)]*(&?)")
@@ -133,6 +154,152 @@ def generate_image(prompt, model, aspect_ratio, resolution, api_key,
     }
 
 
+def _redact_secret(value, secret):
+    """Strip a bearer credential from standalone fallback error output."""
+    text = str(value)
+    if secret:
+        text = text.replace(secret, "IMAGE_API_KEY_REDACTED")
+    return text
+
+
+def _encode_subject_reference(reference):
+    """Normalise subject references into MiniMax image_file payloads.
+
+    Accepts an http(s) URL, an existing data URI, or a local file path
+    (encoded to a base64 data URI). Returns the request-ready list or None.
+    """
+    if not reference:
+        return None
+    items = reference if isinstance(reference, (list, tuple)) else [reference]
+    payload = []
+    for item in items:
+        item = str(item)
+        if item.startswith(("http://", "https://", "data:")):
+            image_file = item
+        else:
+            path = Path(item).expanduser().resolve()
+            if not path.exists():
+                raise FileNotFoundError(f"Subject reference not found: {path}")
+            mime = MINIMAX_IMAGE_MIME.get(path.suffix.lower(), "image/png")
+            encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
+            image_file = f"data:{mime};base64,{encoded}"
+        payload.append({"type": "character", "image_file": image_file})
+    return payload
+
+
+def build_minimax_request(prompt, model, *, aspect_ratio=None, width=None,
+                          height=None, response_format="url", seed=None,
+                          count=1, prompt_optimizer=None, subject_reference=None):
+    """Assemble the MiniMax image_generation request body."""
+    body = {"model": model, "prompt": prompt, "response_format": response_format}
+    if width and height:
+        body["width"] = int(width)
+        body["height"] = int(height)
+    elif aspect_ratio:
+        body["aspect_ratio"] = aspect_ratio
+    if seed is not None:
+        body["seed"] = int(seed)
+    if count and int(count) != 1:
+        body["n"] = int(count)
+    if prompt_optimizer is not None:
+        body["prompt_optimizer"] = bool(prompt_optimizer)
+    subject = _encode_subject_reference(subject_reference)
+    if subject:
+        body["subject_reference"] = subject
+    return body
+
+
+def parse_minimax_response(result, response_format):
+    """Extract image URLs or base64 payloads from a MiniMax response.
+
+    Raises ValueError with the upstream status message when the request was
+    not accepted, mirroring the base_resp.status_code contract.
+    """
+    base_resp = result.get("base_resp", {})
+    status_code = base_resp.get("status_code")
+    if status_code not in (None, 0):
+        raise ValueError(base_resp.get("status_msg") or f"status_code {status_code}")
+    data = result.get("data") or {}
+    if response_format == "base64":
+        return "base64", list(data.get("image_base64") or [])
+    return "url", list(data.get("image_urls") or [])
+
+
+def generate_image_minimax(prompt, model, api_key, *, region="global_en",
+                           aspect_ratio=None, width=None, height=None,
+                           response_format="url", seed=None, count=1,
+                           prompt_optimizer=None, subject_reference=None):
+    """Call the MiniMax image_generation endpoint and save the results."""
+    endpoint = MINIMAX_ENDPOINTS.get(region)
+    if not endpoint:
+        print(json.dumps({"error": True, "message": f"Invalid region '{region}'. Valid: {sorted(MINIMAX_ENDPOINTS)}"}))
+        sys.exit(1)
+
+    body = build_minimax_request(
+        prompt, model, aspect_ratio=aspect_ratio, width=width, height=height,
+        response_format=response_format, seed=seed, count=count,
+        prompt_optimizer=prompt_optimizer, subject_reference=subject_reference,
+    )
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=data,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = _redact_secret(e.read().decode("utf-8", "replace") if e.fp else "", api_key)
+        print(json.dumps({"error": True, "status": e.code, "message": error_body}))
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(json.dumps({"error": True, "message": _redact_secret(e.reason, api_key)}))
+        sys.exit(1)
+
+    try:
+        kind, items = parse_minimax_response(result, response_format)
+    except ValueError as e:
+        print(json.dumps({"error": True, "message": _redact_secret(e, api_key)}))
+        sys.exit(1)
+
+    if not items:
+        metadata = result.get("metadata", {})
+        print(json.dumps({"error": True, "message": f"No image returned. metadata: {metadata}"}))
+        sys.exit(1)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    saved = []
+    for index, item in enumerate(items):
+        output_path = (OUTPUT_DIR / f"banana_{timestamp}_{index}.png").resolve()
+        if kind == "base64":
+            output_path.write_bytes(base64.b64decode(item))
+        else:
+            try:
+                with urllib.request.urlopen(item, timeout=120) as img_resp:
+                    output_path.write_bytes(img_resp.read())
+            except urllib.error.URLError as e:
+                print(json.dumps({"error": True, "message": _redact_secret(e.reason, api_key)}))
+                sys.exit(1)
+        saved.append(str(output_path))
+
+    metadata = result.get("metadata", {})
+    return {
+        "paths": saved,
+        "path": saved[0],
+        "model": model,
+        "region": region,
+        "response_format": response_format,
+        "aspect_ratio": aspect_ratio,
+        "image_urls": items if kind == "url" else [],
+        "success_count": metadata.get("success_count"),
+        "failed_count": metadata.get("failed_count"),
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate images via Gemini REST API")
     parser.add_argument("--prompt", required=True, help="Image generation prompt")
@@ -142,8 +309,51 @@ def main():
     parser.add_argument("--api-key", default=None, help="Google AI API key (or set GOOGLE_AI_API_KEY env)")
     parser.add_argument("--thinking", default=None, choices=["minimal", "low", "medium", "high"], help="Thinking level")
     parser.add_argument("--image-only", action="store_true", help="Return image only (no text)")
+    parser.add_argument("--provider", default="default", choices=["default", "minimax"],
+                        help="Backend provider (default: default)")
+    parser.add_argument("--region", default=MINIMAX_DEFAULT_REGION, choices=sorted(MINIMAX_ENDPOINTS),
+                        help=f"MiniMax region (default: {MINIMAX_DEFAULT_REGION})")
+    parser.add_argument("--response-format", default="url", choices=sorted(MINIMAX_RESPONSE_FORMATS),
+                        help="MiniMax response format: url or base64 (default: url)")
+    parser.add_argument("--width", type=int, default=None, help="MiniMax pixel width (used with --height)")
+    parser.add_argument("--height", type=int, default=None, help="MiniMax pixel height (used with --width)")
+    parser.add_argument("--seed", type=int, default=None, help="MiniMax generation seed")
+    parser.add_argument("--count", type=int, default=1, help="MiniMax image count (n, default: 1)")
+    parser.add_argument("--subject-reference", action="append", default=None,
+                        help="MiniMax subject reference: URL, data URI, or local file (repeatable)")
+    parser.add_argument("--prompt-optimizer", dest="prompt_optimizer", action="store_true", default=None,
+                        help="Enable MiniMax prompt_optimizer")
+    parser.add_argument("--no-prompt-optimizer", dest="prompt_optimizer", action="store_false",
+                        help="Disable MiniMax prompt_optimizer")
 
     args = parser.parse_args()
+
+    if args.provider == "minimax":
+        model = args.model if args.model in MINIMAX_MODELS else MINIMAX_DEFAULT_MODEL
+        api_key = args.api_key or os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            print(json.dumps({"error": True, "message": "No API key. Set MINIMAX_API_KEY env or pass --api-key"}))
+            sys.exit(1)
+        try:
+            result = generate_image_minimax(
+                prompt=args.prompt,
+                model=model,
+                api_key=api_key,
+                region=args.region,
+                aspect_ratio=args.aspect_ratio,
+                width=args.width,
+                height=args.height,
+                response_format=args.response_format,
+                seed=args.seed,
+                count=args.count,
+                prompt_optimizer=args.prompt_optimizer,
+                subject_reference=args.subject_reference,
+            )
+        except FileNotFoundError as e:
+            print(json.dumps({"error": True, "message": str(e)}))
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+        return
 
     if args.aspect_ratio not in VALID_RATIOS:
         print(json.dumps({"error": True, "message": f"Invalid aspect ratio '{args.aspect_ratio}'. Valid: {sorted(VALID_RATIOS)}"}))

--- a/extensions/banana/scripts/generate.py
+++ b/extensions/banana/scripts/generate.py
@@ -25,10 +25,18 @@ import urllib.request
 from datetime import datetime
 from pathlib import Path
 
+_SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+from url_safety import safe_requests_get  # noqa: E402
+
 DEFAULT_MODEL = os.environ.get("NANOBANANA_MODEL")
 DEFAULT_RESOLUTION = "1K"
 DEFAULT_RATIO = "1:1"
 OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
+MINIMAX_SUBJECT_REFERENCE_DIR = Path(
+    os.environ.get("MINIMAX_SUBJECT_REFERENCE_DIR", Path.cwd())
+).expanduser().resolve()
 API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
 VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "2:3", "3:2",
@@ -178,6 +186,13 @@ def _encode_subject_reference(reference):
             image_file = item
         else:
             path = Path(item).expanduser().resolve()
+            try:
+                path.relative_to(MINIMAX_SUBJECT_REFERENCE_DIR)
+            except ValueError as exc:
+                raise ValueError(
+                    "Subject reference must be inside "
+                    f"{MINIMAX_SUBJECT_REFERENCE_DIR}"
+                ) from exc
             if not path.exists():
                 raise FileNotFoundError(f"Subject reference not found: {path}")
             mime = MINIMAX_IMAGE_MIME.get(path.suffix.lower(), "image/png")
@@ -279,10 +294,11 @@ def generate_image_minimax(prompt, model, api_key, *, region="global_en",
             output_path.write_bytes(base64.b64decode(item))
         else:
             try:
-                with urllib.request.urlopen(item, timeout=120) as img_resp:
-                    output_path.write_bytes(img_resp.read())
-            except urllib.error.URLError as e:
-                print(json.dumps({"error": True, "message": _redact_secret(e.reason, api_key)}))
+                img_resp = safe_requests_get(item, timeout=120)
+                img_resp.raise_for_status()
+                output_path.write_bytes(img_resp.content)
+            except Exception as e:
+                print(json.dumps({"error": True, "message": _redact_secret(e, api_key)}))
                 sys.exit(1)
         saved.append(str(output_path))
 
@@ -349,7 +365,7 @@ def main():
                 prompt_optimizer=args.prompt_optimizer,
                 subject_reference=args.subject_reference,
             )
-        except FileNotFoundError as e:
+        except (FileNotFoundError, ValueError) as e:
             print(json.dumps({"error": True, "message": str(e)}))
             sys.exit(1)
         print(json.dumps(result, indent=2))

--- a/tests/test_banana_minimax_image.py
+++ b/tests/test_banana_minimax_image.py
@@ -1,0 +1,160 @@
+"""Tests for the Banana direct REST fallback MiniMax image_generation path."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import io
+import json
+import urllib.error
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SECRET = "sk-" + "DUMMYMINIMAXKEY0000000000"
+
+
+def _load_generate():
+    spec = importlib.util.spec_from_file_location(
+        "banana_generate_minimax", REPO_ROOT / "extensions/banana/scripts/generate.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _capture_exit_output(callable_):
+    out = io.StringIO()
+    with redirect_stdout(out):
+        try:
+            callable_()
+        except SystemExit as exc:
+            assert exc.code == 1
+    return json.loads(out.getvalue())
+
+
+def test_endpoints_cover_global_and_cn_regions():
+    module = _load_generate()
+    assert module.MINIMAX_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/image_generation"
+    assert module.MINIMAX_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/image_generation"
+    assert module.MINIMAX_MODELS == {"image-01", "image-01-live"}
+    assert module.MINIMAX_DEFAULT_MODEL == "image-01"
+
+
+def test_build_request_uses_aspect_ratio_and_controls():
+    module = _load_generate()
+    body = module.build_minimax_request(
+        "a cat", "image-01", aspect_ratio="16:9", response_format="url",
+        seed=7, count=3, prompt_optimizer=True,
+    )
+    assert body["model"] == "image-01"
+    assert body["prompt"] == "a cat"
+    assert body["aspect_ratio"] == "16:9"
+    assert body["response_format"] == "url"
+    assert body["seed"] == 7
+    assert body["n"] == 3
+    assert body["prompt_optimizer"] is True
+    assert "width" not in body and "height" not in body
+
+
+def test_build_request_prefers_pixel_dimensions_and_subject_reference():
+    module = _load_generate()
+    body = module.build_minimax_request(
+        "a cat", "image-01-live", aspect_ratio="1:1", width=1024, height=768,
+        response_format="base64", subject_reference="https://example.com/ref.png",
+    )
+    assert body["width"] == 1024
+    assert body["height"] == 768
+    assert "aspect_ratio" not in body
+    assert body["response_format"] == "base64"
+    assert body["subject_reference"] == [
+        {"type": "character", "image_file": "https://example.com/ref.png"}
+    ]
+
+
+def test_subject_reference_local_file_becomes_data_uri(tmp_path):
+    module = _load_generate()
+    ref = tmp_path / "ref.png"
+    ref.write_bytes(b"pixels")
+    payload = module._encode_subject_reference([str(ref)])
+    assert payload[0]["type"] == "character"
+    assert payload[0]["image_file"].startswith("data:image/png;base64,")
+
+
+def test_parse_response_extracts_urls_and_base64():
+    module = _load_generate()
+    kind, urls = module.parse_minimax_response(
+        {"data": {"image_urls": ["https://cdn/img.png"]}, "base_resp": {"status_code": 0}},
+        "url",
+    )
+    assert kind == "url" and urls == ["https://cdn/img.png"]
+
+    kind, payloads = module.parse_minimax_response(
+        {"data": {"image_base64": ["QUJD"]}, "base_resp": {"status_code": 0}},
+        "base64",
+    )
+    assert kind == "base64" and payloads == ["QUJD"]
+
+
+def test_parse_response_raises_on_upstream_error():
+    module = _load_generate()
+    with pytest.raises(ValueError, match="insufficient balance"):
+        module.parse_minimax_response(
+            {"base_resp": {"status_code": 1008, "status_msg": "insufficient balance"}},
+            "url",
+        )
+
+
+def test_generate_base64_saves_file(tmp_path):
+    module = _load_generate()
+    encoded = base64.b64encode(b"fake-png-bytes").decode("utf-8")
+    payload = {
+        "data": {"image_base64": [encoded]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+        result = module.generate_image_minimax(
+            "a cat", "image-01", SECRET, region="cn_zh", response_format="base64",
+        )
+    assert result["region"] == "cn_zh"
+    assert result["success_count"] == "1"
+    assert len(result["paths"]) == 1
+    saved = Path(result["paths"][0])
+    assert saved.exists()
+    assert saved.read_bytes() == b"fake-png-bytes"
+
+
+def test_generate_redacts_api_key_in_http_error(tmp_path):
+    module = _load_generate()
+    body = ('{"message":"bad request with ' + SECRET + '"}').encode()
+    err = urllib.error.HTTPError(
+        url=module.MINIMAX_ENDPOINTS["global_en"], code=401, msg="Unauthorized",
+        hdrs={}, fp=io.BytesIO(body),
+    )
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module.urllib.request, "urlopen", side_effect=err):
+        out = _capture_exit_output(
+            lambda: module.generate_image_minimax("a cat", "image-01", SECRET)
+        )
+    assert SECRET not in json.dumps(out)

--- a/tests/test_banana_minimax_image.py
+++ b/tests/test_banana_minimax_image.py
@@ -35,11 +35,25 @@ class _FakeResponse:
     def read(self):
         return self._body
 
+    @property
+    def content(self):
+        return self._body
+
+    def raise_for_status(self):
+        return None
+
     def __enter__(self):
         return self
 
     def __exit__(self, *exc):
         return False
+
+
+class _BinaryResponse:
+    content = b"image"
+
+    def raise_for_status(self):
+        return None
 
 
 def _capture_exit_output(callable_):
@@ -93,11 +107,21 @@ def test_build_request_prefers_pixel_dimensions_and_subject_reference():
 
 def test_subject_reference_local_file_becomes_data_uri(tmp_path):
     module = _load_generate()
+    module.MINIMAX_SUBJECT_REFERENCE_DIR = tmp_path.resolve()
     ref = tmp_path / "ref.png"
     ref.write_bytes(b"pixels")
     payload = module._encode_subject_reference([str(ref)])
     assert payload[0]["type"] == "character"
     assert payload[0]["image_file"].startswith("data:image/png;base64,")
+
+
+def test_subject_reference_rejects_file_outside_allowlist(tmp_path):
+    module = _load_generate()
+    module.MINIMAX_SUBJECT_REFERENCE_DIR = tmp_path.resolve()
+    outside = tmp_path.parent / "outside.png"
+    outside.write_bytes(b"pixels")
+    with pytest.raises(ValueError, match="inside"):
+        module._encode_subject_reference([str(outside)])
 
 
 def test_parse_response_extracts_urls_and_base64():
@@ -143,6 +167,21 @@ def test_generate_base64_saves_file(tmp_path):
     saved = Path(result["paths"][0])
     assert saved.exists()
     assert saved.read_bytes() == b"fake-png-bytes"
+
+
+def test_generate_url_uses_safe_fetch(tmp_path):
+    module = _load_generate()
+    payload = {
+        "data": {"image_urls": ["https://cdn.example/img.png"]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0},
+    }
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module.urllib.request, "urlopen", return_value=_FakeResponse(payload)), \
+            patch.object(module, "safe_requests_get", return_value=_BinaryResponse()) as fetch:
+        result = module.generate_image_minimax("a cat", "image-01", SECRET)
+    fetch.assert_called_once_with("https://cdn.example/img.png", timeout=120)
+    assert Path(result["path"]).read_bytes() == b"image"
 
 
 def test_generate_redacts_api_key_in_http_error(tmp_path):


### PR DESCRIPTION
Reason: The Banana direct REST fallback could not target the MiniMax image_generation API, so text-to-image generation had no MiniMax path.

## What changed

- `extensions/banana/scripts/generate.py`: add an opt-in `--provider minimax` path to the stdlib-only fallback generator, leaving the existing default path unchanged.
  - Global (`https://api.minimax.io/v1/image_generation`) and CN (`https://api.minimaxi.com/v1/image_generation`) endpoints, selected with `--region {global_en,cn_zh}`.
  - `image-01` (default) and `image-01-live` models.
  - Request controls: `aspect_ratio` or explicit `--width`/`--height`, `--response-format {url,base64}`, `--seed`, `--count` (n), `--prompt-optimizer`/`--no-prompt-optimizer`, and `--subject-reference` (URL, data URI, or local file encoded to a base64 data URI).
  - Bearer authorization; response parsing for both `data.image_urls` (downloaded and saved to the existing output directory) and base64 payloads (decoded and saved); `base_resp.status_code` error surfacing and `metadata` success/failed counts.
  - API-key redaction on error output.
- `tests/test_banana_minimax_image.py`: unit tests for endpoint/model configuration, request-body assembly, URL and base64 response parsing, subject-reference encoding, the base64 save flow, and key redaction.

## Checks

- `python3 -m py_compile extensions/banana/scripts/generate.py`
- `python3 -m pytest tests/test_banana_minimax_image.py tests/test_banana_api_key_safety.py tests/test_banana_install_layout.py -q` -> 14 passed
