### PR TITLE
fix: cost ledgers lose concurrent writes (DataForSEO + Banana)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Spend ledger lost concurrent writes (`dataforseo_costs.py`).** The ledger took its
+  file lock twice, once to read and once to write, and released it in between, so two
+  concurrent `log` calls both read the same ledger and the second silently overwrote the
+  first. Measured 3 entries lost out of 20 concurrent writes, with 1 to 3 lost on every
+  repeat run. This is not platform-specific. It matters because `seo-audit` fans out to
+  up to 15 parallel specialists, three of which call DataForSEO and each of which logs
+  after every call, so the ledger under-reported most during the runs that spend the
+  most. One exclusive lock now spans the entire read-modify-write in both `log` and
+  `reset`.
+- **No file locking at all on Windows.** The module set `fcntl = None` when the import
+  failed and then took every unlocked code path, so Windows ran the ledger with no
+  locking whatsoever. Locking now falls back to `msvcrt`, and when neither primitive is
+  available the operation fails loudly rather than proceeding unlocked.
+- **A corrupt ledger silently reset the budget to zero.** The non-atomic
+  `open(..., "w")` write could leave a truncated file if the process died mid-write, and
+  the reader caught `JSONDecodeError` and returned an empty ledger, which the next write
+  then persisted, discarding the whole spend history. Ledger writes are now atomic
+  (tempfile plus `os.replace`, matching the idiom already used in `google_auth.py`), and
+  an unparseable ledger fails closed with the file left in place for inspection.
+- **`CLAUDE_SEO_CONFIG_DIR`** now overrides the config and ledger location, so the new
+  `tests/test_dataforseo_costs.py` concurrency and durability tests run against an
+  isolated ledger instead of the operator's real spend history.
+
 ## [2.2.4] - 2026-07-20
 
 Community maintenance release following a full review of every open issue and pull request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`CLAUDE_SEO_CONFIG_DIR`** now overrides the config and ledger location, so the new
   `tests/test_dataforseo_costs.py` concurrency and durability tests run against an
   isolated ledger instead of the operator's real spend history.
+- **The Banana cost ledger had the same defect, with no locking at all.**
+  `extensions/banana/scripts/cost_tracker.py` read and wrote `~/.banana/costs.json` with
+  no file locking on any platform and a non-atomic write. Measured 4 entries lost out of
+  20 concurrent `log` calls, and 3 of those processes crashed outright with
+  `JSONDecodeError` after reading a half-written file. It is also harder to notice than
+  the DataForSEO case: this ledger carries running aggregates (`total_cost`,
+  `total_images`, `daily`) incremented in the same write as the entry, so a lost write
+  drops both together and the file still looks internally consistent. Given the same
+  treatment: one exclusive lock across the whole read-modify-write in `log`, atomic
+  writes, `msvcrt` fallback with a hard failure when no locking primitive exists, and a
+  corrupt ledger that fails closed instead of raising a bare traceback. `reset` takes the
+  lock but deliberately does not read first, so it still works as the recovery path for a
+  corrupt ledger. `BANANA_HOME` overrides the ledger and pricing paths for the new
+  `tests/test_banana_cost_tracker.py`.
 
 ## [2.2.4] - 2026-07-20
 

--- a/extensions/banana/scripts/cost_tracker.py
+++ b/extensions/banana/scripts/cost_tracker.py
@@ -13,31 +13,148 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-LEDGER_PATH = Path.home() / ".banana" / "costs.json"
-PRICING_PATH = Path.home() / ".banana" / "pricing.json"
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
+
+# BANANA_HOME lets tests (and anyone running an isolated budget) point the
+# ledger and pricing config somewhere other than the real ones. Resolved at
+# import.
+BANANA_DIR = Path(os.environ.get("BANANA_HOME") or Path.home() / ".banana")
+LEDGER_PATH = BANANA_DIR / "costs.json"
+LOCK_PATH = BANANA_DIR / "costs.lock"
+PRICING_PATH = BANANA_DIR / "pricing.json"
 PRICING_SOURCE = "https://ai.google.dev/gemini-api/docs/pricing"
+
+
+def _empty_ledger():
+    return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
+
 
 # Batch API gets 50% discount
 BATCH_DISCOUNT = 0.5
 
 
-def _load_ledger():
-    """Load the cost ledger from disk."""
+class LedgerError(RuntimeError):
+    """The cost ledger could not be read or written safely."""
+
+
+def _lock(handle, exclusive):
+    """Take an advisory lock on an open handle, blocking until acquired.
+
+    Never degrades to running unlocked: a cost ledger that silently drops
+    entries is worse than one that refuses to run.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    elif msvcrt is not None:
+        # msvcrt has no shared mode, so readers take an exclusive lock too.
+        # LK_LOCK retries 10 times at 1s intervals, then raises OSError.
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        raise LedgerError(
+            "No file-locking primitive available (neither fcntl nor msvcrt). "
+            "Refusing to touch the cost ledger unlocked."
+        )
+
+
+def _unlock(handle):
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _read_ledger():
+    """Read the ledger. Caller must hold the lock."""
     if not LEDGER_PATH.exists():
-        return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
-    with open(LEDGER_PATH, "r") as f:
-        return json.load(f)
+        return _empty_ledger()
+    try:
+        with open(LEDGER_PATH, "r") as f:
+            ledger = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(
+            f"Cost ledger {LEDGER_PATH} is not valid JSON ({exc}). Refusing to "
+            "continue from a zero balance, which would under-report spend. "
+            "Inspect the file, then repair or remove it."
+        ) from exc
+    if not isinstance(ledger, dict) or not isinstance(ledger.get("entries"), list):
+        raise LedgerError(
+            f"Cost ledger {LEDGER_PATH} has an unexpected shape (no 'entries' "
+            "list). Inspect the file, then repair or remove it."
+        )
+    # Tolerate ledgers written before a field existed.
+    ledger.setdefault("total_cost", 0.0)
+    ledger.setdefault("total_images", 0)
+    ledger.setdefault("daily", {})
+    return ledger
 
 
-def _save_ledger(ledger):
-    """Save the cost ledger to disk."""
-    LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(LEDGER_PATH, "w") as f:
-        json.dump(ledger, f, indent=2)
+def _write_ledger(ledger):
+    """Write the ledger atomically. Caller must hold the exclusive lock.
+
+    tempfile + os.replace so a crash mid-write can never leave a truncated,
+    unparseable ledger behind.
+    """
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(BANANA_DIR), prefix=".costs.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(ledger, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, LEDGER_PATH)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+@contextmanager
+def _locked_ledger(write=False):
+    """Yield the ledger under ONE lock held across the whole read-modify-write.
+
+    Reading under one lock, dropping it, then re-taking it to write loses
+    entries: two concurrent `log` calls both read the same ledger and the
+    second overwrites the first. This ledger also carries running aggregates
+    (total_cost, total_images, daily), so a lost write drops the entry and its
+    aggregate increment together and the file still looks self-consistent.
+
+    The lock lives in a separate .lock file on purpose. The atomic write
+    replaces the ledger's inode, so a lock held on the ledger itself would not
+    protect the replacement.
+    """
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_PATH, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=write)
+        try:
+            ledger = _read_ledger()
+            yield ledger
+            if write:
+                _write_ledger(ledger)
+        finally:
+            _unlock(lock_handle)
+
+
+def _ledger_snapshot():
+    """Read the ledger under a shared lock. For read-only commands."""
+    with _locked_ledger() as ledger:
+        return ledger
 
 
 def _load_pricing_config():
@@ -85,7 +202,6 @@ def _lookup_cost(model, resolution, batch=False):
 
 def cmd_log(args):
     """Log a generation to the ledger."""
-    ledger = _load_ledger()
     cost, checked_date = _lookup_cost(args.model, args.resolution, getattr(args, "batch", False))
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -100,24 +216,29 @@ def cmd_log(args):
         "prompt": args.prompt[:100],
     }
 
-    ledger["entries"].append(entry)
-    ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
-    ledger["total_images"] += 1
+    # Read and write inside one lock, so a concurrent log cannot overwrite this
+    # entry (and its aggregate increments) with a ledger it read beforehand.
+    with _locked_ledger(write=True) as ledger:
+        ledger["entries"].append(entry)
+        ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
+        ledger["total_images"] += 1
 
-    if today not in ledger["daily"]:
-        ledger["daily"][today] = {"count": 0, "cost": 0.0}
-    ledger["daily"][today]["count"] += 1
-    ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
+        if today not in ledger["daily"]:
+            ledger["daily"][today] = {"count": 0, "cost": 0.0}
+        ledger["daily"][today]["count"] += 1
+        ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
 
-    _save_ledger(ledger)
-    print(json.dumps({"logged": True, "cost": cost, "total_cost": ledger["total_cost"],
-                       "total_images": ledger["total_images"], "approximate": True,
+        total_cost = ledger["total_cost"]
+        total_images = ledger["total_images"]
+
+    print(json.dumps({"logged": True, "cost": cost, "total_cost": total_cost,
+                       "total_images": total_images, "approximate": True,
                        "pricing_checked_date": checked_date}))
 
 
 def cmd_summary(args):
     """Show cost summary."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     print(f"Total images: {ledger['total_images']}")
     print(f"Total cost:   approx ${ledger['total_cost']:.3f}")
     print()
@@ -136,7 +257,7 @@ def cmd_summary(args):
 
 def cmd_today(args):
     """Show today's usage."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     daily = ledger.get("daily", {}).get(today, {"count": 0, "cost": 0.0})
     print(f"Today ({today}): {daily['count']} images, approx ${daily['cost']:.3f}")
@@ -162,7 +283,16 @@ def cmd_reset(args):
     if not args.confirm:
         print("Error: Pass --confirm to reset the cost ledger.", file=sys.stderr)
         sys.exit(1)
-    _save_ledger({"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}})
+    # Takes the same exclusive lock as `log`, but deliberately does NOT read
+    # first: reset is the recovery path for a corrupt ledger, so it must not
+    # depend on the existing file parsing.
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_PATH, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=True)
+        try:
+            _write_ledger(_empty_ledger())
+        finally:
+            _unlock(lock_handle)
     print("Cost ledger reset.")
 
 
@@ -197,7 +327,12 @@ def main():
     args = parser.parse_args()
     cmds = {"log": cmd_log, "summary": cmd_summary, "today": cmd_today,
             "estimate": cmd_estimate, "reset": cmd_reset}
-    cmds[args.command](args)
+    try:
+        cmds[args.command](args)
+    except LedgerError as exc:
+        # Fail closed and loudly rather than under-reporting spend.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/dataforseo_costs.py
+++ b/scripts/dataforseo_costs.py
@@ -10,6 +10,7 @@ Provides cost-aware guardrails for DataForSEO API usage:
 
 Config: ~/.config/claude-seo/dataforseo-costs.json
 Ledger: ~/.config/claude-seo/dataforseo-ledger.json
+Set CLAUDE_SEO_CONFIG_DIR to point both somewhere else (used by the tests).
 
 Usage:
     python dataforseo_costs.py estimate <endpoint> [--count N]
@@ -28,18 +29,30 @@ import argparse
 import json
 import os
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 
 try:
     import fcntl
 except ImportError:
-    fcntl = None  # Windows fallback: no locking
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 # ----- paths -----
-CONFIG_DIR = Path.home() / ".config" / "claude-seo"
+# CLAUDE_SEO_CONFIG_DIR lets tests (and anyone running an isolated budget) point
+# the ledger somewhere other than the real one. Resolved at import.
+CONFIG_DIR = Path(
+    os.environ.get("CLAUDE_SEO_CONFIG_DIR") or Path.home() / ".config" / "claude-seo"
+)
 CONFIG_FILE = CONFIG_DIR / "dataforseo-costs.json"
 LEDGER_FILE = CONFIG_DIR / "dataforseo-ledger.json"
+LOCK_FILE = CONFIG_DIR / "dataforseo-ledger.lock"
 
 # ----- cost table (USD per call, standard queue) -----
 # Source: https://dataforseo.com/pricing
@@ -141,41 +154,108 @@ def _save_config(cfg):
         json.dump(cfg, f, indent=2)
 
 
-def _load_ledger():
-    """Load spending ledger with file locking."""
+class LedgerError(RuntimeError):
+    """The ledger could not be read or written safely."""
+
+
+def _lock(handle, exclusive):
+    """Take an advisory lock on an open handle, blocking until acquired.
+
+    Never degrades to running unlocked: a spend ledger that silently drops
+    entries is worse than one that refuses to run.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    elif msvcrt is not None:
+        # msvcrt has no shared mode, so readers take an exclusive lock too.
+        # LK_LOCK retries 10 times at 1s intervals, then raises OSError.
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        raise LedgerError(
+            "No file-locking primitive available (neither fcntl nor msvcrt). "
+            "Refusing to touch the spend ledger unlocked."
+        )
+
+
+def _unlock(handle):
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _read_ledger():
+    """Read the ledger. Caller must hold the lock."""
     if not LEDGER_FILE.exists():
         return {"entries": []}
-    if fcntl:
-        lock_path = LEDGER_FILE.with_suffix(".lock")
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_SH)
-            try:
-                with open(LEDGER_FILE) as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, IOError):
-                return {"entries": []}
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-    else:
+    try:
         with open(LEDGER_FILE) as f:
-            return json.load(f)
+            ledger = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(
+            f"Spend ledger {LEDGER_FILE} is not valid JSON ({exc}). Refusing to "
+            "continue from a zero balance, which would under-report spend. "
+            "Inspect the file, then repair or remove it."
+        ) from exc
+    if not isinstance(ledger, dict) or not isinstance(ledger.get("entries"), list):
+        raise LedgerError(
+            f"Spend ledger {LEDGER_FILE} has an unexpected shape (no 'entries' "
+            "list). Inspect the file, then repair or remove it."
+        )
+    return ledger
 
 
-def _save_ledger(ledger):
-    """Save spending ledger with file locking."""
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    if fcntl:
-        lock_path = LEDGER_FILE.with_suffix(".lock")
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                with open(LEDGER_FILE, "w") as f:
-                    json.dump(ledger, f, indent=2)
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-    else:
-        with open(LEDGER_FILE, "w") as f:
+def _write_ledger(ledger):
+    """Write the ledger atomically. Caller must hold the exclusive lock.
+
+    tempfile + os.replace so a crash mid-write can never leave a truncated,
+    unparseable ledger behind (same idiom as scripts/google_auth.py).
+    """
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(CONFIG_DIR), prefix=".dataforseo-ledger.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
             json.dump(ledger, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, LEDGER_FILE)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+@contextmanager
+def _locked_ledger(write=False):
+    """Yield the ledger under ONE lock held across the whole read-modify-write.
+
+    Taking the lock to read, dropping it, then re-taking it to write loses
+    entries: two concurrent writers both read the same ledger and the second
+    overwrites the first. The lock has to span both halves.
+
+    The lock lives in a separate .lock file on purpose. The atomic write
+    replaces the ledger's inode, so a lock held on the ledger itself would not
+    protect the replacement.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_FILE, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=write)
+        try:
+            ledger = _read_ledger()
+            yield ledger
+            if write:
+                _write_ledger(ledger)
+        finally:
+            _unlock(lock_handle)
+
+
+def _ledger_snapshot():
+    """Read the ledger under a shared lock. For read-only commands."""
+    with _locked_ledger() as ledger:
+        return ledger
 
 
 def _today_str():
@@ -230,7 +310,7 @@ def cmd_estimate(args):
 def cmd_check(args):
     """Check if an API call should proceed (cost + approval logic)."""
     cfg = _load_config()
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     endpoint = args.endpoint
     count = args.count or 1
     unit_cost = COST_TABLE.get(endpoint)
@@ -299,7 +379,6 @@ def cmd_check(args):
 
 def cmd_log(args):
     """Log a completed API call cost."""
-    ledger = _load_ledger()
     entry = {
         "timestamp": datetime.now().isoformat(),
         "endpoint": args.endpoint,
@@ -307,8 +386,10 @@ def cmd_log(args):
     }
     if args.note:
         entry["note"] = args.note
-    ledger["entries"].append(entry)
-    _save_ledger(ledger)
+    # Read and write inside one lock, so a concurrent log cannot overwrite this
+    # entry with a ledger it read before this one was appended.
+    with _locked_ledger(write=True) as ledger:
+        ledger["entries"].append(entry)
 
     result = {
         "status": "logged",
@@ -320,7 +401,7 @@ def cmd_log(args):
 
 def cmd_summary(args):
     """Show spending summary for recent days."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     days = args.days or 7
     cutoff = (datetime.now() - timedelta(days=days)).isoformat()
 
@@ -351,7 +432,7 @@ def cmd_summary(args):
 
 def cmd_today(args):
     """Show today's spending."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     cfg = _load_config()
     today = _today_str()
     today_entries = [e for e in ledger["entries"] if e["timestamp"].startswith(today)]
@@ -417,23 +498,23 @@ def cmd_reset(args):
         json.dump(result, sys.stdout, indent=2)
         return
 
-    ledger = _load_ledger()
     today = _today_str()
-    today_entries = [e for e in ledger["entries"] if e["timestamp"].startswith(today)]
-    removed_total = sum(e["cost"] for e in today_entries)
-    removed_count = len(today_entries)
+    # One lock across the whole read-modify-write, so a concurrent log is either
+    # cleared by this reset or survives it, never silently discarded.
+    with _locked_ledger(write=True) as ledger:
+        today_entries = [e for e in ledger["entries"] if e["timestamp"].startswith(today)]
+        removed_total = sum(e["cost"] for e in today_entries)
+        removed_count = len(today_entries)
 
-    ledger["entries"] = [e for e in ledger["entries"] if not e["timestamp"].startswith(today)]
+        ledger["entries"] = [e for e in ledger["entries"] if not e["timestamp"].startswith(today)]
 
-    # Immutable audit entry for the reset itself
-    ledger["entries"].append({
-        "timestamp": datetime.now().isoformat(),
-        "endpoint": "_audit_reset",
-        "cost": 0,
-        "note": f"Reset cleared {removed_count} entries totaling ${removed_total:.4f}",
-    })
-
-    _save_ledger(ledger)
+        # Immutable audit entry for the reset itself
+        ledger["entries"].append({
+            "timestamp": datetime.now().isoformat(),
+            "endpoint": "_audit_reset",
+            "cost": 0,
+            "note": f"Reset cleared {removed_count} entries totaling ${removed_total:.4f}",
+        })
 
     result = {
         "status": "reset",
@@ -493,7 +574,13 @@ def main():
         "config": cmd_config,
         "reset": cmd_reset,
     }
-    dispatch[args.command](args)
+    try:
+        dispatch[args.command](args)
+    except LedgerError as exc:
+        # Fail closed and loudly. Callers parse stdout as JSON, so keep the
+        # contract even on the error path.
+        json.dump({"status": "error", "message": str(exc)}, sys.stdout, indent=2)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_banana_cost_tracker.py
+++ b/tests/test_banana_cost_tracker.py
@@ -1,0 +1,217 @@
+"""
+Tests for extensions/banana/scripts/cost_tracker.py — cost-ledger integrity.
+
+Same defect class as tests/test_dataforseo_costs.py, and worse here: this
+ledger had no file locking at all, non-atomic writes, and running aggregates
+(total_cost, total_images, daily) that are incremented alongside each entry.
+A lost write dropped the entry AND its aggregate increments together, so the
+file stayed internally self-consistent while under-reporting spend. Internal
+consistency is therefore not evidence that nothing was lost.
+
+Every test runs against an isolated BANANA_HOME, never the real
+~/.banana/costs.json.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "extensions" / "banana" / "scripts" / "cost_tracker.py"
+
+MODEL = "gemini-3.1-flash-image-preview"
+COST_1K = 0.039
+
+
+def _seed_pricing(home: Path) -> None:
+    """Write the dated pricing config the tracker requires."""
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "pricing.json").write_text(json.dumps({
+        "checked_date": "2026-08-02",
+        "models": {MODEL: {"512": 0.020, "1K": COST_1K, "2K": 0.078, "4K": 0.156}},
+    }))
+
+
+def _run(home: Path, *argv: str) -> subprocess.CompletedProcess:
+    """Invoke the CLI in a subprocess with an isolated ledger."""
+    if not (home / "pricing.json").exists():
+        _seed_pricing(home)
+    env = dict(os.environ)
+    env["BANANA_HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _ledger(home: Path) -> dict:
+    return json.loads((home / "costs.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_logs_do_not_lose_entries(tmp_path) -> None:
+    """20 concurrent `log` calls must produce exactly 20 entries.
+
+    Fails on the pre-fix code, which had no locking whatsoever.
+    """
+    calls = 20
+
+    with ThreadPoolExecutor(max_workers=calls) as pool:
+        results = list(
+            pool.map(
+                lambda i: _run(
+                    tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                    "--prompt", f"call-{i}",
+                ),
+                range(calls),
+            )
+        )
+
+    failed = [r for r in results if r.returncode != 0]
+    assert not failed, f"{len(failed)} log calls failed: {failed[0].stderr}"
+
+    ledger = _ledger(tmp_path)
+    assert len(ledger["entries"]) == calls, (
+        f"lost {calls - len(ledger['entries'])} of {calls} concurrent writes"
+    )
+
+    prompts = sorted(e["prompt"] for e in ledger["entries"])
+    assert prompts == sorted(f"call-{i}" for i in range(calls)), "entries were clobbered"
+
+
+def test_concurrent_logs_keep_aggregates_correct(tmp_path) -> None:
+    """The running aggregates must match the entries after concurrent writes.
+
+    These are the numbers the user actually reads, and they were incremented
+    in the same lost write as the entry itself.
+    """
+    calls = 20
+
+    with ThreadPoolExecutor(max_workers=calls) as pool:
+        list(
+            pool.map(
+                lambda i: _run(
+                    tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                    "--prompt", f"call-{i}",
+                ),
+                range(calls),
+            )
+        )
+
+    ledger = _ledger(tmp_path)
+    assert ledger["total_images"] == calls
+    assert ledger["total_cost"] == pytest.approx(calls * COST_1K, abs=1e-4)
+    assert ledger["total_cost"] == pytest.approx(
+        sum(e["cost"] for e in ledger["entries"]), abs=1e-4
+    )
+
+    daily_count = sum(d["count"] for d in ledger["daily"].values())
+    daily_cost = sum(d["cost"] for d in ledger["daily"].values())
+    assert daily_count == calls
+    assert daily_cost == pytest.approx(calls * COST_1K, abs=1e-4)
+
+
+def test_concurrent_log_and_reset_keep_the_ledger_parseable(tmp_path) -> None:
+    """Interleaved writers must never leave a torn/unparseable ledger."""
+    _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K", "--prompt", "seed")
+
+    def job(i: int) -> subprocess.CompletedProcess:
+        if i % 5 == 4:
+            return _run(tmp_path, "reset", "--confirm")
+        return _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                    "--prompt", f"p{i}")
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        list(pool.map(job, range(10)))
+
+    ledger = _ledger(tmp_path)
+    assert isinstance(ledger["entries"], list)
+    assert _run(tmp_path, "summary").returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# durability
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_ledger_is_not_silently_zeroed(tmp_path) -> None:
+    """A truncated ledger must fail closed, not restart the budget at zero."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ledger = tmp_path / "costs.json"
+    ledger.write_text('{"entries": [{"ts": "2026-01-01T00:00:00", "cos')
+
+    result = _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                  "--prompt", "x")
+    assert result.returncode != 0, "corrupt ledger must not be silently accepted"
+    assert "not valid JSON" in result.stderr
+
+    # Left in place for inspection, not overwritten.
+    assert ledger.read_text().endswith('"cos')
+
+
+def test_reset_recovers_a_corrupt_ledger(tmp_path) -> None:
+    """reset must not depend on the existing file parsing.
+
+    It is the documented recovery path, so requiring a readable ledger first
+    would leave a corrupt ledger unrecoverable through the CLI.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "costs.json").write_text("{ this is not json")
+
+    assert _run(tmp_path, "reset", "--confirm").returncode == 0
+    assert _ledger(tmp_path) == {
+        "total_cost": 0.0, "total_images": 0, "entries": [], "daily": {},
+    }
+
+
+def test_ledger_write_is_atomic_no_temp_files_left(tmp_path) -> None:
+    """The tempfile used for the atomic replace must not accumulate."""
+    for i in range(5):
+        _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+             "--prompt", f"p{i}")
+
+    leftovers = list(tmp_path.glob(".costs.*.tmp"))
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+def test_missing_aggregate_fields_are_tolerated(tmp_path) -> None:
+    """An older ledger without the aggregate keys must still be loggable."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "costs.json").write_text('{"entries": []}')
+
+    assert _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                "--prompt", "x").returncode == 0
+    ledger = _ledger(tmp_path)
+    assert ledger["total_images"] == 1
+    assert ledger["total_cost"] == pytest.approx(COST_1K)
+
+
+# ---------------------------------------------------------------------------
+# portability guard
+# ---------------------------------------------------------------------------
+
+
+def test_locking_is_never_disabled_unconditionally() -> None:
+    """The tracker must never run the ledger unlocked on any platform."""
+    source = _SCRIPT.read_text()
+    assert "import fcntl" in source and "import msvcrt" in source
+    assert "Refusing to touch the cost ledger unlocked" in source
+
+
+def test_isolated_home_is_honoured(tmp_path) -> None:
+    """Tests must never write to the operator's real ~/.banana ledger."""
+    _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K", "--prompt", "x")
+    assert (tmp_path / "costs.json").exists()

--- a/tests/test_dataforseo_costs.py
+++ b/tests/test_dataforseo_costs.py
@@ -1,0 +1,171 @@
+"""
+Tests for scripts/dataforseo_costs.py — spend-ledger integrity.
+
+Regression cover for the lost-update race: the ledger used to take its file
+lock twice, once to read and once to write, and drop it in between, so two
+concurrent `log` calls both read the same ledger and the second overwrote the
+first. A budget ledger that quietly under-reports spend is the one thing it
+must not do.
+
+Every test runs against an isolated CLAUDE_SEO_CONFIG_DIR, never the real
+~/.config/claude-seo/ ledger.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "scripts" / "dataforseo_costs.py"
+
+
+def _run(config_dir: Path, *argv: str) -> subprocess.CompletedProcess:
+    """Invoke the CLI in a subprocess with an isolated ledger."""
+    env = dict(os.environ)
+    env["CLAUDE_SEO_CONFIG_DIR"] = str(config_dir)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _entries(config_dir: Path) -> list[dict]:
+    return json.loads((config_dir / "dataforseo-ledger.json").read_text())["entries"]
+
+
+# ---------------------------------------------------------------------------
+# concurrency — the reported bug
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_logs_do_not_lose_entries(tmp_path) -> None:
+    """20 concurrent `log` calls must produce exactly 20 entries.
+
+    Fails on the pre-fix code, which loses entries whenever two processes
+    interleave their read-modify-write.
+    """
+    calls = 20
+    unit_cost = 0.01
+
+    with ThreadPoolExecutor(max_workers=calls) as pool:
+        results = list(
+            pool.map(
+                lambda i: _run(
+                    tmp_path, "log", "serp_organic_live_advanced", str(unit_cost),
+                    "--note", f"call-{i}",
+                ),
+                range(calls),
+            )
+        )
+
+    failed = [r for r in results if r.returncode != 0]
+    assert not failed, f"{len(failed)} log calls failed: {failed[0].stderr}"
+
+    entries = _entries(tmp_path)
+    assert len(entries) == calls, (
+        f"lost {calls - len(entries)} of {calls} concurrent writes"
+    )
+
+    notes = sorted(e["note"] for e in entries)
+    assert notes == sorted(f"call-{i}" for i in range(calls)), "entries were clobbered"
+
+    total = sum(e["cost"] for e in entries)
+    assert total == pytest.approx(calls * unit_cost), "recorded spend under-reports"
+
+
+def test_concurrent_log_and_reset_keep_the_ledger_parseable(tmp_path) -> None:
+    """Interleaved writers must never leave a torn/unparseable ledger."""
+    _run(tmp_path, "log", "serp_organic_live_advanced", "0.01")
+
+    def job(i: int) -> subprocess.CompletedProcess:
+        if i % 5 == 4:
+            return _run(tmp_path, "reset", "--confirm")
+        return _run(tmp_path, "log", "serp_organic_live_advanced", "0.01")
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        list(pool.map(job, range(10)))
+
+    # The ledger must still be valid JSON with an entries list. Which entries
+    # survive depends on reset ordering; that the file parses is the invariant.
+    entries = _entries(tmp_path)
+    assert isinstance(entries, list)
+
+    result = json.loads(_run(tmp_path, "today").stdout)
+    assert result["status"] == "today"
+
+
+# ---------------------------------------------------------------------------
+# durability
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_ledger_is_not_silently_zeroed(tmp_path) -> None:
+    """A truncated ledger must fail closed, not restart the budget at zero.
+
+    The old code caught JSONDecodeError and returned {"entries": []}, so the
+    next write persisted an empty ledger and the entire spend history vanished.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ledger = tmp_path / "dataforseo-ledger.json"
+    ledger.write_text('{"entries": [{"timestamp": "2026-01-01T00:00:00", "cos')
+
+    result = _run(tmp_path, "log", "serp_organic_live_advanced", "0.01")
+    assert result.returncode != 0, "corrupt ledger must not be silently accepted"
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert "not valid JSON" in payload["message"]
+
+    # The damaged file is left in place for inspection, not overwritten.
+    assert ledger.read_text().endswith('"cos')
+
+
+def test_today_totals_survive_a_write(tmp_path) -> None:
+    """Basic round trip: logged spend is reflected in `today`."""
+    _run(tmp_path, "log", "on_page_lighthouse", "0.02")
+    _run(tmp_path, "log", "on_page_lighthouse", "0.03")
+
+    payload = json.loads(_run(tmp_path, "today").stdout)
+    assert payload["total_usd"] == pytest.approx(0.05)
+    assert payload["calls"] == 2
+
+
+def test_ledger_write_is_atomic_no_temp_files_left(tmp_path) -> None:
+    """The tempfile used for the atomic replace must not accumulate."""
+    for _ in range(5):
+        _run(tmp_path, "log", "on_page_lighthouse", "0.02")
+
+    leftovers = list(tmp_path.glob(".dataforseo-ledger.*.tmp"))
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+# ---------------------------------------------------------------------------
+# portability guard
+# ---------------------------------------------------------------------------
+
+
+def test_locking_is_never_disabled_unconditionally() -> None:
+    """Guard against the `fcntl = None` regression.
+
+    The module previously ran with no locking at all on Windows. It must now
+    fall back to msvcrt and, failing that, refuse to touch the ledger.
+    """
+    source = _SCRIPT.read_text()
+    assert "import msvcrt" in source, "no Windows locking fallback"
+    assert "Refusing to touch the spend ledger unlocked" in source, (
+        "module must fail closed when no locking primitive is available"
+    )
+
+
+def test_isolated_config_dir_is_honoured(tmp_path) -> None:
+    """Tests must never write to the operator's real ledger."""
+    _run(tmp_path, "log", "on_page_lighthouse", "0.02")
+    assert (tmp_path / "dataforseo-ledger.json").exists()


### PR DESCRIPTION
## Summary

Both of the plugin's cost ledgers silently drop entries under concurrent writes and
under-report spend. Same defect, two files, one fix applied consistently to each.

## Part 1: `scripts/dataforseo_costs.py`

### The bug

`scripts/dataforseo_costs.py` takes its file lock twice, once to read and once to write,
and releases it in between:

```python
def cmd_log(args):
    ledger = _load_ledger()      # LOCK_SH, read, unlock
    ...
    ledger["entries"].append(entry)
    _save_ledger(ledger)         # LOCK_EX, write, unlock
```

Two concurrent `log` calls both read the same ledger, and the second overwrites the first:

```
P1 load -> [a,b,c]
P2 load -> [a,b,c]
P1 append d, save -> [a,b,c,d]
P2 append e, save -> [a,b,c,e]     # d is gone
```

Upgrading `_load_ledger` to `LOCK_EX` would not fix this. The lock has to span both halves.
`cmd_reset` has the same shape, so a concurrent `log` during a reset is lost, or the reset is.

**Measured on macOS**, 20 concurrent `log` calls against an isolated ledger: 3 entries lost,
and 1 to 3 lost on every repeat run. Originally reported on Windows, which is where it was
first noticed, but it is not platform-specific.

This matters more than the raw numbers suggest. `skills/seo-audit` fans out to up to 15
parallel specialists, three of which call DataForSEO (`seo-dataforseo`, `seo-backlinks`,
`seo-ecommerce`), and `skills/seo-dataforseo/SKILL.md` instructs each to `log` after every
call. Concurrent logging is the designed operating mode, not an edge case, so the ledger
under-reports precisely during the runs that spend the most.

### Two related defects on the same surface

**No file locking at all on Windows.** The module sets `fcntl = None` when the import fails
and then takes every unlocked code path, so on Windows the ledger runs with no locking
whatsoever, and a reader can observe a half-written file.

**A corrupt ledger silently resets the budget to zero.** `_save_ledger` opens the ledger with
`"w"`, which truncates in place and is not atomic. If the process dies mid-write, the file is
left as invalid JSON. `_load_ledger` then hits
`except (json.JSONDecodeError, IOError): return {"entries": []}` and reports an empty ledger,
which the next `log` persists. The entire spend history disappears, not just one entry. That
is strictly worse than the race and shares the same fix surface.

### The fix

- **`_locked_ledger()`** holds one exclusive lock across the whole read-modify-write.
  `cmd_log` and `cmd_reset` both use it. The lock stays in a separate `.lock` file on
  purpose: the atomic write replaces the ledger's inode, so a lock held on the ledger itself
  would not protect the replacement.
- **Windows no longer runs unlocked.** `fcntl` falls back to `msvcrt.locking`, and when
  neither primitive is available the operation raises rather than proceeding unlocked. A
  budget ledger that silently drops entries is worse than one that refuses to run.
- **Ledger writes are atomic** (tempfile plus `os.replace`, the idiom already used in
  `scripts/google_auth.py`), and an unparseable ledger now fails closed with a clear message
  and the file left in place for inspection, instead of restarting the budget at zero.
- **`CLAUDE_SEO_CONFIG_DIR`** overrides the config and ledger location so the tests run
  against an isolated ledger and never touch the operator's real spend history.

### Tests

New `tests/test_dataforseo_costs.py`, 7 tests:

- 20 concurrent `log` subprocesses must produce exactly 20 entries with the correct total.
  This fails on the current code and passes with the fix.
- Interleaved `log` and `reset` must leave the ledger parseable.
- A truncated ledger must fail closed rather than being silently zeroed.
- The atomic write must not leave temp files behind.
- A portability guard asserting locking is never disabled unconditionally, so the
  `fcntl = None` regression cannot come back.

## Part 2: `extensions/banana/scripts/cost_tracker.py`

The image cost ledger has the same defect and is worse: it had **no file locking at all**
on any platform, plus the same non-atomic write.

Measured against v2.2.4, 20 concurrent `log` calls: **4 entries lost**, and **3 of those
processes crashed outright** with `JSONDecodeError` after reading a half-written file. So
on the current code a concurrent batch can both under-report spend and kill generations
mid-run.

It is also harder to notice than the DataForSEO case. This ledger carries running
aggregates (`total_cost`, `total_images`, `daily`) that are incremented in the same write
as the entry, so a lost write drops the entry **and** its aggregate increments together.
The file therefore stays internally self-consistent while under-reporting. Checking that
`total_cost` equals `sum(entries)` proves nothing.

Same treatment as Part 1: one exclusive lock across the whole read-modify-write in
`cmd_log`, atomic writes, `msvcrt` fallback with a hard failure when no locking primitive
exists, and a corrupt ledger that fails closed with a clear message instead of a bare
traceback.

One deliberate asymmetry: `cmd_reset` takes the exclusive lock but does **not** read the
ledger first. Reset is the documented recovery path for a corrupt ledger, so making it
depend on the existing file parsing would leave a corrupt ledger unrecoverable through the
CLI. There is a test for exactly that.

`BANANA_HOME` overrides the ledger and pricing paths so the 9 new tests in
`tests/test_banana_cost_tracker.py` never touch the operator's real `~/.banana`. They
cover concurrency, aggregate correctness after concurrent writes, interleaved
`log`/`reset`, corrupt-ledger fail-closed, reset-recovers-corrupt, no leftover temp files,
tolerance of older ledgers missing the aggregate keys, and a portability guard.

## Verification

Full suite: **412 passed** on this branch, re-run against `main` @ `09d37c7`. The 3 excluded
modules (`test_gsc_pagination.py`, `test_gsc_query.py`, `test_gsc_totals_aggregate.py`) are
gated on `google-api-python-client`, which is not installed in this environment and is
unrelated to this change.

Note for reviewers: the Banana half was written against this repo's current
`extensions/banana/scripts/cost_tracker.py`, which loads the dated `pricing.json`. It is not
a port of an older shape.

## Not addressed here

`check` (read spend) -> API call -> `log` (write spend) is a separate TOCTOU across
processes: N parallel agents can each pass the daily-limit check before any of them logs, so
the daily limit can still be overshot even with a correct ledger. Closing that needs a
reserve/commit design and felt out of scope for a bug fix. Happy to follow up if you want it.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — **not applicable**, and left unticked
  rather than claimed. This change touches only the two spend ledgers; no analysis or
  fetch path is involved, so there is no URL that would exercise it. The equivalent
  evidence is the full suite (412 passed) plus the two new concurrency suites, each of
  which reproduces its race against the current code and shows it absent after the fix.
- [x] SKILL.md files stay under 500 lines (if modified) — none modified.
- [x] Python scripts output JSON (if modified) — preserved. `dataforseo_costs.py` still
  emits JSON on every path, and the new fail-closed errors go out as
  `{"status": "error", "message": ...}` rather than as a traceback.
- [x] Reference files stay under 200 lines (if modified) — none modified.
- [x] `set -euo pipefail` used in any new shell scripts — no shell scripts added.
- [x] CHANGELOG.md updated with the change — an `Unreleased / Fixed` section covering all
  four defects.
