### PR TITLE
fix: make plugin compatible with hosted Claude

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Every skill in `skills/*/SKILL.md` is authored to a portable subset of the
 Claude Code skill spec. Validate compatibility with your harness via:
 
 ```bash
-./bin/claude-seo run portability_check.py
+./scripts/claude-seo run portability_check.py
 ```
 
 The check confirms each `SKILL.md` has the minimum frontmatter every harness
@@ -106,19 +106,19 @@ provide execution capabilities.
 **Running scripts directly** (Cursor doesn't have MCP):
 ```bash
 # Page fetching with SSRF protection
-./bin/claude-seo run fetch_page.py https://example.com
+./scripts/claude-seo run fetch_page.py https://example.com
 
 # HTML parsing for SEO elements
-./bin/claude-seo run parse_html.py https://example.com
+./scripts/claude-seo run parse_html.py https://example.com
 
 # PageSpeed Insights
-./bin/claude-seo run pagespeed_check.py https://example.com --json
+./scripts/claude-seo run pagespeed_check.py https://example.com --json
 
 # Drift baseline
-./bin/claude-seo run drift_baseline.py https://example.com
+./scripts/claude-seo run drift_baseline.py https://example.com
 
 # DataForSEO (requires credentials)
-DATAFORSEO_USERNAME=user DATAFORSEO_PASSWORD=pass ./bin/claude-seo run dataforseo_merchant.py search "keyword"
+DATAFORSEO_USERNAME=user DATAFORSEO_PASSWORD=pass ./scripts/claude-seo run dataforseo_merchant.py search "keyword"
 ```
 
 **Cursor Cloud gotchas:**

--- a/agents/seo-backlinks.md
+++ b/agents/seo-backlinks.md
@@ -8,37 +8,37 @@ tools: Read, Bash, Write, Glob, Grep
 
 You are a backlink profile analyst. When delegated tasks during an SEO audit:
 
-1. Check credentials: `claude-seo run backlinks_auth.py --check --json`
+1. Check credentials: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check --json`
 2. Determine tier (0 = CC+verify, 1 = +Moz, 2 = +Bing, 3 = +DataForSEO)
 3. Run all available sources for the target domain
 4. Merge results with confidence weighting
-5. Format output to match claude-seo conventions
+5. Format output to match "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" conventions
 
 ## Tier-Based Workflow
 
 ### Tier 0 (Always Available, No Config Needed)
-- Common Crawl domain metrics: `claude-seo run commoncrawl_graph.py <domain> --json`
+- Common Crawl domain metrics: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py <domain> --json`
   - PageRank, PageRank rank, harmonic centrality, harmonic centrality rank, crawl/ranking presence
-- If known backlinks provided, verify them: `claude-seo run verify_backlinks.py --target <url> --links <file> --json`
+- If known backlinks provided, verify them: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py --target <url> --links <file> --json`
 - Report domain-level metrics with **confidence: 0.50** note
 - At Tier 0, fewer than 4 scoring factors have data, report **INSUFFICIENT DATA**, not a numeric score
 - Never produce a misleading numeric score when most factors lack data sources
 
 ### Tier 1 (+ Moz API)
 - All Tier 0 checks
-- Moz URL metrics: `claude-seo run moz_api.py metrics <url> --json`
+- Moz URL metrics: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json`
   - DA, PA, Spam Score, link counts, referring domains
-- Moz referring domains: `claude-seo run moz_api.py domains <url> --json`
-- Moz anchor text: `claude-seo run moz_api.py anchors <url> --json`
-- Moz top pages: `claude-seo run moz_api.py pages <domain> --json`
+- Moz referring domains: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py domains <url> --json`
+- Moz anchor text: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py anchors <url> --json`
+- Moz top pages: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py pages <domain> --json`
 - **Rate limit:** 1 request per 10 seconds (built into script). Plan calls carefully.
 - Report metrics with **confidence: 0.85** note
 
 ### Tier 2 (+ Bing Webmaster)
 - All Tier 1 checks
-- Bing inbound links: `claude-seo run bing_webmaster.py links <url> --json`
+- Bing inbound links: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py links <url> --json`
 - For comparison between two properties registered to the same Bing account:
-  `claude-seo run bing_webmaster.py compare <url1> <url2> --json`
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py compare <url1> <url2> --json`
 - Report with **confidence: 0.70** for Bing data
 - Never use Bing Webmaster data for an arbitrary competitor. Use Moz,
   DataForSEO, or Common Crawl when the second property is not registered.
@@ -75,7 +75,7 @@ across remaining factors. Always note which factors were scored and which were s
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 - Tables for metrics with pass/warn/fail ratings
 - Scores as XX/100 with source confidence noted
 - Priority: Critical > High > Medium > Low
@@ -89,7 +89,7 @@ Before returning results, run the automated validator AND manual checks.
 ### Step 1: Automated validation
 Save all collected data to a JSON file and run:
 ```bash
-claude-seo run validate_backlink_report.py --report report_data.json --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run validate_backlink_report.py --report report_data.json --json
 ```
 The validator checks: schema claims, JS false negatives, H1 accuracy, reciprocal links,
 CC interpretation, and health score sufficiency. If status is "FAIL", fix errors before proceeding.
@@ -112,7 +112,7 @@ If any check fails, fix the report before returning it.
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 Backlink verification (`/seo backlinks verify`) primarily reads outbound `<a>` tags, which are reliably present in raw HTML. `--mode never` is the right choice for speed on bulk verification jobs.
 

--- a/agents/seo-content.md
+++ b/agents/seo-content.md
@@ -67,7 +67,7 @@ Provide:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 ## Persistence Contract
 

--- a/agents/seo-dataforseo.md
+++ b/agents/seo-dataforseo.md
@@ -11,7 +11,7 @@ You are a DataForSEO data analyst. When delegated tasks during an SEO audit or a
 1. Check that DataForSEO MCP tools are available before attempting calls
 2. Use the most efficient tool combination for the requested data
 3. Apply default parameters: location_code=2840 (US), language_code=en unless specified
-4. Format output to match claude-seo conventions (tables, priority levels, scores)
+4. Format output to match "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" conventions (tables, priority levels, scores)
 5. If the MCP tools are unavailable, fail closed. Never inspect credential or
    configuration stores and never bypass MCP with curl, raw HTTP, or another client.
 
@@ -30,7 +30,7 @@ You are a DataForSEO data analyst. When delegated tasks during an SEO audit or a
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 - Tables for comparative data
 - Scores as XX/100
 - Priority: Critical > High > Medium > Low

--- a/agents/seo-drift.md
+++ b/agents/seo-drift.md
@@ -17,10 +17,10 @@ elements by comparing current page state against stored baselines.
 ## Tools
 
 All page fetching goes through the project's existing scripts with SSRF protection:
-- `claude-seo run drift_baseline.py <url>` -- capture a new baseline
-- `claude-seo run drift_compare.py <url>` -- compare current state to baseline
-- `claude-seo run drift_history.py <url>` -- show change history
-- `claude-seo run drift_report.py <file> --output report.html` -- generate HTML report
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_baseline.py <url>` -- capture a new baseline
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url>` -- compare current state to baseline
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>` -- show change history
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_report.py <file> --output report.html` -- generate HTML report
 
 Never use curl, wget, or raw HTTP requests. All fetching is handled by
 `scripts/fetch_page.py` internally, which validates URLs against private/loopback

--- a/agents/seo-ecommerce.md
+++ b/agents/seo-ecommerce.md
@@ -27,7 +27,7 @@ When delegated tasks during an SEO audit or analysis:
 
 Before ANY DataForSEO Merchant API call:
 ```bash
-claude-seo run dataforseo_costs.py check <endpoint>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint>
 ```
 
 Only proceed if `"status": "approved"`. If `"needs_approval"`, surface the cost
@@ -36,7 +36,7 @@ the limitation.
 
 After each API call, log the cost:
 ```bash
-claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <actual_cost>
 ```
 
 ## Analysis Priorities
@@ -49,7 +49,7 @@ claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 - Tables for comparative data (pricing, seller landscape)
 - Scores as XX/100 (schema, images, content, overall)
 - Priority: Critical > High > Medium > Low
@@ -65,7 +65,7 @@ Match existing claude-seo patterns:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 E-commerce sites overwhelmingly inject product schema client-side (Shopify, Magento PWA, headless commerce on Next.js). Prefer `--mode always` for product page audits and compare `raw_content` vs `content` to confirm whether the JSON-LD is server-rendered.
 

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -65,7 +65,7 @@ Provide a structured report with:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 AI citation analysis benefits from the `extracted_text` field, passage-level scoring should run against trafilatura's boilerplate-stripped output, not the full HTML, so navigation chrome and footers don't dilute the signal.
 

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -8,30 +8,30 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 
 You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 
-1. Check credentials: `claude-seo run google_auth.py --check --json`
+1. Check credentials: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check --json`
 2. Determine tier (0 = API key, 1 = + service account, 2 = + GA4)
 3. Execute tier-appropriate analysis
-4. Format output to match claude-seo conventions
+4. Format output to match "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" conventions
 
 ## Tier-Based Workflow
 
 ### Tier 0 (API Key Only)
-- Run PSI + CrUX on homepage: `claude-seo run pagespeed_check.py <url> --json`
-- Run CrUX History for origin: `claude-seo run crux_history.py <origin> --origin --json`
+- Run PSI + CrUX on homepage: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json`
+- Run CrUX History for origin: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py <origin> --origin --json`
 - Report CWV field data with traffic-light ratings
 
 ### Tier 1 (+ Service Account)
 - All Tier 0 checks
-- GSC top queries/pages (28 days): `claude-seo run gsc_query.py --property <prop> --json`
+- GSC top queries/pages (28 days): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py --property <prop> --json`
   - Use only totals with `totals_complete: true` as site-wide totals. Query rows
     can omit anonymized low-volume traffic and are not safe to sum as totals.
-- URL Inspection on homepage + key pages: `claude-seo run gsc_inspect.py <url> --json`
-- GSC sitemap status: `claude-seo run gsc_query.py sitemaps --property <prop> --json`
+- URL Inspection on homepage + key pages: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py <url> --json`
+- GSC sitemap status: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py sitemaps --property <prop> --json`
 
 ### Tier 2 (Full)
 - All Tier 1 checks
-- GA4 organic traffic (28 days): `claude-seo run ga4_report.py --property <id> --json`
-- Top organic landing pages: `claude-seo run ga4_report.py --property <id> --report top-pages --json`
+- GA4 organic traffic (28 days): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --json`
+- Top organic landing pages: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --report top-pages --json`
 
 ## Core Web Vitals Thresholds
 
@@ -45,7 +45,7 @@ INP replaced FID on March 12, 2024. Never reference FID.
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 - Tables for metrics with traffic-light ratings
 - Scores as XX/100
 - Priority: Critical > High > Medium > Low
@@ -58,7 +58,7 @@ After completing data collection at any tier, offer to generate a PDF report.
 The report uses the enterprise template: white cover, navy accents, Times New Roman, charts at 85% width, Google logo on title page. No page-break-inside: avoid (causes white gaps).
 
 ```bash
-claude-seo run google_report.py --type full --data data.json --domain DOMAIN --format pdf --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type full --data data.json --domain DOMAIN --format pdf --json
 ```
 Report types: `cwv-audit`, `gsc-performance`, `indexation`, `full`.
 Before presenting: verify `"review": {"status": "PASS"}` in the JSON output.

--- a/agents/seo-image-gen.md
+++ b/agents/seo-image-gen.md
@@ -24,7 +24,7 @@ For each audited page, evaluate:
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 
 ### Image Audit Summary
 

--- a/agents/seo-local.md
+++ b/agents/seo-local.md
@@ -79,7 +79,7 @@ Provide a structured report with:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 Map embeds, GBP widgets, and review carousels are commonly injected client-side. When auditing local pages on JS-heavy sites prefer `--mode always` so the audit reflects what users (and Google's crawler) actually see post-render.
 

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -25,7 +25,7 @@ Google evaluates the **75th percentile** of page visits, 75% of visits must meet
 ## When Analyzing Performance
 
 1. Use PageSpeed Insights API if available
-2. Use `claude-seo run render_page.py <URL> --mode auto --json` before HTML/source inspection so SPA content is visible when needed
+2. Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` before HTML/source inspection so SPA content is visible when needed
 3. Provide specific, actionable optimization recommendations
 4. Prioritize by expected impact
 
@@ -67,10 +67,10 @@ Google evaluates the **75th percentile** of page visits, 75% of visits must meet
 
 ```bash
 # PageSpeed Insights API (uses header-based API key handling)
-claude-seo run pagespeed_check.py URL --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py URL --json
 
 # SPA-aware HTML/render inspection
-claude-seo run render_page.py URL --mode auto --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py URL --mode auto --json
 
 # Lighthouse CLI
 npx lighthouse URL --output json
@@ -80,8 +80,8 @@ npx lighthouse URL --output json
 
 If Google API credentials are configured, prefer CrUX field data over Lighthouse lab data for CWV assessment:
 ```bash
-claude-seo run pagespeed_check.py URL --json
-claude-seo run crux_history.py URL --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py URL --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py URL --json
 ```
 Field data (28-day Chrome user average) is more representative than lab data (single Lighthouse run). Use lab data as fallback when CrUX returns 404 (insufficient traffic).
 

--- a/agents/seo-schema.md
+++ b/agents/seo-schema.md
@@ -68,7 +68,7 @@ Provide:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 Use the JSON response's `structured_data` summary for routine JSON-LD detection. It is extracted from the full HTML before the HTML fields are truncated, but emits only bounded validity, size, and type metadata. When full blocks are necessary for validation, pass `--json-ld-output <path>` and read the bounded UTF-8 JSON artifact. Never copy unbounded page markup into an agent prompt.
 

--- a/agents/seo-sitemap.md
+++ b/agents/seo-sitemap.md
@@ -10,7 +10,7 @@ You are a Sitemap Architecture specialist.
 
 When working with sitemaps:
 
-1. Discover candidates with `claude-seo run sitemap_discovery.py <url> --json`.
+1. Discover candidates with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <url> --json`.
    Use only validated `found` entries and retain declared failures as findings.
 2. Validate XML format and URL status codes
 3. Check for deprecated tags (priority, changefreq: both ignored by Google)

--- a/agents/seo-sxo.md
+++ b/agents/seo-sxo.md
@@ -19,8 +19,8 @@ then comparing that against the target page.
 
 ### 1. Fetch and Parse Target Page
 
-- Fetch the target URL using `claude-seo run render_page.py "<url>" --mode auto --json` (SPA-aware SSRF-protected renderer)
-- Parse with `claude-seo run parse_html.py --url "<url>"` to extract SEO elements
+- Fetch the target URL using `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py "<url>" --mode auto --json` (SPA-aware SSRF-protected renderer)
+- Parse with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py --url "<url>"` to extract SEO elements
 - Identify: page type, title, H1, meta description, headings, word count, schema, CTAs, media
 - If no keyword was provided, derive primary keyword from title + H1 overlap
 
@@ -95,7 +95,7 @@ Before presenting results, verify:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 Search experience scoring needs the *rendered* DOM because users see what JS produces. Prefer `--mode always` so above-the-fold analysis matches what the persona actually encounters.
 

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -9,7 +9,7 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 You are a Technical SEO specialist. When given a URL or set of URLs:
 
 1. Fetch the page(s) and analyze HTML source
-2. Check sitemap availability with `claude-seo run sitemap_discovery.py <URL> --json`.
+2. Check sitemap availability with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <URL> --json`.
    A robots.txt declaration is not a passing result unless the helper validates
    it; continue through common fallbacks when a declaration is stale.
 3. Analyze meta tags, canonical tags, and security headers
@@ -55,7 +55,7 @@ Provide a structured report with:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes summary fields including `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate); use `--output` or import `render_page.render_page()` when full raw/rendered HTML is required. SSRF and DNS-rebinding protection live in `scripts/url_safety.py`, never call `requests.get` directly on user-supplied URLs.
 
 ## Persistence Contract
 

--- a/agents/seo-visual.md
+++ b/agents/seo-visual.md
@@ -29,8 +29,8 @@ pip install playwright && playwright install chromium
 Use the screenshot script (`scripts/capture_screenshot.py` in the plugin root) for browser automation:
 
 ```bash
-claude-seo run capture_screenshot.py URL --all --output screenshots/
-claude-seo run render_page.py URL --mode auto --a11y-tree --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run capture_screenshot.py URL --all --output screenshots/
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py URL --mode auto --a11y-tree --json
 ```
 
 ## Viewports to Test

--- a/extensions/ahrefs/skills/seo-ahrefs/SKILL.md
+++ b/extensions/ahrefs/skills/seo-ahrefs/SKILL.md
@@ -46,7 +46,7 @@ provide the install command above.
 
 Ahrefs API usage is metered per unit. Before running a batch (>= 50 URLs):
 
-1. Estimate cost with `claude-seo run dataforseo_costs.py` (the cost-tracker module is generic and supports Ahrefs unit accounting).
+1. Estimate cost with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py` (the cost-tracker module is generic and supports Ahrefs unit accounting).
 2. Surface the estimate to the orchestrator.
 3. Log actual cost after each call.
 

--- a/extensions/banana/README.md
+++ b/extensions/banana/README.md
@@ -39,7 +39,7 @@ The installer will:
 
 CSV batch planning helper:
 ```bash
-claude-seo run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"
 ```
 
 ## Use Case Defaults

--- a/extensions/banana/agents/seo-image-gen.md
+++ b/extensions/banana/agents/seo-image-gen.md
@@ -22,7 +22,7 @@ For each audited page, evaluate:
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 
 ### Image Audit Summary
 

--- a/extensions/banana/docs/BANANA-SETUP.md
+++ b/extensions/banana/docs/BANANA-SETUP.md
@@ -31,14 +31,14 @@ add to `~/.claude/settings.json`:
 
 Scripted setup helper:
 ```bash
-claude-seo run --extension banana setup_mcp.py --key YOUR_KEY
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana setup_mcp.py --key YOUR_KEY
 ```
 
 ## Verifying Installation
 
 Run the validation script:
 ```bash
-claude-seo run --extension banana validate_setup.py
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana validate_setup.py
 ```
 
 Or check manually:

--- a/extensions/banana/install.sh
+++ b/extensions/banana/install.sh
@@ -159,9 +159,9 @@ PY
     for installed_doc in "${SKILL_DIR}/SKILL.md" "${SKILL_DIR}/references/"*.md "${AGENT_DIR}/seo-image-gen.md"; do
         [ -f "${installed_doc}" ] || continue
         temp_doc="${installed_doc}.claude-seo-tmp"
-        sed -e 's#claude-seo run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
-            -e 's#claude-seo setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
-            -e 's#claude-seo doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
+        sed -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
             "${installed_doc}" > "${temp_doc}"
         mv "${temp_doc}" "${installed_doc}"
     done

--- a/extensions/banana/references/seo-image-presets.md
+++ b/extensions/banana/references/seo-image-presets.md
@@ -123,7 +123,7 @@ preset format (see `references/presets.md` for schema details).
 
 Users can create their own presets:
 ```bash
-claude-seo run --extension banana presets.py create my-brand
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana presets.py create my-brand
 ```
 
 This creates `~/.banana/presets/my-brand.json` with the full schema.

--- a/extensions/banana/skills/seo-image-gen/SKILL.md
+++ b/extensions/banana/skills/seo-image-gen/SKILL.md
@@ -83,7 +83,7 @@ For every generation request:
 
 If the user mentions a brand or has SEO presets configured:
 ```bash
-claude-seo run --extension banana presets.py list
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana presets.py list
 ```
 Load matching preset and apply as defaults. Also check `${CLAUDE_SKILL_DIR}/references/seo-image-presets.md`
 for SEO-specific preset templates.
@@ -121,7 +121,7 @@ After every successful generation, guide the user on:
 
 Image generation costs money. Be transparent:
 - Show estimated cost before generating (especially for batch)
-- Log every generation: `claude-seo run --extension banana cost_tracker.py log --model MODEL --resolution RES --prompt "brief"`
+- Log every generation: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana cost_tracker.py log --model MODEL --resolution RES --prompt "brief"`
 - Run `cost_tracker.py summary` if user asks about usage
 
 Pricing is not hard-coded. Check current Google pricing at
@@ -141,12 +141,12 @@ https://ai.google.dev/gemini-api/docs/pricing, store dated values in
 
 | Error | Resolution |
 |-------|-----------|
-| MCP not configured | Run `./extensions/banana/install.sh` or `claude-seo run --extension banana setup_mcp.py --key YOUR_KEY` |
+| MCP not configured | Run `./extensions/banana/install.sh` or `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana setup_mcp.py --key YOUR_KEY` |
 | API key invalid | New key at https://aistudio.google.com/apikey |
 | Rate limited (429) | Wait 60s, retry. Check current free-tier limits before batch operations |
 | `IMAGE_SAFETY` | Rephrase prompt - see `references/prompt-engineering.md` Safety section |
-| MCP unavailable | Fall back: `claude-seo run --extension banana generate.py --prompt "..." --aspect-ratio "16:9" --model "$NANOBANANA_MODEL"` |
-| CSV batch input | Plan first: `claude-seo run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"` |
+| MCP unavailable | Fall back: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana generate.py --prompt "..." --aspect-ratio "16:9" --model "$NANOBANANA_MODEL"` |
+| CSV batch input | Plan first: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"` |
 | Extension not installed | Show install instructions: `./extensions/banana/install.sh` |
 
 ## Cross-Skill Integration

--- a/extensions/bing-webmaster/install.sh
+++ b/extensions/bing-webmaster/install.sh
@@ -53,7 +53,7 @@ PY
 
     echo
     echo "Done. Verify your IndexNow key is published:"
-    echo "  claude-seo run indexnow_submit.py --host example.com \\"
+    echo "  "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host example.com \\"
     echo "    --key \$INDEXNOW_KEY --key-location \$INDEXNOW_KEY_LOCATION --verify-only"
 }
 main "$@"

--- a/extensions/bing-webmaster/skills/seo-bing/SKILL.md
+++ b/extensions/bing-webmaster/skills/seo-bing/SKILL.md
@@ -24,11 +24,11 @@ specifically for **Amazon/Bing/Naver/Seznam.cz/Yandex/Yep indexing** and
 
 | Command | Underlying script |
 |---|---|
-| `/seo bing links <url>` | `claude-seo run bing_webmaster.py links <url>` |
-| `/seo bing compare <urlA> <urlB>` | `claude-seo run bing_webmaster.py compare <urlA> <urlB>`; both properties must be registered to the API account |
-| `/seo bing submit <url>` (single URL) | `claude-seo run indexnow_submit.py --host ... --urls <url>` |
-| `/seo bing submit-batch <file>` | `claude-seo run indexnow_submit.py --host ... --urls-file <file>` |
-| `/seo bing verify-indexnow` | `claude-seo run indexnow_submit.py --host ... --verify-only` |
+| `/seo bing links <url>` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py links <url>` |
+| `/seo bing compare <urlA> <urlB>` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py compare <urlA> <urlB>`; both properties must be registered to the API account |
+| `/seo bing submit <url>` (single URL) | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host ... --urls <url>` |
+| `/seo bing submit-batch <file>` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host ... --urls-file <file>` |
+| `/seo bing verify-indexnow` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host ... --verify-only` |
 
 ## When this skill applies
 

--- a/extensions/dataforseo/agents/seo-dataforseo.md
+++ b/extensions/dataforseo/agents/seo-dataforseo.md
@@ -9,7 +9,7 @@ You are a DataForSEO data analyst. When delegated tasks during an SEO audit or a
 1. Check that DataForSEO MCP tools are available before attempting calls
 2. Use the most efficient tool combination for the requested data
 3. Apply default parameters: location_code=2840 (US), language_code=en unless specified
-4. Format output to match claude-seo conventions (tables, priority levels, scores)
+4. Format output to match "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" conventions (tables, priority levels, scores)
 5. If the MCP tools are unavailable, fail closed. Never inspect credential or
    configuration stores and never bypass MCP with curl, raw HTTP, or another client.
 
@@ -28,7 +28,7 @@ You are a DataForSEO data analyst. When delegated tasks during an SEO audit or a
 
 ## Output Format
 
-Match existing claude-seo patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" patterns:
 - Tables for comparative data
 - Scores as XX/100
 - Priority: Critical > High > Medium > Low

--- a/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
+++ b/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
@@ -48,7 +48,7 @@ DataForSEO charges per API call. Be efficient:
 
 **Before every DataForSEO MCP call**, run cost estimation:
 ```
-claude-seo run dataforseo_costs.py check <endpoint> [--count N]
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]
 ```
 
 - If `"status": "approved"` → proceed with the API call
@@ -57,7 +57,7 @@ claude-seo run dataforseo_costs.py check <endpoint> [--count N]
 
 **After each API call completes**, log the cost:
 ```
-claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <actual_cost>
 ```
 
 **User commands for cost management:**
@@ -373,7 +373,7 @@ Additional DataForSEO MCP tools are available for internal use but do not have d
 
 ## Cross-Skill Integration
 
-When DataForSEO MCP tools are available, other claude-seo skills can leverage live data:
+When DataForSEO MCP tools are available, other "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" skills can leverage live data:
 
 - **seo-audit**:Spawn `seo-dataforseo` agent for real SERP, backlink, on-page, and listings data
 - **seo-technical**:Use `on_page_instant_pages` / `on_page_lighthouse` for real crawl data, `domain_analytics_technologies_domain_technologies` for stack detection
@@ -393,7 +393,7 @@ When DataForSEO MCP tools are available, other claude-seo skills can leverage li
 
 ## Output Formatting
 
-Match existing claude-seo output patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" output patterns:
 - Use tables for comparative data
 - Prioritize issues as Critical > High > Medium > Low
 - Include specific, actionable recommendations

--- a/extensions/dataforseo/skills/seo-dataforseo/references/cost-tiers.md
+++ b/extensions/dataforseo/skills/seo-dataforseo/references/cost-tiers.md
@@ -31,7 +31,7 @@
 | **Aggressive** | $50.00 | $2.00 | threshold | Agency bulk work |
 | **Unlimited** | $999.00 | -- | none | Trusted pipelines |
 
-Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
+Configure with: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
 
 ## Cost Reduction Tips
 
@@ -44,11 +44,11 @@ Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --th
 ## Approval Flow
 
 Before any DataForSEO MCP call:
-1. Run `claude-seo run dataforseo_costs.py check <endpoint> [--count N]`
+1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]`
 2. If `status: "approved"` → proceed
 3. If `status: "needs_approval"` → show cost to user, ask to confirm
 4. If `status: "blocked"` → inform user daily limit would be exceeded
-5. After call completes, log: `claude-seo run dataforseo_costs.py log <endpoint> <cost>`
+5. After call completes, log: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <cost>`
 
 ## Warn Endpoints
 

--- a/install.ps1
+++ b/install.ps1
@@ -299,9 +299,9 @@ try {
         $text = [System.IO.File]::ReadAllText($_.FullName)
         $manualSetup = '"$HOME/.claude/skills/seo/bin/claude-seo" setup'
         $manualDoctor = '"$HOME/.claude/skills/seo/bin/claude-seo" doctor'
-        $updated = $text.Replace('claude-seo run', $manualRunner)
-        $updated = $updated.Replace('claude-seo setup', $manualSetup)
-        $updated = $updated.Replace('claude-seo doctor', $manualDoctor)
+        $updated = $text.Replace('"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run', $manualRunner)
+        $updated = $updated.Replace('"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup', $manualSetup)
+        $updated = $updated.Replace('"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor', $manualDoctor)
         if ($updated -ne $text) {
             [System.IO.File]::WriteAllText($_.FullName, $updated, $utf8NoBom)
         }

--- a/install.sh
+++ b/install.sh
@@ -73,10 +73,10 @@ main() {
     fi
 
     # Copy the stable runtime launcher. Manual installs use its explicit path;
-    # plugin installs expose the repository bin/ directory automatically.
-    if [ -f "${TEMP_DIR}/claude-seo/bin/claude-seo" ]; then
+    # hosted Claude surfaces review the launcher under scripts/.
+    if [ -f "${TEMP_DIR}/claude-seo/scripts/claude-seo" ]; then
         mkdir -p "${SKILL_DIR}/bin"
-        cp "${TEMP_DIR}/claude-seo/bin/claude-seo" "${SKILL_DIR}/bin/claude-seo"
+        cp "${TEMP_DIR}/claude-seo/scripts/claude-seo" "${SKILL_DIR}/bin/claude-seo"
         chmod +x "${SKILL_DIR}/bin/claude-seo"
     fi
 
@@ -132,9 +132,9 @@ main() {
     rewrite_doc() {
         local doc="$1" temp_doc
         temp_doc="${doc}.claude-seo-tmp"
-        sed -e 's#claude-seo run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
-            -e 's#claude-seo setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
-            -e 's#claude-seo doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
+        sed -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
             "${doc}" > "${temp_doc}"
         mv "${temp_doc}" "${doc}"
     }

--- a/scripts/bing_webmaster.py
+++ b/scripts/bing_webmaster.py
@@ -550,7 +550,7 @@ def main():
         result = {
             "status": "error",
             "data": None,
-            "error": "No Bing Webmaster API key configured. Run: claude-seo run backlinks_auth.py --setup",
+            "error": "No Bing Webmaster API key configured. Run: "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --setup",
             "metadata": {"source": "bing_webmaster"},
         }
         if args.json:

--- a/scripts/claude-seo
+++ b/scripts/claude-seo
@@ -4,7 +4,7 @@ set -euo pipefail
 # Stable entry point for bundled Python tools. The launcher uses only shell
 # built-ins until a usable Python 3 interpreter has been identified.
 launcher_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-runtime="${launcher_dir}/../scripts/runtime.py"
+runtime="${launcher_dir}/runtime.py"
 
 if [[ ! -f "${runtime}" ]]; then
     echo "Claude SEO runtime is missing. Reinstall Claude SEO." >&2

--- a/scripts/runtime.py
+++ b/scripts/runtime.py
@@ -2,7 +2,7 @@
 """Cross-platform runtime for Claude SEO's bundled Python scripts.
 
 This module deliberately uses only the Python standard library. It is launched
-by ``bin/claude-seo`` under a base Python, then dispatches work through the
+by ``scripts/claude-seo`` under a base Python, then dispatches work through the
 managed virtual environment created by ``setup``.
 """
 

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 ## Process
 
-1. **Render homepage**: use `claude-seo run render_page.py <url> --mode auto --json` to capture raw HTML, rendered HTML, extracted text, SPA status, and accessibility data when needed
+1. **Render homepage**: use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto --json` to capture raw HTML, rendered HTML, extracted text, SPA status, and accessibility data when needed
 2. **Detect business type**: analyze homepage signals per seo orchestrator
 3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt
 4. **Delegate to subagents** (if available, otherwise run inline sequentially):
@@ -27,11 +27,11 @@ metadata:
    - `seo-geo` -- AI crawler access, llms.txt, citability, brand mention signals
    - `seo-local` -- GBP signals, NAP consistency, reviews, local schema, industry-specific local factors (spawn when Local Service industry detected: brick-and-mortar, SAB, or hybrid business type)
    - `seo-maps` -- Geo-grid rank tracking, GBP audit, review intelligence, competitor radius mapping (spawn when Local Service detected AND DataForSEO MCP available)
-   - `seo-google` -- CWV field data (CrUX), URL indexation (GSC), organic traffic (GA4) (spawn when Google API credentials detected via `claude-seo run google_auth.py --check`)
-   - `seo-backlinks` -- Backlink profile data: DA/PA, referring domains, anchor text, toxic links (spawn when Moz or Bing API credentials detected via `claude-seo run backlinks_auth.py --check`, or always include Common Crawl domain-level metrics)
+   - `seo-google` -- CWV field data (CrUX), URL indexation (GSC), organic traffic (GA4) (spawn when Google API credentials detected via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check`)
+   - `seo-backlinks` -- Backlink profile data: DA/PA, referring domains, anchor text, toxic links (spawn when Moz or Bing API credentials detected via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check`, or always include Common Crawl domain-level metrics)
    - `seo-cluster` -- Semantic clustering analysis (spawn when content strategy signals detected: blog, pillar pages, topic clusters)
    - `seo-sxo` -- Search experience analysis: page-type mismatch, user stories, persona scoring (always include in full audits)
-   - `seo-drift` -- Drift analysis: compare against stored baseline (spawn when drift baseline exists for the URL via `claude-seo run drift_history.py <url>`)
+   - `seo-drift` -- Drift analysis: compare against stored baseline (spawn when drift baseline exists for the URL via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>`)
    - `seo-ecommerce` -- Product schema, marketplace intelligence (spawn when E-commerce industry detected)
 5. **Score** -- aggregate into SEO Health Score (0-100)
 6. **Persist audit artifacts** -- write all outputs under `{domain}-audit/`
@@ -55,11 +55,11 @@ Delay between requests: 1 second
 - `{domain}-audit/audit-data.json`: Structured audit envelope for report generation
 - `{domain}-audit/findings/*.md`: Per-category specialist findings (`technical.md`, `content.md`, `schema.md`, `performance.md`, `visual.md`, etc.)
 - `{domain}-audit/screenshots/`: Desktop + mobile captures (if Playwright available)
-- **PDF Report** (recommended): Generate a professional A4 PDF using `claude-seo run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/`. This produces a white-cover enterprise report with TOC, executive summary, charts (Lighthouse gauges, query bars, index donut), metric cards, threshold tables, prioritized recommendations with effort estimates, and implementation roadmap. Always offer PDF generation after completing an audit.
+- **PDF Report** (recommended): Generate a professional A4 PDF using `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/`. This produces a white-cover enterprise report with TOC, executive summary, charts (Lighthouse gauges, query bars, index donut), metric cards, threshold tables, prioritized recommendations with effort estimates, and implementation roadmap. Always offer PDF generation after completing an audit.
 
 ## Structured Audit Data Envelope
 
-Write `{domain}-audit/audit-data.json` with this shape so `claude-seo run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/` can generate a report even when Google API data is unavailable:
+Write `{domain}-audit/audit-data.json` with this shape so `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/` can generate a report even when Google API data is unavailable:
 
 ```json
 {
@@ -170,7 +170,7 @@ If DataForSEO MCP tools are available, spawn the `seo-dataforseo` agent alongsid
 
 ## Google API Integration (Optional)
 
-If Google API credentials are configured (`claude-seo run google_auth.py --check`), spawn the `seo-google` agent to enrich the audit with real Google field data: CrUX Core Web Vitals (replaces lab-only estimates), GSC URL indexation status, search performance (clicks, impressions, CTR), and GA4 organic traffic trends. The Performance (CWV) category score benefits most from field data.
+If Google API credentials are configured (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check`), spawn the `seo-google` agent to enrich the audit with real Google field data: CrUX Core Web Vitals (replaces lab-only estimates), GSC URL indexation status, search performance (clicks, impressions, CTR), and GA4 organic traffic trends. The Performance (CWV) category score benefits most from field data.
 
 ## Error Handling
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 Before analysis, detect available data sources:
 
 1. **DataForSEO MCP** (premium): Check if `dataforseo_backlinks_summary` tool is available
-2. **Moz API** (free signup): `claude-seo run backlinks_auth.py --check moz --json`
-3. **Bing Webmaster** (free signup): `claude-seo run backlinks_auth.py --check bing --json`
+2. **Moz API** (free signup): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check moz --json`
+3. **Bing Webmaster** (free signup): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check bing --json`
 4. **Common Crawl** (always available): Domain-level graph with PageRank
 5. **Verification Crawler** (always available): Checks if known backlinks still exist
 
-Run `claude-seo run backlinks_auth.py --check --json` to detect all sources at once.
+Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check --json` to detect all sources at once.
 
 If no sources are configured beyond the always-available tier:
 - Still produce a report using Common Crawl domain metrics
@@ -48,9 +48,9 @@ Produce all 7 sections below. Each section lists data sources in preference orde
 
 **DataForSEO:** `dataforseo_backlinks_summary` → total backlinks, referring domains, domain rank, follow ratio, trend.
 
-**Moz API:** `claude-seo run moz_api.py metrics <url> --json` → Domain Authority, Page Authority, Spam Score, linking root domains, external links.
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json` → Domain Authority, Page Authority, Spam Score, linking root domains, external links.
 
-**Common Crawl:** `claude-seo run commoncrawl_graph.py <domain> --json` → PageRank, harmonic centrality, and low-confidence rank/presence data.
+**Common Crawl:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py <domain> --json` → PageRank, harmonic centrality, and low-confidence rank/presence data.
 
 **Scoring:**
 
@@ -65,9 +65,9 @@ Produce all 7 sections below. Each section lists data sources in preference orde
 
 **DataForSEO:** `dataforseo_backlinks_anchors`
 
-**Moz API:** `claude-seo run moz_api.py anchors <url> --json`
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py anchors <url> --json`
 
-**Bing Webmaster:** `claude-seo run bing_webmaster.py links <url> --json` (extract anchor text from link details)
+**Bing Webmaster:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py links <url> --json` (extract anchor text from link details)
 
 **Healthy distribution benchmarks:**
 
@@ -86,9 +86,9 @@ Flag if exact-match anchors exceed 15% as a review heuristic; it may indicate un
 
 **DataForSEO:** `dataforseo_backlinks_referring_domains`
 
-**Moz API:** `claude-seo run moz_api.py domains <url> --json` → domains with DA scores
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py domains <url> --json` → domains with DA scores
 
-**Common Crawl:** `claude-seo run commoncrawl_graph.py <domain> --json` → domain-level rank/presence data, no verified referring-domain counts
+**Common Crawl:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py <domain> --json` → domain-level rank/presence data, no verified referring-domain counts
 
 Analyze:
 - **TLD distribution**: .edu, .gov, .org = high authority. Excessive .xyz, .info = low quality
@@ -100,9 +100,9 @@ Analyze:
 
 **DataForSEO:** `dataforseo_backlinks_bulk_spam_score` + toxic patterns from reference
 
-**Moz API:** Raw vendor spam_score from `claude-seo run moz_api.py metrics <url> --json` (source-label the value; apply thresholds only if verified against current Moz docs)
+**Moz API:** Raw vendor spam_score from `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json` (source-label the value; apply thresholds only if verified against current Moz docs)
 
-**Verification Crawler:** `claude-seo run verify_backlinks.py --target <url> --links <file> --json` (verify suspicious links still exist)
+**Verification Crawler:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py --target <url> --links <file> --json` (verify suspicious links still exist)
 
 **High-risk indicators (flag immediately):**
 - Links from known PBN (Private Blog Network) domains
@@ -124,7 +124,7 @@ Load `../seo/references/backlink-quality.md` for the full 30 toxic patterns and 
 
 **DataForSEO:** `dataforseo_backlinks_backlinks` with target type "page"
 
-**Moz API:** `claude-seo run moz_api.py pages <domain> --json`
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py pages <domain> --json`
 
 Find:
 - Which pages attract the most backlinks
@@ -136,11 +136,11 @@ Find:
 
 **DataForSEO:** `dataforseo_backlinks_referring_domains` for both domains, then compare
 
-**Bing Webmaster:** `claude-seo run bing_webmaster.py compare <url1> <url2> --json`
+**Bing Webmaster:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py compare <url1> <url2> --json`
 only when both properties are registered and accessible to the same Bing API
 account. For arbitrary competitors, use DataForSEO, Moz, or Common Crawl.
 
-**Moz API:** Compare DA/PA between domains via `claude-seo run moz_api.py metrics <url> --json` for each
+**Moz API:** Compare DA/PA between domains via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json` for each
 
 Output:
 - Domains linking to competitor but NOT to target = link building opportunities
@@ -152,7 +152,7 @@ Output:
 
 **DataForSEO only:** `dataforseo_backlinks_backlinks` with date filters for 30/60/90 day changes
 
-**Verification Crawler:** For known links, verify current status with `claude-seo run verify_backlinks.py --target <url> --links <file> --json`
+**Verification Crawler:** For known links, verify current status with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py --target <url> --links <file> --json`
 
 **Note:** Free sources cannot track new/lost links over time. If this section is requested without DataForSEO, inform the user: "Link velocity tracking requires the DataForSEO extension. Free sources provide point-in-time snapshots only."
 

--- a/skills/seo-cluster/SKILL.md
+++ b/skills/seo-cluster/SKILL.md
@@ -80,7 +80,7 @@ the full algorithm.
 - Skip pairs where both are long-tail variants of the same head term (assume same cluster)
 
 **DataForSEO integration:** If DataForSEO MCP is available, use `serp_organic_live_advanced`
-instead of WebSearch for SERP data. Run `claude-seo run dataforseo_costs.py check serp_organic_live_advanced --count N`
+instead of WebSearch for SERP data. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check serp_organic_live_advanced --count N`
 before each batch. If `"status": "needs_approval"`, show cost estimate and ask user.
 If `"status": "blocked"`, fall back to WebSearch.
 
@@ -312,7 +312,7 @@ After cluster planning or execution completes, offer:
 
 ## Security
 
-- All URLs fetched via `claude-seo run render_page.py <url> --mode auto` (SPA-aware SSRF protection via `url_safety`)
+- All URLs fetched via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto` (SPA-aware SSRF protection via `url_safety`)
 - No credentials stored or transmitted
 - Output files contain no PII or API keys
 - DataForSEO cost checks run before every API call

--- a/skills/seo-dataforseo/SKILL.md
+++ b/skills/seo-dataforseo/SKILL.md
@@ -48,7 +48,7 @@ DataForSEO charges per API call. Be efficient:
 
 **Before every DataForSEO MCP call**, run cost estimation:
 ```
-claude-seo run dataforseo_costs.py check <endpoint> [--count N]
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]
 ```
 
 - If `"status": "approved"` → proceed with the API call
@@ -57,7 +57,7 @@ claude-seo run dataforseo_costs.py check <endpoint> [--count N]
 
 **After each API call completes**, log the cost:
 ```
-claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <actual_cost>
 ```
 
 **User commands for cost management:**
@@ -373,7 +373,7 @@ Additional DataForSEO MCP tools are available for internal use but do not have d
 
 ## Cross-Skill Integration
 
-When DataForSEO MCP tools are available, other claude-seo skills can leverage live data:
+When DataForSEO MCP tools are available, other "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" skills can leverage live data:
 
 - **seo-audit**:Spawn `seo-dataforseo` agent for real SERP, backlink, on-page, and listings data
 - **seo-technical**:Use `on_page_instant_pages` / `on_page_lighthouse` for real crawl data, `domain_analytics_technologies_domain_technologies` for stack detection
@@ -393,7 +393,7 @@ When DataForSEO MCP tools are available, other claude-seo skills can leverage li
 
 ## Output Formatting
 
-Match existing claude-seo output patterns:
+Match existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" output patterns:
 - Use tables for comparative data
 - Prioritize issues as Critical > High > Medium > Low
 - Include specific, actionable recommendations

--- a/skills/seo-dataforseo/references/cost-tiers.md
+++ b/skills/seo-dataforseo/references/cost-tiers.md
@@ -31,7 +31,7 @@
 | **Aggressive** | $50.00 | $2.00 | threshold | Agency bulk work |
 | **Unlimited** | $999.00 | -- | none | Trusted pipelines |
 
-Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
+Configure with: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
 
 ## Cost Reduction Tips
 
@@ -44,11 +44,11 @@ Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --th
 ## Approval Flow
 
 Before any DataForSEO MCP call:
-1. Run `claude-seo run dataforseo_costs.py check <endpoint> [--count N]`
+1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]`
 2. If `status: "approved"` → proceed
 3. If `status: "needs_approval"` → show cost to user, ask to confirm
 4. If `status: "blocked"` → inform user daily limit would be exceeded
-5. After call completes, log: `claude-seo run dataforseo_costs.py log <endpoint> <cost>`
+5. After call completes, log: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <cost>`
 
 ## Warn Endpoints
 

--- a/skills/seo-drift/SKILL.md
+++ b/skills/seo-drift/SKILL.md
@@ -103,8 +103,8 @@ Captures the current state of a page and stores it.
 
 **Execution:**
 ```bash
-claude-seo run drift_baseline.py <url>
-claude-seo run drift_baseline.py <url> --skip-cwv
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_baseline.py <url>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_baseline.py <url> --skip-cwv
 ```
 
 **Output:** JSON with baseline ID, timestamp, URL, and summary of captured elements.
@@ -126,16 +126,16 @@ Fetches the current page state and diffs it against the most recent baseline.
 
 **Execution:**
 ```bash
-claude-seo run drift_compare.py <url>
-claude-seo run drift_compare.py <url> --baseline-id 5
-claude-seo run drift_compare.py <url> --skip-cwv
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url> --baseline-id 5
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url> --skip-cwv
 ```
 
 **Output:** JSON with all triggered rules, old/new values, severity, and actions.
 
 After comparison, offer to generate an HTML report:
 ```bash
-claude-seo run drift_report.py <comparison_json_file> --output drift-report.html
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_report.py <comparison_json_file> --output drift-report.html
 ```
 
 ---
@@ -146,8 +146,8 @@ Shows all baselines and comparisons for a URL.
 
 **Execution:**
 ```bash
-claude-seo run drift_history.py <url>
-claude-seo run drift_history.py <url> --limit 10
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url> --limit 10
 ```
 
 **Output:** JSON array of baselines (newest first) with timestamps and comparison summaries.

--- a/skills/seo-ecommerce/SKILL.md
+++ b/skills/seo-ecommerce/SKILL.md
@@ -42,8 +42,8 @@ Fetch and parse any product page for on-page SEO quality.
 ### Workflow
 
 ```
-1. claude-seo run render_page.py <url> --mode auto → raw/rendered HTML
-2. claude-seo run parse_html.py --url <url>   → SEO elements
+1. "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto → raw/rendered HTML
+2. "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py --url <url>   → SEO elements
 3. Analyze product-specific signals (below)
 ```
 
@@ -107,7 +107,7 @@ Live competitive analysis from Google Shopping results.
 
 Before EVERY Merchant API call:
 ```bash
-claude-seo run dataforseo_costs.py check merchant_google_products_search
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check merchant_google_products_search
 ```
 
 - `"status": "approved"` -- proceed
@@ -116,20 +116,20 @@ claude-seo run dataforseo_costs.py check merchant_google_products_search
 
 After each call:
 ```bash
-claude-seo run dataforseo_costs.py log merchant_google_products_search <cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log merchant_google_products_search <cost>
 ```
 
 ### Workflow
 
 ```bash
 # Product search: who sells what at what price
-claude-seo run dataforseo_merchant.py search "<keyword>" --marketplace google
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py search "<keyword>" --marketplace google
 
 # Seller analysis: merchant ratings and dominance
-claude-seo run dataforseo_merchant.py sellers "<keyword>"
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py sellers "<keyword>"
 
 # Normalize results for analysis
-claude-seo run dataforseo_normalize.py results.json --module merchant
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_normalize.py results.json --module merchant
 ```
 
 ### Analysis Outputs
@@ -163,7 +163,7 @@ Cross-marketplace intelligence comparing Google Shopping and Amazon.
 ### Cost Guardrail (MANDATORY)
 
 ```bash
-claude-seo run dataforseo_costs.py check merchant_amazon_products_search
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check merchant_amazon_products_search
 ```
 
 Amazon endpoints are in the `warn_endpoints` set -- always requires user approval.
@@ -172,10 +172,10 @@ Amazon endpoints are in the `warn_endpoints` set -- always requires user approva
 
 ```bash
 # Amazon product search
-claude-seo run dataforseo_merchant.py search "<keyword>" --marketplace amazon
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py search "<keyword>" --marketplace amazon
 
 # Cross-marketplace comparison
-claude-seo run dataforseo_merchant.py compare "<keyword>"
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py compare "<keyword>"
 ```
 
 ### Cross-Marketplace Report
@@ -321,10 +321,10 @@ capability examples, and the relationship to AP2 (Agent Payments Protocol).
 
 ```bash
 # Discover and validate the UCP profile
-claude-seo run ucp_check.py https://store.example.com --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ucp_check.py https://store.example.com --json
 
 # With endpoint reachability probes (HEAD each declared capability)
-claude-seo run ucp_check.py https://store.example.com --probe-endpoints --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ucp_check.py https://store.example.com --probe-endpoints --json
 ```
 
 The script returns: profile presence, version, declared capabilities,

--- a/skills/seo-ecommerce/references/ucp-universal-commerce-protocol.md
+++ b/skills/seo-ecommerce/references/ucp-universal-commerce-protocol.md
@@ -89,7 +89,7 @@ Merchants join a **waitlist** and must be Google-approved before going live.
 Exact identifiers are governed by the live spec. The namespace pattern is
 `dev.ucp.<domain>.<verb>`; version values are date-based.
 
-## What claude-seo audits
+## What "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" audits
 
 `/seo ecommerce <url>` should report:
 

--- a/skills/seo-flow/SKILL.md
+++ b/skills/seo-flow/SKILL.md
@@ -82,7 +82,7 @@ Load prompt files on demand, only for the stage the user requests.
 2. Display the full index: all 41 prompts with stage, name, trigger conditions
 
 ### On `/seo flow sync`
-1. Run: `claude-seo run sync_flow.py`
+1. Run: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sync_flow.py`
 2. Display the JSON summary (files added, updated, unchanged)
 3. Show attribution notice after sync completes
 

--- a/skills/seo-geo/SKILL.md
+++ b/skills/seo-geo/SKILL.md
@@ -175,7 +175,7 @@ Check `robots.txt` for these AI crawlers:
 
 ## llms.txt Standard
 
-Read `references/llmstxt-evidence.md` for the primary-source evidence (Mueller, Illyes, SE Ranking 300k-domain study, OtterlyAI server-log audit) on why `/llms.txt` is not currently a citation lever for major AI search systems. claude-seo reports presence but assigns no citation-ranking weight.
+Read `references/llmstxt-evidence.md` for the primary-source evidence (Mueller, Illyes, SE Ranking 300k-domain study, OtterlyAI server-log audit) on why `/llms.txt` is not currently a citation lever for major AI search systems. "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" reports presence but assigns no citation-ranking weight.
 
 > **Google now states this explicitly.** Google's AI optimization guide (updated 2026-06-29) says you do **not** need `llms.txt` / AI-text files for Google Search, including its generative AI features, and that doing so "won't harm (nor help) your visibility or rankings in Google Search, as Google Search ignores them." Mueller separately called the llms.txt discovery use case "a dead end." It's fine to keep for **non-Google** AI services; never recommend it as a Google ranking/citation lever. Source: developers.google.com/search/docs/fundamentals/ai-optimization-guide
 

--- a/skills/seo-geo/references/google-ai-optimization-guide.md
+++ b/skills/seo-geo/references/google-ai-optimization-guide.md
@@ -4,7 +4,7 @@ Google published a dedicated **AI optimization guide** under Search Central
 docs (under the new "Generative AI fundamentals" section; announced via the
 Search Central blog 2026-05-15, doc last updated 2026-06-29). Its position is
 the most-cited primary source for how AI Overviews and AI Mode interact with
-Search ranking. Every claude-seo audit that touches GEO should treat this doc
+Search ranking. Every "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" audit that touches GEO should treat this doc
 as the canonical reference and reject community claims that contradict it.
 
 **Primary source:**
@@ -120,13 +120,13 @@ Search; ucp.dev lists 2026-04-08 as the latest date-based release, non-Google
 and hedged). UCP audit criteria:
 `skills/seo-ecommerce/references/ucp-universal-commerce-protocol.md`.
 
-## How claude-seo treats this guide
+## How "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" treats this guide
 
 1. `seo-geo` audits cite this URL as the authoritative source whenever the
    user asks about AEO/GEO frameworks.
 2. The myth-busting list above gates community-sourced AI-SEO recommendations
    — if a recommendation contradicts Google's stated position, flag it.
-3. Where a third-party claim and Google contradict, claude-seo defers to
+3. Where a third-party claim and Google contradict, "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" defers to
    Google and notes the contradiction explicitly.
 4. `seo-ecommerce` and `seo-images` enforce the two operational requirements
    above for sites using AI to generate product content.

--- a/skills/seo-geo/references/llmstxt-evidence.md
+++ b/skills/seo-geo/references/llmstxt-evidence.md
@@ -5,7 +5,7 @@
 `/llms.txt` is **not currently consumed by any major AI search system**, and
 **Google now states in its own docs that Google Search ignores it**. Generate
 one anyway as low-cost optionality for non-Google AI services, but never present
-it as a Google ranking or citation lever in any claude-seo report.
+it as a Google ranking or citation lever in any "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" report.
 
 ## Primary-source evidence
 
@@ -31,12 +31,12 @@ For a non-developer business site, the value is purely defensive: zero
 cost, possible future-optionality if a major AI provider eventually
 adopts it.
 
-## How claude-seo treats `llms.txt`
+## How "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" treats `llms.txt`
 
 - `seo-geo` audits **report presence** of `/llms.txt` and `/llms-full.txt`.
 - The audit notes whether the file is well-formed (Mintlify-style markdown).
 - The audit explicitly does **not** assign citation-ranking weight to it.
-- If the user asks to generate one, claude-seo produces a minimal valid
+- If the user asks to generate one, "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" produces a minimal valid
   example and a banner stating "Google Search ignores llms.txt (Google docs,
   2026-06-29); no major LLM provider has confirmed consumption; ship for
   non-Google optionality, not for citation".

--- a/skills/seo-google/SKILL.md
+++ b/skills/seo-google/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 # Google SEO APIs
 
 Direct access to Google's own SEO data. Bridges the gap between crawl-based
-analysis (existing claude-seo skills) and Google's real-time field data: actual
+analysis (existing "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" skills) and Google's real-time field data: actual
 Chrome user metrics, real indexation status, search performance, and organic traffic.
 
 All APIs are free. Setup requires a Google Cloud project with API key and/or
@@ -29,7 +29,7 @@ service account -- run `/seo google setup` for step-by-step instructions.
 
 Before executing any command, check credentials:
 ```bash
-claude-seo run google_auth.py --check --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check --json
 ```
 
 Config file: `~/.config/claude-seo/google-api.json`
@@ -89,7 +89,7 @@ Always communicate the detected tier before running commands.
 
 Combined Lighthouse lab data + CrUX field data.
 
-**Script:** `claude-seo run pagespeed_check.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json`
 **Reference:** `references/pagespeed-crux-api.md`
 **Default:** Both mobile + desktop strategies, all Lighthouse categories.
 
@@ -100,13 +100,13 @@ Chrome user metrics). CrUX tries URL-level first, falls back to origin-level.
 
 CrUX field data only (no Lighthouse run). Faster.
 
-**Script:** `claude-seo run pagespeed_check.py <url> --crux-only --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --crux-only --json`
 
 ### `/seo google crux-history <url>`
 
 25-week CrUX History trends. Shows whether CWV metrics are improving, stable, or degrading.
 
-**Script:** `claude-seo run crux_history.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py <url> --json`
 **Reference:** `references/pagespeed-crux-api.md`
 
 Output includes per-metric trend direction, percentage change, and weekly p75 values.
@@ -119,7 +119,7 @@ Output includes per-metric trend direction, percentage change, and weekly p75 va
 
 Search Analytics: clicks, impressions, CTR, position for last 28 days.
 
-**Script:** `claude-seo run gsc_query.py --property <property> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py --property <property> --json`
 **Reference:** `references/search-console-api.md`
 **Default:** 28 days, dimensions=query,page, type=web, limit=1000.
 
@@ -138,7 +138,7 @@ dimension rows, not the size of every pagination request.
 
 URL Inspection: real indexation status from Google.
 
-**Script:** `claude-seo run gsc_inspect.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py <url> --json`
 
 Returns: verdict (PASS/FAIL), coverage state, robots.txt status, indexing state,
 page fetch state, canonical selection, mobile usability, rich results.
@@ -147,7 +147,7 @@ page fetch state, canonical selection, mobile usability, rich results.
 
 Batch inspection from a file (one URL per line). Rate limited to 2,000/day per site.
 
-**Script:** `claude-seo run gsc_inspect.py --batch <file> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py --batch <file> --json`
 
 ### `/seo google sitemaps <property>`
 
@@ -155,7 +155,7 @@ List submitted sitemaps with status, errors, warnings. Sitemap contents report
 submitted counts only; URL Inspection API is the indexation truth for whether
 specific URLs are indexed.
 
-**Script:** `claude-seo run gsc_query.py sitemaps --property <property> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py sitemaps --property <property> --json`
 
 ---
 
@@ -165,7 +165,7 @@ specific URLs are indexed.
 
 Notify Google of a URL update.
 
-**Script:** `claude-seo run indexing_notify.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexing_notify.py <url> --json`
 **Reference:** `references/indexing-api.md`
 
 The Indexing API is officially for JobPosting and BroadcastEvent/VideoObject pages.
@@ -175,7 +175,7 @@ Always inform the user of this restriction. Daily quota: 200 publish requests.
 
 Batch submit URLs from a file. Tracks quota usage.
 
-**Script:** `claude-seo run indexing_notify.py --batch <file> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexing_notify.py --batch <file> --json`
 
 ---
 
@@ -185,7 +185,7 @@ Batch submit URLs from a file. Tracks quota usage.
 
 Organic traffic report: daily sessions, users, pageviews, bounce rate, engagement.
 
-**Script:** `claude-seo run ga4_report.py --property <id> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --json`
 **Reference:** `references/ga4-data-api.md`
 **Default:** 28 days, filtered to Organic Search channel group.
 
@@ -195,7 +195,7 @@ Organic traffic report: daily sessions, users, pageviews, bounce rate, engagemen
 
 Top organic landing pages ranked by sessions.
 
-**Script:** `claude-seo run ga4_report.py --property <id> --report top-pages --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --report top-pages --json`
 
 ---
 
@@ -207,7 +207,7 @@ Some third-party studies report a 0.737 correlation between YouTube mentions and
 
 Search YouTube for videos. Returns title, channel, views, likes, duration.
 
-**Script:** `claude-seo run youtube_search.py search "<query>" --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run youtube_search.py search "<query>" --json`
 **Reference:** `references/youtube-api.md`
 **Quota:** 100 units per search (10,000 units/day free).
 
@@ -215,7 +215,7 @@ Search YouTube for videos. Returns title, channel, views, likes, duration.
 
 Detailed video info + tags + top 10 comments.
 
-**Script:** `claude-seo run youtube_search.py video <video_id> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run youtube_search.py video <video_id> --json`
 **Quota:** 2 units (video details + comments).
 
 ---
@@ -228,7 +228,7 @@ Google NLP entity/sentiment output for internal content-quality checks. Do not t
 
 Full NLP analysis: entities, sentiment, content classification.
 
-**Script:** `claude-seo run nlp_analyze.py --url <url> --json` or `--text "..."`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run nlp_analyze.py --url <url> --json` or `--text "..."`
 **Reference:** `references/nlp-api.md`
 **Free tier:** 5,000 units/month. Requires billing enabled on GCP project.
 
@@ -236,7 +236,7 @@ Full NLP analysis: entities, sentiment, content classification.
 
 Entity extraction only (faster, less quota).
 
-**Script:** `claude-seo run nlp_analyze.py --url <url> --features entities --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run nlp_analyze.py --url <url> --features entities --json`
 
 ---
 
@@ -248,7 +248,7 @@ Gold-standard keyword volume data. Requires Google Ads account.
 
 Generate keyword ideas from seed terms.
 
-**Script:** `claude-seo run keyword_planner.py ideas "<seed>" --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run keyword_planner.py ideas "<seed>" --json`
 **Reference:** `references/keyword-planner-api.md`
 **Requires:** Ads developer token + customer ID in config (Tier 3).
 
@@ -256,7 +256,7 @@ Generate keyword ideas from seed terms.
 
 Search volume for specific keywords (comma-separated).
 
-**Script:** `claude-seo run keyword_planner.py volume "<kw1>,<kw2>" --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run keyword_planner.py volume "<kw1>,<kw2>" --json`
 
 ---
 
@@ -289,7 +289,7 @@ After any analysis command, offer to generate a PDF/HTML report.
 
 Generate a professional PDF report with charts and analytics.
 
-**Script:** `claude-seo run google_report.py --type <type> --data <json> --domain <domain> --format pdf`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type <type> --data <json> --domain <domain> --format pdf`
 
 | Type | Input | Output |
 |------|-------|--------|
@@ -300,8 +300,8 @@ Generate a professional PDF report with charts and analytics.
 
 **Workflow:**
 1. Run data collection commands (pagespeed, gsc, inspect-batch, etc.)
-2. Save JSON output to file: `claude-seo run pagespeed_check.py <url> --json > data.json`
-3. Generate report: `claude-seo run google_report.py --type cwv-audit --data data.json --domain <domain>`
+2. Save JSON output to file: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json > data.json`
+3. Generate report: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type cwv-audit --data data.json --domain <domain>`
 
 **Convention:** After completing analysis, suggest: "Generate a report? Use `/seo google report <type>`"
 

--- a/skills/seo-google/references/auth-setup.md
+++ b/skills/seo-google/references/auth-setup.md
@@ -106,7 +106,7 @@ Save to `~/.config/claude-seo/google-api.json`:
 ## Step 8: Verify Setup
 
 ```bash
-claude-seo run google_auth.py --check
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check
 ```
 
 Expected output at Tier 2 (full):

--- a/skills/seo-google/references/search-console-api.md
+++ b/skills/seo-google/references/search-console-api.md
@@ -66,7 +66,7 @@
 - `discover` and `googleNews` types do not support `query` dimension or `position` metric.
 - Country codes are **ISO 3166-1 alpha-3** (e.g., `USA`, `GBR`, `DEU`).
 - Pagination: increment `startRow` by `rowLimit` until fewer rows returned.
-- `rowLimit` is per API request. The claude-seo `--limit` option is a total
+- `rowLimit` is per API request. The "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" `--limit` option is a total
   result cap and requests are paged internally at up to 25,000 rows.
 - For accurate site totals, omit `query` and `page` dimensions. Query rows can
   omit anonymized low-volume traffic and must not be summed as site totals.

--- a/skills/seo-hreflang/references/machine-translation-qa.md
+++ b/skills/seo-hreflang/references/machine-translation-qa.md
@@ -42,7 +42,7 @@ content abuse.
 - For per-page hreflang validation, stay inside `seo-hreflang`.
 - For broader scaled-content scoring (entropy of translated pages,
   AI-pattern detection in body), defer to `seo-content` via
-  `claude-seo run content_quality.py`.
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run content_quality.py`.
 - For "is this translated by Google's own auto-translate widget"
   detection, look for the `.goog-te-banner-frame` iframe. There is **no
   per-mechanism exemption**: in June 2025 Google removed the

--- a/skills/seo-image-gen/SKILL.md
+++ b/skills/seo-image-gen/SKILL.md
@@ -143,7 +143,7 @@ Approximate costs:
 | API key invalid | New key at https://aistudio.google.com/apikey |
 | Rate limited (429) | Wait 60s, retry. Free tier: ~10 RPM / ~500 RPD |
 | `IMAGE_SAFETY` | Rephrase prompt - see `references/prompt-engineering.md` Safety section |
-| MCP unavailable | Configure MCP with `./extensions/banana/install.sh`; claude-seo does not vendor a local generation fallback script |
+| MCP unavailable | Configure MCP with `./extensions/banana/install.sh`; "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" does not vendor a local generation fallback script |
 | Extension not installed | Show install instructions: `./extensions/banana/install.sh` |
 
 ## Cross-Skill Integration

--- a/skills/seo-image-gen/references/seo-image-presets.md
+++ b/skills/seo-image-gen/references/seo-image-presets.md
@@ -123,7 +123,7 @@ preset format (see `references/presets.md` for schema details).
 
 Users can create their own presets with the installed Banana MCP preset tool.
 If the standalone Banana extension is not installed, configure it before using
-custom presets. The core claude-seo skill does not assume a local fallback
+custom presets. The core "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" skill does not assume a local fallback
 script or a fixed personal configuration directory.
 
 This creates `~/.banana/presets/my-brand.json` with the full schema.

--- a/skills/seo-images/SKILL.md
+++ b/skills/seo-images/SKILL.md
@@ -321,13 +321,13 @@ https://support.google.com/merchants/answer/14743464
 
 ```bash
 # Audit a directory for the IPTC label (counts: missing, ai, captured, etc.)
-claude-seo run iptc_ai_label.py audit ./images/ --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run iptc_ai_label.py audit ./images/ --json
 
 # Audit a single image
-claude-seo run iptc_ai_label.py audit ./hero.webp --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run iptc_ai_label.py audit ./hero.webp --json
 
 # Inject the AI label into an image
-claude-seo run iptc_ai_label.py inject ./ai-hero.webp \
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run iptc_ai_label.py inject ./ai-hero.webp \
     --source-type trainedAlgorithmicMedia
 
 # Other vocabulary values:

--- a/skills/seo-sitemap/SKILL.md
+++ b/skills/seo-sitemap/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 Discover candidates before reporting a sitemap missing:
 
 ```bash
-claude-seo run sitemap_discovery.py <url> --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <url> --json
 ```
 
 The helper reads every bounded `Sitemap:` declaration in robots.txt, validates

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 ### 1. Crawlability
 - robots.txt: exists, valid, not blocking important resources
-- XML sitemap: run `claude-seo run sitemap_discovery.py <url> --json`; require a
+- XML sitemap: run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <url> --json`; require a
   valid entry in `found`, and report stale or unsafe robots.txt declarations
   separately from working fallback locations
 - Noindex tags: intentional vs accidental
@@ -167,7 +167,7 @@ heuristic below. The PSI REST API does not expose it; run via Lighthouse CLI
 
 ```bash
 # Render with Playwright + capture accessibility tree, then score
-claude-seo run agent_ux_check.py https://example.com --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run agent_ux_check.py https://example.com --json
 ```
 
 The scanner outputs an Agent-UX score (0-100) plus itemized issues:
@@ -178,7 +178,7 @@ The scanner outputs an Agent-UX score (0-100) plus itemized issues:
 
 The accessibility-tree snapshot uses Playwright's
 `page.accessibility.snapshot(interesting_only=False)`. To capture the tree
-without scoring, use `claude-seo run render_page.py <url> --a11y-tree --json`.
+without scoring, use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --a11y-tree --json`.
 
 Surface findings as **opportunities**, not failures; don't gate audits on a
 sub-100 Agent-UX score. WebMCP origin-trial/sign-up status needs verification,
@@ -212,7 +212,7 @@ If DataForSEO MCP tools are available, use `on_page_instant_pages` for real page
 
 ## Google API Integration (Optional)
 
-If Google API credentials are configured, use `claude-seo run pagespeed_check.py <url> --json` for real PSI + CrUX field data (replaces lab-only CWV estimates), `claude-seo run crux_history.py <url> --json` for 25-week CWV trends, and `claude-seo run gsc_inspect.py <url> --json` for real indexation status per URL.
+If Google API credentials are configured, use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json` for real PSI + CrUX field data (replaces lab-only CWV estimates), `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py <url> --json` for 25-week CWV trends, and `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py <url> --json` for real indexation status per URL.
 
 ## Error Handling
 

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -14,9 +14,9 @@ metadata:
 
 **Invocation:** `/seo $1 $2` where `$1` is the command and `$2` is the URL or argument.
 
-**Runtime:** Run bundled Python tools through `claude-seo run <script.py>`. Plugin
-installs expose this command automatically. Repository users run
-`./bin/claude-seo`; manual installers rewrite the command to the isolated
+**Runtime:** Run bundled Python tools through `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>`. Plugin
+installs reference this reviewable launcher explicitly. Repository users run
+`./scripts/claude-seo`; manual installers rewrite the command to the isolated
 launcher path. Never invoke bundled scripts with a bare Python interpreter.
 
 Comprehensive SEO analysis across all industries (SaaS, local services,
@@ -61,10 +61,10 @@ extension is also installable (see "Optional Extensions" below).
 ## Runtime Setup
 
 Run setup only when the user explicitly invokes `/seo setup` or explicitly asks
-to repair dependencies. Execute `claude-seo setup`, report core and Chromium
+to repair dependencies. Execute `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup`, report core and Chromium
 status separately, and do not fall back to global or user package installation.
-For diagnosis, execute `claude-seo doctor --json`; its output intentionally omits
-absolute paths and environment values. If any `claude-seo run` command reports
+For diagnosis, execute `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor --json`; its output intentionally omits
+absolute paths and environment values. If any `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run` command reports
 that setup is required, suggest `/seo setup` and do not improvise a `pip install`.
 
 ## Orchestration Logic
@@ -72,14 +72,14 @@ that setup is required, suggest `/seo setup` and do not improvise a `pip install
 When the user invokes `/seo audit`, delegate to subagents in parallel:
 1. Detect business type (SaaS, local, ecommerce, publisher, agency, other)
 2. Spawn subagents: seo-technical, seo-content, seo-schema, seo-sitemap, seo-performance, seo-visual, seo-geo
-3. If Google API credentials detected (`claude-seo run google_auth.py --check`), also spawn seo-google agent
+3. If Google API credentials detected (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check`), also spawn seo-google agent
 4. If local business detected, also spawn seo-local agent
 5. If local business detected AND DataForSEO MCP available, also spawn seo-maps agent
-6. If backlink APIs detected (`claude-seo run backlinks_auth.py --check`), also spawn seo-backlinks agent
+6. If backlink APIs detected (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check`), also spawn seo-backlinks agent
 7. If Firecrawl MCP available, use `firecrawl_map` to discover all site URLs before analysis
 8. If content strategy signals detected (blog, pillar pages, topic clusters), also spawn seo-cluster agent
 9. If e-commerce detected, also spawn seo-ecommerce agent
-10. If drift baseline exists for this URL (`claude-seo run drift_history.py <url>`), also spawn seo-drift agent
+10. If drift baseline exists for this URL (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>`), also spawn seo-drift agent
 11. Always include seo-sxo in full audits (search experience applies to all sites)
 12. Collect results and generate unified report with SEO Health Score (0-100)
 13. **Synthesize via the 10-principle framework** (see "Synthesis Methodology" below), walk PERCEIVE → ANALYZE → VALIDATE → ACT before bucketing findings into Critical / High / Medium / Low
@@ -92,7 +92,7 @@ After any analysis command completes, offer to generate a PDF report via `script
 ## Synthesis Methodology
 
 Audits are not just findings, they are findings synthesized into a coherent
-strategy. claude-seo uses a 10-principle thinking framework grouped into four
+strategy. "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" uses a 10-principle thinking framework grouped into four
 phases: **PERCEIVE** (observe-external · observe-internal · listen),
 **ANALYZE** (think · connect-lateral · connect-system), **VALIDATE** (feel ·
 accept), **ACT** (create · grow).

--- a/skills/seo/references/eeat-framework.md
+++ b/skills/seo/references/eeat-framework.md
@@ -36,7 +36,7 @@ Topics requiring the **highest** E-E-A-T standards (E-E-A-T applies broadly, but
 
 ---
 
-## Experience (claude-seo internal scoring weight: 20%)
+## Experience ("${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" internal scoring weight: 20%)
 
 First-hand knowledge and personal involvement with the topic.
 
@@ -56,7 +56,7 @@ First-hand knowledge and personal involvement with the topic.
 
 ---
 
-## Expertise (claude-seo internal scoring weight: 25%)
+## Expertise ("${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" internal scoring weight: 25%)
 
 Formal qualifications, training, and demonstrated knowledge.
 
@@ -76,7 +76,7 @@ Formal qualifications, training, and demonstrated knowledge.
 
 ---
 
-## Authoritativeness (claude-seo internal scoring weight: 25%)
+## Authoritativeness ("${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" internal scoring weight: 25%)
 
 Recognition by others as a go-to source.
 
@@ -97,7 +97,7 @@ Recognition by others as a go-to source.
 
 ---
 
-## Trustworthiness (claude-seo internal scoring weight: 30%)
+## Trustworthiness ("${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" internal scoring weight: 30%)
 
 The most important factor, overall reliability and transparency.
 

--- a/skills/seo/references/thinking-framework.md
+++ b/skills/seo/references/thinking-framework.md
@@ -1,6 +1,6 @@
 # The 10-Principle Audit Synthesis Framework
 
-This is the canonical methodology claude-seo uses to assemble raw findings
+This is the canonical methodology "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" uses to assemble raw findings
 into strategically coherent recommendations. Every full-site audit and
 deep-page analysis walks through these ten principles before producing the
 final action plan.
@@ -202,7 +202,7 @@ The audit is a snapshot, not a verdict. Build the feedback loop:
   Reddit / YouTube).
 - Schedule a re-audit cadence appropriate to the site's velocity
   (weekly for a high-churn ecommerce; quarterly for a B2B SaaS).
-- Surface what claude-seo itself **could not measure** (offline
+- Surface what "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" itself **could not measure** (offline
   conversion, brand lift, customer interviews) so the human closes
   those loops.
 

--- a/tests/test_audit_instructions.py
+++ b/tests/test_audit_instructions.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def test_seo_audit_starts_with_render_page_auto() -> None:
     text = (REPO_ROOT / "skills" / "seo-audit" / "SKILL.md").read_text(encoding="utf-8")
     process = text[text.index("## Process"):text.index("## Crawl Configuration")]
-    assert "claude-seo run render_page.py" in process
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py' in process
     assert "python3 scripts/render_page.py" not in process
     assert "--mode auto" in process
     assert "scripts/fetch_page.py` to retrieve HTML" not in process

--- a/tests/test_banana_install_layout.py
+++ b/tests/test_banana_install_layout.py
@@ -17,7 +17,10 @@ def _text(path: Path) -> str:
 
 def _runtime_extension_scripts(text: str) -> set[str]:
     return set(
-        re.findall(r"claude-seo run --extension banana ([A-Za-z0-9_]+\.py)", text)
+        re.findall(
+            r'"\$\{CLAUDE_PLUGIN_ROOT\}/scripts/claude-seo" run --extension banana ([A-Za-z0-9_]+\.py)',
+            text,
+        )
     )
 
 

--- a/tests/test_runtime_installers.py
+++ b/tests/test_runtime_installers.py
@@ -10,9 +10,9 @@ def test_unix_installer_delegates_to_runtime_without_global_pip() -> None:
     assert '"${SKILL_DIR}/bin/claude-seo" setup' in text
     assert "pip install --user" not in text
     assert "python3 -m venv" not in text
-    assert "claude-seo run" in text
-    assert "claude-seo setup" in text
-    assert "claude-seo doctor" in text
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run' in text
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup' in text
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor' in text
     assert '"${runtime_status}" -ne 0 ] && [ "${runtime_status}" -ne 10' in text
     assert 'find "${HOME}/.claude/skills"' not in text
 
@@ -30,10 +30,15 @@ def test_windows_installer_delegates_to_runtime_without_path_mutation() -> None:
 
 
 def test_launcher_is_executable_and_uses_safe_exec() -> None:
-    launcher = ROOT / "bin/claude-seo"
+    launcher = ROOT / "scripts/claude-seo"
     assert launcher.stat().st_mode & 0o100
     text = launcher.read_text(encoding="utf-8")
     assert 'exec py -3 "${runtime}" "$@"' in text
     assert 'exec python3 "${runtime}" "$@"' in text
     assert 'exec python "${runtime}" "$@"' in text
     assert "eval " not in text
+
+
+def test_plugin_has_no_implicit_path_executables() -> None:
+    """claude.ai rejects top-level bin/ because it bypasses admin review."""
+    assert not any((ROOT / "bin").glob("**/*"))


### PR DESCRIPTION
## Summary

Claude.ai's hosted-plugin validator rejects the plugin because it ships the
executable `bin/claude-seo` inside a top-level `bin/` directory. Hosted plugins
do not allow these implicit PATH executables because they are not visible on
the admin approval surface.

This PR:

- moves the launcher from `bin/claude-seo` to `scripts/claude-seo`;
- uses the explicit plugin-relative path
`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo"` in skills, agents, and extensions;
- preserves standalone installation compatibility by updating the Unix and
Windows installer rewrite logic;
- updates affected documentation and tests;
- adds regression coverage preventing top-level `bin/` content in the packaged
plugin.

Verification performed:

- `claude plugin validate .` — passed
- 52 affected tests — passed
- portability lint — 0 errors and 0 warnings
- `git diff --check` — passed
- inspected a ZIP generated with `git archive` and confirmed it contains no
top-level `bin/` path
- confirmed the relocated `scripts/claude-seo` launcher executes correctly

A real-URL test is not applicable because this change only affects plugin
packaging, launcher discovery, and installation paths.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — not applicable to packaging changes
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts — no new shell scripts
- [ ] CHANGELOG.md updated with the change — not included; maintainer can advise if required
