### PR TITLE
Raise requests floor to 2.33.0 (CVE-2026-25645)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Last updated: July 20, 2026 (v2.2.4)
 
 beautifulsoup4>=4.12.0,<5.0.0     # No known CVEs
-requests>=2.32.4,<3.0.0           # CVE-2024-47081, CVE-2024-35195 fixes
+requests>=2.33.0,<3.0.0           # CVE-2026-25645 fix (insecure temp file reuse in extract_zipped_paths)
 lxml>=6.1.1,<7.0.0                # CVE-2025-24928 + additional libxml2 security patches
 playwright>=1.59.0,<2.0.0         # CVE-2025-59288 fix (macOS)
 urllib3>=2.7.0,<3.0.0             # High-severity urllib3 advisories GHSA-mf9v-mfxr-j63j, GHSA-qccp-gfcp-xxvc


### PR DESCRIPTION
requirements.txt pins requests>=2.32.4, which still admits 2.32.x releases affected by CVE-2026-25645 (GHSA-gc5v-m9x4-r6x2, insecure temp file reuse in extract_zipped_paths(), fixed in 2.33.0). The other security floors were raised for v2.2.4; this one was left behind.

Raises the floor to requests>=2.33.0 and updates the line comment to name the CVE.

Verified in:
- Windows 11, Python 3.14.4, global environment — pip install --dry-run -r requirements.txt resolves clean (exit 0)
- Windows 11, Python 3.14.4, claude-seo isolated venv from the v2.2.4 installer — same dry-run resolves clean; the installed requests 2.34.2 already satisfies the new floor

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.