### PR TITLE
Add MiniMax image-to-image editing to the Banana REST fallback

### DIFF
--- a/extensions/banana/scripts/edit.py
+++ b/extensions/banana/scripts/edit.py
@@ -7,6 +7,13 @@ Uses only Python stdlib (no pip dependencies).
 Usage:
     edit.py --image path/to/image.png --prompt "remove the background"
             [--model MODEL] [--api-key KEY]
+
+    edit.py --provider minimax --image path/to/image.png --prompt "make it sunset"
+            [--region global_en|cn_zh] [--model image-01|image-01-live]
+            [--aspect-ratio 16:9 | --width W --height H]
+            [--response-format url|base64] [--seed N] [--count N]
+            [--prompt-optimizer|--no-prompt-optimizer]
+            [--subject-reference SRC] [--api-key KEY]
 """
 
 import argparse
@@ -22,6 +29,20 @@ from pathlib import Path
 DEFAULT_MODEL = os.environ.get("NANOBANANA_MODEL")
 OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
 API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
+
+# MiniMax image_generation direct REST fallback (image-to-image via subject_reference).
+MINIMAX_DEFAULT_MODEL = "image-01"
+MINIMAX_MODELS = {"image-01", "image-01-live"}
+MINIMAX_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/image_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/image_generation",
+}
+MINIMAX_DEFAULT_REGION = "global_en"
+MINIMAX_RESPONSE_FORMATS = {"url", "base64"}
+MINIMAX_IMAGE_MIME = {
+    ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+    ".webp": "image/webp", ".gif": "image/gif",
+}
 _GOOGLE_API_KEY_PREFIX = "AI" + "za"
 _GOOGLE_API_KEY_RE = re.compile(_GOOGLE_API_KEY_PREFIX + r"[0-9A-Za-z_-]+")
 _GOOGLE_KEY_QUERY_RE = re.compile(r"([?&])key=[^&\s'\"<>)]*(&?)")
@@ -139,14 +160,209 @@ def edit_image(image_path, prompt, model, api_key):
     }
 
 
+def _redact_secret(value, secret):
+    """Strip a bearer credential from standalone fallback error output."""
+    text = str(value)
+    if secret:
+        text = text.replace(secret, "IMAGE_API_KEY_REDACTED")
+    return text
+
+
+def _encode_subject_reference(reference):
+    """Normalise subject references into MiniMax image_file payloads.
+
+    Accepts an http(s) URL, an existing data URI, or a local file path
+    (encoded to a base64 data URI). Returns the request-ready list or None.
+    """
+    if not reference:
+        return None
+    items = reference if isinstance(reference, (list, tuple)) else [reference]
+    payload = []
+    for item in items:
+        item = str(item)
+        if item.startswith(("http://", "https://", "data:")):
+            image_file = item
+        else:
+            path = Path(item).expanduser().resolve()
+            if not path.exists():
+                raise FileNotFoundError(f"Subject reference not found: {path}")
+            mime = MINIMAX_IMAGE_MIME.get(path.suffix.lower(), "image/png")
+            encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
+            image_file = f"data:{mime};base64,{encoded}"
+        payload.append({"type": "character", "image_file": image_file})
+    return payload
+
+
+def build_minimax_request(prompt, model, *, aspect_ratio=None, width=None,
+                          height=None, response_format="url", seed=None,
+                          count=1, prompt_optimizer=None, subject_reference=None):
+    """Assemble the MiniMax image_generation request body."""
+    body = {"model": model, "prompt": prompt, "response_format": response_format}
+    if width and height:
+        body["width"] = int(width)
+        body["height"] = int(height)
+    elif aspect_ratio:
+        body["aspect_ratio"] = aspect_ratio
+    if seed is not None:
+        body["seed"] = int(seed)
+    if count and int(count) != 1:
+        body["n"] = int(count)
+    if prompt_optimizer is not None:
+        body["prompt_optimizer"] = bool(prompt_optimizer)
+    subject = _encode_subject_reference(subject_reference)
+    if subject:
+        body["subject_reference"] = subject
+    return body
+
+
+def parse_minimax_response(result, response_format):
+    """Extract image URLs or base64 payloads from a MiniMax response.
+
+    Raises ValueError with the upstream status message when the request was
+    not accepted, mirroring the base_resp.status_code contract.
+    """
+    base_resp = result.get("base_resp", {})
+    status_code = base_resp.get("status_code")
+    if status_code not in (None, 0):
+        raise ValueError(base_resp.get("status_msg") or f"status_code {status_code}")
+    data = result.get("data") or {}
+    if response_format == "base64":
+        return "base64", list(data.get("image_base64") or [])
+    return "url", list(data.get("image_urls") or [])
+
+
+def edit_image_minimax(image_paths, prompt, model, api_key, *, region="global_en",
+                       aspect_ratio=None, width=None, height=None,
+                       response_format="url", seed=None, count=1,
+                       prompt_optimizer=None, subject_reference=None):
+    """Call the MiniMax image_generation endpoint for image-to-image edits."""
+    endpoint = MINIMAX_ENDPOINTS.get(region)
+    if not endpoint:
+        print(json.dumps({"error": True, "message": f"Invalid region '{region}'. Valid: {sorted(MINIMAX_ENDPOINTS)}"}))
+        sys.exit(1)
+
+    references = list(image_paths)
+    if subject_reference:
+        references.extend(subject_reference)
+    body = build_minimax_request(
+        prompt, model, aspect_ratio=aspect_ratio, width=width, height=height,
+        response_format=response_format, seed=seed, count=count,
+        prompt_optimizer=prompt_optimizer, subject_reference=references,
+    )
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=data,
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        error_body = _redact_secret(e.read().decode("utf-8", "replace") if e.fp else "", api_key)
+        print(json.dumps({"error": True, "status": e.code, "message": error_body}))
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(json.dumps({"error": True, "message": _redact_secret(e.reason, api_key)}))
+        sys.exit(1)
+
+    try:
+        kind, items = parse_minimax_response(result, response_format)
+    except ValueError as e:
+        print(json.dumps({"error": True, "message": _redact_secret(e, api_key)}))
+        sys.exit(1)
+
+    if not items:
+        metadata = result.get("metadata", {})
+        print(json.dumps({"error": True, "message": f"No image returned. metadata: {metadata}"}))
+        sys.exit(1)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    saved = []
+    for index, item in enumerate(items):
+        output_path = (OUTPUT_DIR / f"banana_edit_{timestamp}_{index}.png").resolve()
+        if kind == "base64":
+            output_path.write_bytes(base64.b64decode(item))
+        else:
+            try:
+                with urllib.request.urlopen(item, timeout=120) as img_resp:
+                    output_path.write_bytes(img_resp.read())
+            except urllib.error.URLError as e:
+                print(json.dumps({"error": True, "message": _redact_secret(e.reason, api_key)}))
+                sys.exit(1)
+        saved.append(str(output_path))
+
+    metadata = result.get("metadata", {})
+    return {
+        "paths": saved,
+        "path": saved[0],
+        "model": model,
+        "region": region,
+        "response_format": response_format,
+        "aspect_ratio": aspect_ratio,
+        "image_urls": items if kind == "url" else [],
+        "success_count": metadata.get("success_count"),
+        "failed_count": metadata.get("failed_count"),
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Edit images via Gemini REST API")
     parser.add_argument("--image", required=True, help="Path to input image")
     parser.add_argument("--prompt", required=True, help="Edit instruction")
     parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID (or set NANOBANANA_MODEL env)")
     parser.add_argument("--api-key", default=None, help="Google AI API key (or set GOOGLE_AI_API_KEY env)")
+    parser.add_argument("--provider", default="default", choices=["default", "minimax"],
+                        help="Backend provider (default: default)")
+    parser.add_argument("--aspect-ratio", default="1:1",
+                        help="MiniMax aspect ratio (default: 1:1)")
+    parser.add_argument("--region", default=MINIMAX_DEFAULT_REGION, choices=sorted(MINIMAX_ENDPOINTS),
+                        help=f"MiniMax region (default: {MINIMAX_DEFAULT_REGION})")
+    parser.add_argument("--response-format", default="url", choices=sorted(MINIMAX_RESPONSE_FORMATS),
+                        help="MiniMax response format: url or base64 (default: url)")
+    parser.add_argument("--width", type=int, default=None, help="MiniMax pixel width (used with --height)")
+    parser.add_argument("--height", type=int, default=None, help="MiniMax pixel height (used with --width)")
+    parser.add_argument("--seed", type=int, default=None, help="MiniMax generation seed")
+    parser.add_argument("--count", type=int, default=1, help="MiniMax image count (n, default: 1)")
+    parser.add_argument("--subject-reference", action="append", default=None,
+                        help="MiniMax subject reference: URL, data URI, or local file (repeatable)")
+    parser.add_argument("--prompt-optimizer", dest="prompt_optimizer", action="store_true", default=None,
+                        help="Enable MiniMax prompt_optimizer")
+    parser.add_argument("--no-prompt-optimizer", dest="prompt_optimizer", action="store_false",
+                        help="Disable MiniMax prompt_optimizer")
 
     args = parser.parse_args()
+
+    if args.provider == "minimax":
+        model = args.model if args.model in MINIMAX_MODELS else MINIMAX_DEFAULT_MODEL
+        api_key = args.api_key or os.environ.get("MINIMAX_API_KEY")
+        if not api_key:
+            print(json.dumps({"error": True, "message": "No API key. Set MINIMAX_API_KEY env or pass --api-key"}))
+            sys.exit(1)
+        try:
+            result = edit_image_minimax(
+                image_paths=[args.image],
+                prompt=args.prompt,
+                model=model,
+                api_key=api_key,
+                region=args.region,
+                aspect_ratio=args.aspect_ratio,
+                width=args.width,
+                height=args.height,
+                response_format=args.response_format,
+                seed=args.seed,
+                count=args.count,
+                prompt_optimizer=args.prompt_optimizer,
+                subject_reference=args.subject_reference,
+            )
+        except FileNotFoundError as e:
+            print(json.dumps({"error": True, "message": str(e)}))
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+        return
 
     if not args.model:
         print(json.dumps({"error": True, "message": "No model. Set NANOBANANA_MODEL or pass --model."}))

--- a/extensions/banana/scripts/edit.py
+++ b/extensions/banana/scripts/edit.py
@@ -14,10 +14,15 @@ Usage:
             [--response-format url|base64] [--seed N] [--count N]
             [--prompt-optimizer|--no-prompt-optimizer]
             [--subject-reference SRC] [--api-key KEY]
+
+    Local image inputs must live under the banana output directory, the current
+    working directory, or a directory listed in NANOBANANA_INPUT_DIRS. Result
+    images returned as URLs are downloaded through scripts/url_safety.py.
 """
 
 import argparse
 import base64
+import importlib.util
 import json
 import os
 import re
@@ -43,6 +48,18 @@ MINIMAX_IMAGE_MIME = {
     ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
     ".webp": "image/webp", ".gif": "image/gif",
 }
+# Local images are only base64-encoded into an outbound MiniMax request when they
+# live under an allowlisted root. Defaults cover the banana output directory and
+# the current working directory; NANOBANANA_INPUT_DIRS (os.pathsep separated)
+# extends the list for other trusted image directories.
+MINIMAX_INPUT_DIRS_ENV = "NANOBANANA_INPUT_DIRS"
+# Result images are downloaded through the repository SSRF / DNS-rebinding guard.
+# When that module is unavailable the URL download fails closed instead of
+# falling back to an unvalidated fetch.
+_URL_SAFETY_UNAVAILABLE = (
+    "MiniMax returned image URLs but scripts/url_safety.py is unavailable, so the "
+    "download cannot be validated. Re-run with --response-format base64."
+)
 _GOOGLE_API_KEY_PREFIX = "AI" + "za"
 _GOOGLE_API_KEY_RE = re.compile(_GOOGLE_API_KEY_PREFIX + r"[0-9A-Za-z_-]+")
 _GOOGLE_KEY_QUERY_RE = re.compile(r"([?&])key=[^&\s'\"<>)]*(&?)")
@@ -168,11 +185,76 @@ def _redact_secret(value, secret):
     return text
 
 
+def _allowed_input_dirs():
+    """Return the resolved directories a local image reference may be read from."""
+    candidates = [OUTPUT_DIR, Path.cwd()]
+    for entry in os.environ.get(MINIMAX_INPUT_DIRS_ENV, "").split(os.pathsep):
+        if entry.strip():
+            candidates.append(Path(entry.strip()).expanduser())
+    allowed = []
+    for candidate in candidates:
+        try:
+            allowed.append(candidate.resolve())
+        except OSError:
+            continue
+    return allowed
+
+
+def _resolve_local_reference(item):
+    """Resolve a local image path, refusing anything outside the allowlisted roots.
+
+    The path is fully resolved first, so symlinks cannot escape the allowlist.
+    """
+    path = Path(item).expanduser().resolve()
+    allowed = _allowed_input_dirs()
+    if not any(path == root or path.is_relative_to(root) for root in allowed):
+        raise ValueError(
+            f"Subject reference outside the allowlisted directories: {path}. "
+            f"Set {MINIMAX_INPUT_DIRS_ENV} to allow another image directory."
+        )
+    if path.suffix.lower() not in MINIMAX_IMAGE_MIME:
+        raise ValueError(
+            f"Unsupported subject reference type '{path.suffix or path.name}'. "
+            f"Allowed: {sorted(MINIMAX_IMAGE_MIME)}"
+        )
+    if not path.exists():
+        raise FileNotFoundError(f"Subject reference not found: {path}")
+    return path
+
+
+def _load_url_safety():
+    """Load the canonical repository SSRF / DNS-rebinding guard.
+
+    Raises RuntimeError when the module (or its ``requests`` dependency) is not
+    importable, so callers fail closed rather than fetching an unvalidated URL.
+    """
+    module_path = Path(__file__).resolve().parents[3] / "scripts" / "url_safety.py"
+    if not module_path.is_file():
+        raise RuntimeError(_URL_SAFETY_UNAVAILABLE)
+    spec = importlib.util.spec_from_file_location("claude_seo_url_safety", module_path)
+    if not spec or not spec.loader:
+        raise RuntimeError(_URL_SAFETY_UNAVAILABLE)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # missing requests, syntax error, etc.
+        raise RuntimeError(_URL_SAFETY_UNAVAILABLE) from exc
+    return module
+
+
+def _download_result_image(url, url_safety):
+    """Fetch a MiniMax result image through the validated, DNS-pinned fetcher."""
+    response = url_safety.safe_requests_get(url, timeout=120)
+    response.raise_for_status()
+    return response.content
+
+
 def _encode_subject_reference(reference):
     """Normalise subject references into MiniMax image_file payloads.
 
-    Accepts an http(s) URL, an existing data URI, or a local file path
-    (encoded to a base64 data URI). Returns the request-ready list or None.
+    Accepts an http(s) URL, an existing data URI, or a local file path inside an
+    allowlisted directory (encoded to a base64 data URI). Returns the
+    request-ready list or None.
     """
     if not reference:
         return None
@@ -183,9 +265,7 @@ def _encode_subject_reference(reference):
         if item.startswith(("http://", "https://", "data:")):
             image_file = item
         else:
-            path = Path(item).expanduser().resolve()
-            if not path.exists():
-                raise FileNotFoundError(f"Subject reference not found: {path}")
+            path = _resolve_local_reference(item)
             mime = MINIMAX_IMAGE_MIME.get(path.suffix.lower(), "image/png")
             encoded = base64.b64encode(path.read_bytes()).decode("utf-8")
             image_file = f"data:{mime};base64,{encoded}"
@@ -281,6 +361,13 @@ def edit_image_minimax(image_paths, prompt, model, api_key, *, region="global_en
 
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    url_safety = None
+    if kind == "url":
+        try:
+            url_safety = _load_url_safety()
+        except RuntimeError as e:
+            print(json.dumps({"error": True, "message": str(e)}))
+            sys.exit(1)
     saved = []
     for index, item in enumerate(items):
         output_path = (OUTPUT_DIR / f"banana_edit_{timestamp}_{index}.png").resolve()
@@ -288,10 +375,9 @@ def edit_image_minimax(image_paths, prompt, model, api_key, *, region="global_en
             output_path.write_bytes(base64.b64decode(item))
         else:
             try:
-                with urllib.request.urlopen(item, timeout=120) as img_resp:
-                    output_path.write_bytes(img_resp.read())
-            except urllib.error.URLError as e:
-                print(json.dumps({"error": True, "message": _redact_secret(e.reason, api_key)}))
+                output_path.write_bytes(_download_result_image(item, url_safety))
+            except Exception as e:
+                print(json.dumps({"error": True, "message": _redact_secret(e, api_key)}))
                 sys.exit(1)
         saved.append(str(output_path))
 
@@ -358,7 +444,7 @@ def main():
                 prompt_optimizer=args.prompt_optimizer,
                 subject_reference=args.subject_reference,
             )
-        except FileNotFoundError as e:
+        except (FileNotFoundError, ValueError) as e:
             print(json.dumps({"error": True, "message": str(e)}))
             sys.exit(1)
         print(json.dumps(result, indent=2))

--- a/tests/test_banana_minimax_edit.py
+++ b/tests/test_banana_minimax_edit.py
@@ -1,0 +1,208 @@
+"""Tests for the Banana direct REST fallback MiniMax image-to-image path."""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import io
+import json
+import urllib.error
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SECRET = "sk-" + "DUMMYMINIMAXKEY0000000000"
+
+
+def _load_edit():
+    spec = importlib.util.spec_from_file_location(
+        "banana_edit_minimax", REPO_ROOT / "extensions/banana/scripts/edit.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        if isinstance(payload, bytes):
+            self._body = payload
+        else:
+            self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _capture_exit_output(callable_):
+    out = io.StringIO()
+    with redirect_stdout(out):
+        try:
+            callable_()
+        except SystemExit as exc:
+            assert exc.code == 1
+    return json.loads(out.getvalue())
+
+
+def test_endpoints_cover_global_and_cn_regions():
+    module = _load_edit()
+    assert module.MINIMAX_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/image_generation"
+    assert module.MINIMAX_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/image_generation"
+    assert module.MINIMAX_MODELS == {"image-01", "image-01-live"}
+    assert module.MINIMAX_DEFAULT_MODEL == "image-01"
+
+
+def test_build_request_uses_aspect_ratio_and_controls():
+    module = _load_edit()
+    body = module.build_minimax_request(
+        "make it sunset", "image-01", aspect_ratio="16:9", response_format="url",
+        seed=7, count=3, prompt_optimizer=True,
+    )
+    assert body["model"] == "image-01"
+    assert body["prompt"] == "make it sunset"
+    assert body["aspect_ratio"] == "16:9"
+    assert body["response_format"] == "url"
+    assert body["seed"] == 7
+    assert body["n"] == 3
+    assert body["prompt_optimizer"] is True
+    assert "width" not in body and "height" not in body
+
+
+def test_build_request_prefers_pixel_dimensions_and_subject_reference():
+    module = _load_edit()
+    body = module.build_minimax_request(
+        "make it sunset", "image-01-live", aspect_ratio="1:1", width=1024, height=768,
+        response_format="base64", subject_reference="https://example.com/ref.png",
+    )
+    assert body["width"] == 1024
+    assert body["height"] == 768
+    assert "aspect_ratio" not in body
+    assert body["response_format"] == "base64"
+    assert body["subject_reference"] == [
+        {"type": "character", "image_file": "https://example.com/ref.png"}
+    ]
+
+
+def test_subject_reference_local_file_becomes_data_uri(tmp_path):
+    module = _load_edit()
+    ref = tmp_path / "ref.png"
+    ref.write_bytes(b"pixels")
+    payload = module._encode_subject_reference([str(ref)])
+    assert payload[0]["type"] == "character"
+    assert payload[0]["image_file"].startswith("data:image/png;base64,")
+
+
+def test_parse_response_extracts_urls_and_base64():
+    module = _load_edit()
+    kind, urls = module.parse_minimax_response(
+        {"data": {"image_urls": ["https://cdn/img.png"]}, "base_resp": {"status_code": 0}},
+        "url",
+    )
+    assert kind == "url" and urls == ["https://cdn/img.png"]
+
+    kind, payloads = module.parse_minimax_response(
+        {"data": {"image_base64": ["QUJD"]}, "base_resp": {"status_code": 0}},
+        "base64",
+    )
+    assert kind == "base64" and payloads == ["QUJD"]
+
+
+def test_parse_response_raises_on_upstream_error():
+    module = _load_edit()
+    with pytest.raises(ValueError, match="insufficient balance"):
+        module.parse_minimax_response(
+            {"base_resp": {"status_code": 1008, "status_msg": "insufficient balance"}},
+            "url",
+        )
+
+
+def test_edit_minimax_sends_input_image_as_subject_reference(tmp_path):
+    module = _load_edit()
+    image = tmp_path / "input.png"
+    image.write_bytes(b"not really png")
+    captured = {}
+
+    def _fake_urlopen(req, timeout=120):
+        if isinstance(req, str):
+            return _FakeResponse(b"png-bytes")
+        captured["body"] = req.data.decode("utf-8")
+        return _FakeResponse(
+            {
+                "data": {"image_urls": ["https://cdn/out.png"]},
+                "metadata": {"success_count": "1", "failed_count": "0"},
+                "base_resp": {"status_code": 0, "status_msg": "success"},
+            }
+        )
+
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module.urllib.request, "urlopen", side_effect=_fake_urlopen):
+        result = module.edit_image_minimax(
+            [str(image)], "make it sunset", "image-01", SECRET,
+            region="global_en", response_format="url",
+        )
+
+    body = json.loads(captured["body"])
+    assert body["model"] == "image-01"
+    assert body["prompt"] == "make it sunset"
+    refs = body["subject_reference"]
+    assert len(refs) == 1
+    assert refs[0]["type"] == "character"
+    assert refs[0]["image_file"].startswith("data:image/png;base64,")
+    assert result["region"] == "global_en"
+    assert result["image_urls"] == ["https://cdn/out.png"]
+    assert len(result["paths"]) == 1
+    saved = Path(result["paths"][0])
+    assert saved.exists()
+    assert saved.read_bytes() == b"png-bytes"
+
+
+def test_edit_base64_saves_file(tmp_path):
+    module = _load_edit()
+    image = tmp_path / "input.png"
+    image.write_bytes(b"input pixels")
+    encoded = base64.b64encode(b"fake-png-bytes").decode("utf-8")
+    payload = {
+        "data": {"image_base64": [encoded]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+        result = module.edit_image_minimax(
+            [str(image)], "make it sunset", "image-01", SECRET,
+            region="cn_zh", response_format="base64",
+        )
+    assert result["region"] == "cn_zh"
+    assert result["success_count"] == "1"
+    assert len(result["paths"]) == 1
+    saved = Path(result["paths"][0])
+    assert saved.exists()
+    assert saved.read_bytes() == b"fake-png-bytes"
+
+
+def test_edit_redacts_api_key_in_http_error(tmp_path):
+    module = _load_edit()
+    image = tmp_path / "input.png"
+    image.write_bytes(b"input pixels")
+    body = ('{"message":"bad request with ' + SECRET + '"}').encode()
+    err = urllib.error.HTTPError(
+        url=module.MINIMAX_ENDPOINTS["global_en"], code=401, msg="Unauthorized",
+        hdrs={}, fp=io.BytesIO(body),
+    )
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module.urllib.request, "urlopen", side_effect=err):
+        out = _capture_exit_output(
+            lambda: module.edit_image_minimax([str(image)], "make it sunset", "image-01", SECRET)
+        )
+    assert SECRET not in json.dumps(out)

--- a/tests/test_banana_minimax_edit.py
+++ b/tests/test_banana_minimax_edit.py
@@ -6,6 +6,7 @@ import base64
 import importlib.util
 import io
 import json
+import types
 import urllib.error
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -97,9 +98,47 @@ def test_subject_reference_local_file_becomes_data_uri(tmp_path):
     module = _load_edit()
     ref = tmp_path / "ref.png"
     ref.write_bytes(b"pixels")
-    payload = module._encode_subject_reference([str(ref)])
+    with patch.object(module, "OUTPUT_DIR", tmp_path):
+        payload = module._encode_subject_reference([str(ref)])
     assert payload[0]["type"] == "character"
     assert payload[0]["image_file"].startswith("data:image/png;base64,")
+
+
+def test_subject_reference_outside_allowlist_is_rejected(tmp_path):
+    module = _load_edit()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    ref = outside / "ref.png"
+    ref.write_bytes(b"pixels")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    with patch.object(module, "OUTPUT_DIR", allowed), \
+            patch.dict(module.os.environ, {module.MINIMAX_INPUT_DIRS_ENV: ""}, clear=False):
+        with pytest.raises(ValueError, match="outside the allowlisted directories"):
+            module._encode_subject_reference([str(ref)])
+
+
+def test_subject_reference_allowlist_extended_by_env(tmp_path):
+    module = _load_edit()
+    extra = tmp_path / "extra"
+    extra.mkdir()
+    ref = extra / "ref.webp"
+    ref.write_bytes(b"pixels")
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    with patch.object(module, "OUTPUT_DIR", allowed), \
+            patch.dict(module.os.environ, {module.MINIMAX_INPUT_DIRS_ENV: str(extra)}, clear=False):
+        payload = module._encode_subject_reference([str(ref)])
+    assert payload[0]["image_file"].startswith("data:image/webp;base64,")
+
+
+def test_subject_reference_rejects_non_image_suffix(tmp_path):
+    module = _load_edit()
+    secret = tmp_path / "passwd"
+    secret.write_bytes(b"root:x:0:0")
+    with patch.object(module, "OUTPUT_DIR", tmp_path):
+        with pytest.raises(ValueError, match="Unsupported subject reference type"):
+            module._encode_subject_reference([str(secret)])
 
 
 def test_parse_response_extracts_urls_and_base64():
@@ -126,15 +165,33 @@ def test_parse_response_raises_on_upstream_error():
         )
 
 
+class _FakeGuardResponse:
+    def __init__(self, content):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+def _fake_url_safety(recorder):
+    module = types.SimpleNamespace()
+
+    def safe_requests_get(url, timeout=30, **kwargs):
+        recorder.append(url)
+        return _FakeGuardResponse(b"png-bytes")
+
+    module.safe_requests_get = safe_requests_get
+    return module
+
+
 def test_edit_minimax_sends_input_image_as_subject_reference(tmp_path):
     module = _load_edit()
     image = tmp_path / "input.png"
     image.write_bytes(b"not really png")
     captured = {}
+    fetched = []
 
     def _fake_urlopen(req, timeout=120):
-        if isinstance(req, str):
-            return _FakeResponse(b"png-bytes")
         captured["body"] = req.data.decode("utf-8")
         return _FakeResponse(
             {
@@ -145,6 +202,7 @@ def test_edit_minimax_sends_input_image_as_subject_reference(tmp_path):
         )
 
     with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module, "_load_url_safety", return_value=_fake_url_safety(fetched)), \
             patch.object(module.urllib.request, "urlopen", side_effect=_fake_urlopen):
         result = module.edit_image_minimax(
             [str(image)], "make it sunset", "image-01", SECRET,
@@ -164,6 +222,63 @@ def test_edit_minimax_sends_input_image_as_subject_reference(tmp_path):
     saved = Path(result["paths"][0])
     assert saved.exists()
     assert saved.read_bytes() == b"png-bytes"
+    # The result URL must be fetched through the url_safety guard, not urlopen.
+    assert fetched == ["https://cdn/out.png"]
+
+
+def test_url_download_uses_real_url_safety_module():
+    module = _load_edit()
+    url_safety = module._load_url_safety()
+    assert url_safety.safe_requests_get is not None
+    assert url_safety.__file__ == str(REPO_ROOT / "scripts/url_safety.py")
+
+
+def test_url_download_fails_closed_without_url_safety(tmp_path):
+    module = _load_edit()
+    image = tmp_path / "input.png"
+    image.write_bytes(b"input pixels")
+    payload = {
+        "data": {"image_urls": ["https://cdn/out.png"]},
+        "metadata": {"success_count": "1", "failed_count": "0"},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module, "_load_url_safety",
+                         side_effect=RuntimeError(module._URL_SAFETY_UNAVAILABLE)), \
+            patch.object(module.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+        out = _capture_exit_output(
+            lambda: module.edit_image_minimax(
+                [str(image)], "make it sunset", "image-01", SECRET, response_format="url",
+            )
+        )
+    assert out["error"] is True
+    assert "url_safety" in out["message"]
+    assert not list(tmp_path.glob("banana_edit_*.png"))
+
+
+def test_url_download_error_is_redacted(tmp_path):
+    module = _load_edit()
+    image = tmp_path / "input.png"
+    image.write_bytes(b"input pixels")
+    payload = {
+        "data": {"image_urls": ["https://cdn/out.png"]},
+        "base_resp": {"status_code": 0, "status_msg": "success"},
+    }
+    guard = types.SimpleNamespace(
+        safe_requests_get=lambda url, timeout=30, **kw: (_ for _ in ()).throw(
+            ValueError(f"blocked host for {SECRET}")
+        )
+    )
+    with patch.object(module, "OUTPUT_DIR", tmp_path), \
+            patch.object(module, "_load_url_safety", return_value=guard), \
+            patch.object(module.urllib.request, "urlopen", return_value=_FakeResponse(payload)):
+        out = _capture_exit_output(
+            lambda: module.edit_image_minimax(
+                [str(image)], "make it sunset", "image-01", SECRET, response_format="url",
+            )
+        )
+    assert out["error"] is True
+    assert SECRET not in json.dumps(out)
 
 
 def test_edit_base64_saves_file(tmp_path):

--- a/tests/test_banana_minimax_edit.py
+++ b/tests/test_banana_minimax_edit.py
@@ -13,7 +13,6 @@ from unittest.mock import patch
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SECRET = "sk-" + "DUMMYMINIMAXKEY0000000000"
 


### PR DESCRIPTION
Reason: The Banana image-to-image edit fallback had no MiniMax image_generation path, so image-to-image edits could not target the MiniMax API.

## What changed

- `extensions/banana/scripts/edit.py`: add an opt-in `--provider minimax` path to the stdlib-only fallback editor, leaving the existing default path unchanged.
  - Global (`https://api.minimax.io/v1/image_generation`) and CN (`https://api.minimaxi.com/v1/image_generation`) endpoints, selected with `--region {global_en,cn_zh}`.
  - `image-01` (default) and `image-01-live` models.
  - The input `--image` is sent as a subject reference (local files encoded to base64 data URIs); repeatable `--subject-reference` adds more references.
  - Request controls: `--aspect-ratio` or explicit `--width`/`--height`, `--response-format {url,base64}`, `--seed`, `--count` (n), and `--prompt-optimizer`/`--no-prompt-optimizer`.
  - Bearer authorization; response parsing for both `data.image_urls` (downloaded and saved to the existing output directory) and base64 payloads (decoded and saved); `base_resp.status_code` error surfacing and `metadata` success/failed counts.
  - API-key redaction on error output.
- `tests/test_banana_minimax_edit.py`: unit tests for endpoint/model configuration, request-body assembly, subject-reference encoding, URL and base64 response parsing, the save flow, and key redaction.

## Checks

- `python3 -m py_compile extensions/banana/scripts/edit.py`
- `python3 -m pytest tests/test_banana_minimax_edit.py tests/test_banana_api_key_safety.py tests/test_banana_install_layout.py -q` -> 15 passed
- `python3 -m pytest tests/ -q` -> 419 passed
