### PR TITLE
fix(url_safety): send browser-like default headers on safe fetches

### DIFF
--- a/scripts/url_safety.py
+++ b/scripts/url_safety.py
@@ -424,6 +424,34 @@ def _pin_dns(hostname: str, pinned_ip: str, port: int) -> Iterator[None]:
         _dns_patch_lock.release()
 
 
+# Default request headers, mirroring the browser-like defaults fetch_page.py
+# has used since v1.2.1 (issue #9). Without them ``requests`` announces itself
+# as ``User-Agent: python-requests/x.y.z`` with no Accept-Language, which many
+# managed WAFs and CDNs answer with 403/406, and which SSR frameworks answer
+# with the empty client-side shell. Callers do not see an exception in that
+# case, they analyse the error page or the shell as if it were the real
+# document. Any header here can be overridden by passing ``headers=``.
+DEFAULT_REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/150.0.7871.115 Safari/537.36 ClaudeSEO/2.0"
+    ),
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def _with_default_headers(kwargs: dict) -> dict:
+    """Fill in DEFAULT_REQUEST_HEADERS for header keys the caller did not set."""
+    headers = dict(DEFAULT_REQUEST_HEADERS)
+    headers.update(kwargs.get("headers") or {})
+    kwargs["headers"] = headers
+    return kwargs
+
+
 def safe_requests_get(
     url: str,
     *,
@@ -434,12 +462,15 @@ def safe_requests_get(
     ``requests.get`` with DNS-rebinding protection.
 
     The request's hostname is pinned to a pre-validated IP for the
-    duration of the call. Standard ``requests`` semantics otherwise.
+    duration of the call. Standard ``requests`` semantics otherwise,
+    except that browser-like default headers are supplied for any header
+    the caller did not set (see ``DEFAULT_REQUEST_HEADERS``).
     """
     norm_url, pinned_ip = validate_url_strict(url)
     parsed = urlparse(norm_url)
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     assert parsed.hostname is not None  # validate_url_strict guarantees this
+    kwargs = _with_default_headers(kwargs)
     with _pin_dns(parsed.hostname, pinned_ip, port):
         return requests.get(norm_url, timeout=timeout, **kwargs)
 
@@ -454,12 +485,15 @@ def safe_requests_head(
     ``requests.head`` with DNS-rebinding protection.
 
     The request's hostname is pinned to a pre-validated IP for the
-    duration of the call. Standard ``requests`` semantics otherwise.
+    duration of the call. Standard ``requests`` semantics otherwise,
+    except that browser-like default headers are supplied for any header
+    the caller did not set (see ``DEFAULT_REQUEST_HEADERS``).
     """
     norm_url, pinned_ip = validate_url_strict(url)
     parsed = urlparse(norm_url)
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
     assert parsed.hostname is not None
+    kwargs = _with_default_headers(kwargs)
     with _pin_dns(parsed.hostname, pinned_ip, port):
         return requests.head(norm_url, timeout=timeout, **kwargs)
 

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -341,9 +341,47 @@ def test_safe_requests_head_uses_strict_validation_and_dns_pin() -> None:
         "https://safe.example/path",
         timeout=7,
         allow_redirects=True,
+        headers=url_safety.DEFAULT_REQUEST_HEADERS,
     )
     assert captured["pin"] == ("safe.example", "1.1.1.1", 443)
     assert result is response
+
+
+def test_default_headers_are_browser_like() -> None:
+    headers = url_safety.DEFAULT_REQUEST_HEADERS
+    assert "python-requests" not in headers["User-Agent"]
+    assert headers["User-Agent"].startswith("Mozilla/5.0")
+    assert "Accept-Language" in headers
+
+
+def test_with_default_headers_fills_unset_headers() -> None:
+    assert url_safety._with_default_headers({})["headers"] == (
+        url_safety.DEFAULT_REQUEST_HEADERS
+    )
+    assert url_safety._with_default_headers({"headers": None})["headers"] == (
+        url_safety.DEFAULT_REQUEST_HEADERS
+    )
+
+
+def test_with_default_headers_lets_caller_override() -> None:
+    # fetch_page.py --user-agent (Googlebot cloaking checks) must still win.
+    merged = url_safety._with_default_headers(
+        {"headers": {"User-Agent": "Googlebot/2.1"}}
+    )["headers"]
+    assert merged["User-Agent"] == "Googlebot/2.1"
+    # Headers the caller did not set are still filled in.
+    assert merged["Accept-Language"] == (
+        url_safety.DEFAULT_REQUEST_HEADERS["Accept-Language"]
+    )
+
+
+def test_with_default_headers_preserves_other_kwargs_and_constant() -> None:
+    before = dict(url_safety.DEFAULT_REQUEST_HEADERS)
+    kwargs = url_safety._with_default_headers({"stream": True, "allow_redirects": False})
+    assert kwargs["stream"] is True
+    assert kwargs["allow_redirects"] is False
+    url_safety._with_default_headers({"headers": {"User-Agent": "mutating/1.0"}})
+    assert url_safety.DEFAULT_REQUEST_HEADERS == before
 
 
 def test_pin_dns_restores_getaddrinfo_on_exception() -> None:


### PR DESCRIPTION
## What's wrong

`safe_requests_get` and `safe_requests_head` in `scripts/url_safety.py` never pass a `headers=` mapping, so every raw fetch goes out as:

```
User-Agent: python-requests/2.34.2
```

with no `Accept-Language`. Managed WAFs and CDNs answer that with 403/406, and SSR frameworks answer it with the empty client-side shell.

The failure is silent. Nothing raises — the caller gets a 200-shaped error page or a hydration shell and analyses it as if it were the real document, so an incorrect score comes back looking like a correct one.

Reproducer on current `main`:

```python
from url_safety import safe_requests_get
r = safe_requests_get("https://en.wikipedia.org/wiki/Search_engine_optimization", timeout=30)
print(r.status_code, r.request.headers["User-Agent"])
# 403 python-requests/2.34.2
```

Roughly 11 call sites across 8 scripts are affected, including `render_page.py`, `parse_html.py`, `preload_check.py`, `ucp_check.py` and `parasite_risk.py`.

This is the same class of bug as #9, which was fixed in `fetch_page.py` in v1.2.1. The v2.0.0 `url_safety.py` helpers are a newer code path that never picked up those defaults.

## The fix

Adds `DEFAULT_REQUEST_HEADERS` (the same browser-like values `fetch_page.py` already uses) merged in via `_with_default_headers()`, so **caller-supplied headers still win**.

Deliberately unaffected:

- `fetch_page.py --user-agent` — Googlebot cloaking checks still send Googlebot
- `sitemap_discovery.py` — keeps its `application/xml` Accept header
- `safe_requests_session` — both callers already set their own headers, left alone

URL validation, DNS pinning and SSRF behaviour are untouched; the change only fills in headers.

## Verification

Full suite: **414 passed** (410 existing + 4 new).

One existing test, `test_safe_requests_head_uses_strict_validation_and_dns_pin`, asserted the exact call args and so encoded the missing-headers behaviour. Updated to expect the defaults; its actual purpose (strict validation + DNS pin) is unchanged.

Live before/after:

| URL | before | after |
|---|---|---|
| en.wikipedia.org/wiki/Search_engine_optimization | 403 | **200** |
| a Hostinger/cPanel ModSecurity host | 406 | **200** |
| nytimes.com | 200 | 200 |
| stackoverflow.com | 200 | 200 |

Sites that already worked are unaffected.

Closes the `url_safety.py` half of #9.