### PR TITLE
fix(extensions): write MCP config to ~/.claude.json, not settings.json

### DIFF
--- a/extensions/ahrefs/docs/AHREFS-SETUP.md
+++ b/extensions/ahrefs/docs/AHREFS-SETUP.md
@@ -18,7 +18,7 @@ The installer:
 3. Pre-warms the `@ahrefs/mcp@0.0.11` npm package via `npx --yes` so the first
    MCP call doesn't spend 10+ seconds downloading.
 4. Copies `skills/seo-ahrefs/SKILL.md` into `~/.claude/skills/seo-ahrefs/`.
-5. Atomically writes `mcpServers.ahrefs` into `~/.claude/settings.json`
+5. Atomically writes `mcpServers.ahrefs` into `~/.claude.json`
    with your token in the `env` block. The settings file is `chmod 0o600`
    after the merge (same hardening as the OAuth token).
 
@@ -41,7 +41,7 @@ Re-run the installer to pre-warm or run `npx --yes --package=@ahrefs/mcp@0.0.11 
 
 The Python merge script is idempotent — re-running only replaces the
 `mcpServers.ahrefs.env.AHREFS_API_TOKEN` value, leaving the rest of
-`settings.json` intact.
+`~/.claude.json` intact.
 
 ## Uninstall
 

--- a/extensions/ahrefs/install.ps1
+++ b/extensions/ahrefs/install.ps1
@@ -14,7 +14,10 @@ if (-not (Test-Cmd python)) { throw "Python 3 is required." }
 if (-not (Test-Cmd npx))    { throw "Node 18+ / npx is required." }
 
 $SkillDir = Join-Path $HOME ".claude/skills"
-$SettingsJson = Join-Path $HOME ".claude/settings.json"
+# MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+# NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+# there, so entries written to settings.json silently never load.
+$McpConfigJson = Join-Path $HOME ".claude.json"
 
 if (-not (Test-Path (Join-Path $SkillDir "seo"))) {
     throw "claude-seo base plugin not installed."
@@ -34,7 +37,7 @@ Write-Host "✓ Installed skill: $SkillTarget"
 # Pre-warm.
 & npx --yes --package=@ahrefs/mcp@0.0.11 mcp --help *> $null
 
-# Merge settings.json.
+# Merge ~/.claude.json.
 $pyScript = @"
 import json, os, sys, tempfile
 path, token = sys.argv[1], sys.argv[2]
@@ -55,7 +58,7 @@ with os.fdopen(fd, 'w') as fh:
 os.replace(tmp, path)
 print(f'Wrote mcpServers.ahrefs to {path}')
 "@
-$pyScript | python - $SettingsJson $Plain
+$pyScript | python - $McpConfigJson $Plain
 
 Write-Host ""
 Write-Host "Done. Open a new Claude Code session and run /seo ahrefs metrics <url>."

--- a/extensions/ahrefs/install.sh
+++ b/extensions/ahrefs/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Claude SEO — Ahrefs extension installer.
 #
-# Wires the official @ahrefs/mcp server into ~/.claude/settings.json and
+# Wires the official @ahrefs/mcp server into ~/.claude.json and
 # copies the seo-ahrefs mirror skill into ~/.claude/skills/.
 #
 # Prereq: an Ahrefs API token. Get one at https://ahrefs.com/api.
@@ -9,7 +9,10 @@ set -euo pipefail
 
 main() {
     SKILL_DIR="${HOME}/.claude/skills"
-    SETTINGS_JSON="${HOME}/.claude/settings.json"
+    # MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+    # NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+    # there, so entries written to settings.json silently never load.
+    MCP_CONFIG_JSON="${HOME}/.claude.json"
 
     echo "════════════════════════════════════════"
     echo "║   Claude SEO — Ahrefs extension      ║"
@@ -46,9 +49,9 @@ main() {
     cp "${SOURCE_DIR}/skills/seo-ahrefs/SKILL.md" "${SKILL_DIR}/seo-ahrefs/SKILL.md"
     echo "✓ Installed skill: ${SKILL_DIR}/seo-ahrefs/SKILL.md"
 
-    # Merge MCP config into ~/.claude/settings.json atomically.
-    mkdir -p "$(dirname "${SETTINGS_JSON}")"
-    python3 - "${SETTINGS_JSON}" "${AHREFS_TOKEN}" <<'PY'
+    # Merge MCP config into ~/.claude.json atomically.
+    mkdir -p "$(dirname "${MCP_CONFIG_JSON}")"
+    python3 - "${MCP_CONFIG_JSON}" "${AHREFS_TOKEN}" <<'PY'
 import json
 import os
 import sys

--- a/extensions/ahrefs/uninstall.sh
+++ b/extensions/ahrefs/uninstall.sh
@@ -3,15 +3,15 @@
 set -euo pipefail
 
 SKILL_DIR="${HOME}/.claude/skills/seo-ahrefs"
-SETTINGS_JSON="${HOME}/.claude/settings.json"
+MCP_CONFIG_JSON="${HOME}/.claude.json"
 
 if [ -d "${SKILL_DIR}" ]; then
     rm -rf "${SKILL_DIR}"
     echo "✓ Removed ${SKILL_DIR}"
 fi
 
-if [ -f "${SETTINGS_JSON}" ]; then
-    python3 - "${SETTINGS_JSON}" <<'PY'
+if [ -f "${MCP_CONFIG_JSON}" ]; then
+    python3 - "${MCP_CONFIG_JSON}" <<'PY'
 import json, os, sys, tempfile
 path = sys.argv[1]
 with open(path) as fh:

--- a/extensions/banana/README.md
+++ b/extensions/banana/README.md
@@ -24,7 +24,7 @@ The installer will:
 1. Verify Claude SEO is installed
 2. Prompt for your Google AI API key (if nanobanana-mcp not already configured)
 3. Install the `seo-image-gen` skill and agent
-4. Configure the MCP server in `~/.claude/settings.json`
+4. Configure the MCP server in `~/.claude.json`
 
 ## Commands
 

--- a/extensions/banana/docs/BANANA-SETUP.md
+++ b/extensions/banana/docs/BANANA-SETUP.md
@@ -13,7 +13,7 @@
 ## MCP Server Configuration
 
 The installer configures this automatically. If you need to set it up manually,
-add to `~/.claude/settings.json`:
+add to `~/.claude.json`:
 
 ```json
 {
@@ -44,14 +44,14 @@ claude-seo run --extension banana validate_setup.py
 Or check manually:
 1. `ls ~/.claude/skills/seo-image-gen/SKILL.md`:skill file exists
 2. `ls ~/.claude/agents/seo-image-gen.md`:agent file exists
-3. `grep nanobanana ~/.claude/settings.json`:MCP configured
+3. `grep nanobanana ~/.claude.json`:MCP configured
 
 ## Common Issues
 
 ### "MCP tools not available"
 - Restart Claude Code after installing the extension
 - Verify your API key is valid at [aistudio.google.com](https://aistudio.google.com)
-- Check `~/.claude/settings.json` has the nanobanana-mcp entry
+- Check `~/.claude.json` has the nanobanana-mcp entry
 
 ### "Rate limited (429)"
 - Check current free-tier limits in Google AI Studio

--- a/extensions/banana/install.sh
+++ b/extensions/banana/install.sh
@@ -8,7 +8,10 @@ main() {
     SKILL_DIR="${HOME}/.claude/skills/seo-image-gen"
     AGENT_DIR="${HOME}/.claude/agents"
     SEO_SKILL_DIR="${HOME}/.claude/skills/seo"
-    SETTINGS_FILE="${HOME}/.claude/settings.json"
+    # MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+    # NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+    # there, so entries written to settings.json silently never load.
+    MCP_CONFIG_FILE="${HOME}/.claude.json"
 
     echo "════════════════════════════════════════"
     echo "║  Banana Image Gen - SEO Extension    ║"
@@ -60,8 +63,8 @@ main() {
 
     # Check if nanobanana-mcp is already configured
     MCP_CONFIGURED=false
-    if [ -f "${SETTINGS_FILE}" ]; then
-        if python3 - "${SETTINGS_FILE}" <<'PY' 2>/dev/null; then
+    if [ -f "${MCP_CONFIG_FILE}" ]; then
+        if python3 - "${MCP_CONFIG_FILE}" <<'PY' 2>/dev/null; then
 import json, sys
 settings_path = sys.argv[1]
 with open(settings_path, 'r') as f:
@@ -72,7 +75,7 @@ else:
     sys.exit(1)
 PY
             MCP_CONFIGURED=true
-            echo "✓ nanobanana-mcp already configured in settings.json"
+            echo "✓ nanobanana-mcp already configured in ~/.claude.json"
         fi
     fi
 
@@ -94,7 +97,7 @@ PY
         echo "→ Configuring nanobanana-mcp server..."
         # Credentials are passed as argv (never interpolated into the source string)
         # and the settings file is written atomically with 0600 permissions.
-        python3 - "${SETTINGS_FILE}" "${GOOGLE_AI_API_KEY}" <<'PY'
+        python3 - "${MCP_CONFIG_FILE}" "${GOOGLE_AI_API_KEY}" <<'PY'
 import json, os, sys, tempfile
 
 settings_path, api_key = sys.argv[1:3]
@@ -128,7 +131,7 @@ except Exception:
         os.unlink(tmp)
     raise
 
-print('  ✓ nanobanana-mcp configured in settings.json')
+print('  ✓ nanobanana-mcp configured in ~/.claude.json')
 PY
         if [ $? -ne 0 ]; then
             echo "✗ Could not auto-configure MCP server."

--- a/extensions/banana/scripts/setup_mcp.py
+++ b/extensions/banana/scripts/setup_mcp.py
@@ -2,7 +2,7 @@
 """
 Setup script for Claude Banana MCP server in Claude Code.
 
-Configures @ycse/nanobanana-mcp in Claude Code's settings.json
+Configures @ycse/nanobanana-mcp in Claude Code's ~/.claude.json
 with the user's Google AI API key.
 
 Usage:
@@ -18,13 +18,13 @@ import sys
 import os
 from pathlib import Path
 
-SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+SETTINGS_PATH = Path.home() / ".claude.json"
 MCP_NAME = "nanobanana-mcp"
 MCP_PACKAGE = "@ycse/nanobanana-mcp@1.1.1"
 
 
 def load_settings() -> dict:
-    """Load Claude Code settings.json."""
+    """Load Claude Code ~/.claude.json."""
     if not SETTINGS_PATH.exists():
         return {}
     with open(SETTINGS_PATH, "r") as f:
@@ -32,7 +32,7 @@ def load_settings() -> dict:
 
 
 def save_settings(settings: dict) -> None:
-    """Save Claude Code settings.json."""
+    """Save Claude Code ~/.claude.json."""
     SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(SETTINGS_PATH, "w") as f:
         json.dump(settings, f, indent=2)

--- a/extensions/banana/scripts/validate_setup.py
+++ b/extensions/banana/scripts/validate_setup.py
@@ -3,7 +3,7 @@
 Validate that the Claude Banana MCP server is properly configured.
 
 Checks:
-1. Claude Code settings.json has the MCP entry
+1. Claude Code ~/.claude.json has the MCP entry
 2. API key is present
 3. Node.js/npx is available
 4. Output directory exists or can be created
@@ -18,7 +18,7 @@ import shutil
 import sys
 from pathlib import Path
 
-SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+SETTINGS_PATH = Path.home() / ".claude.json"
 MCP_NAME = "nanobanana-mcp"
 OUTPUT_DIR = Path.home() / "Documents" / "nanobanana_generated"
 
@@ -48,22 +48,22 @@ def main() -> int:
 
     # 1. Settings file exists
     results.append(check(
-        "Claude Code settings.json exists",
+        "Claude Code ~/.claude.json exists",
         SETTINGS_PATH.exists(),
         str(SETTINGS_PATH),
     ))
 
     if not SETTINGS_PATH.exists():
-        print("\nCannot continue without settings.json.")
+        print("\nCannot continue without ~/.claude.json.")
         return 1
 
     # 2. Load and parse settings
     try:
         with open(SETTINGS_PATH) as f:
             settings = json.load(f)
-        results.append(check("settings.json is valid JSON", True))
+        results.append(check("~/.claude.json is valid JSON", True))
     except json.JSONDecodeError as e:
-        results.append(check("settings.json is valid JSON", False, str(e)))
+        results.append(check("~/.claude.json is valid JSON", False, str(e)))
         return 1
 
     # 3. MCP entry exists

--- a/extensions/banana/uninstall.sh
+++ b/extensions/banana/uninstall.sh
@@ -11,15 +11,15 @@ main() {
     rm -f "${HOME}/.claude/agents/seo-image-gen.md"
 
     # Ask before removing MCP server (user may use standalone banana skill)
-    SETTINGS_FILE="${HOME}/.claude/settings.json"
-    if [ -f "${SETTINGS_FILE}" ]; then
+    MCP_CONFIG_FILE="${HOME}/.claude.json"
+    if [ -f "${MCP_CONFIG_FILE}" ]; then
         # Check if standalone banana skill still exists
         if [ -d "${HOME}/.claude/skills/banana" ]; then
             echo "  ℹ  Standalone banana skill detected at ~/.claude/skills/banana/"
-            echo "  ℹ  Keeping nanobanana-mcp in settings.json (used by standalone skill)"
+            echo "  ℹ  Keeping nanobanana-mcp in ~/.claude.json (used by standalone skill)"
         else
             # No standalone skill, safe to remove MCP
-            python3 - "${SETTINGS_FILE}" <<'PY' 2>/dev/null || echo "  ⚠  Could not auto-remove MCP config. Remove 'nanobanana-mcp' from ~/.claude/settings.json manually."
+            python3 - "${MCP_CONFIG_FILE}" <<'PY' 2>/dev/null || echo "  ⚠  Could not auto-remove MCP config. Remove 'nanobanana-mcp' from ~/.claude.json manually."
 import json, os, sys
 settings_path = sys.argv[1]
 with open(settings_path, 'r') as f:
@@ -30,9 +30,9 @@ if 'mcpServers' in settings and 'nanobanana-mcp' in settings['mcpServers']:
         del settings['mcpServers']
     with open(settings_path, 'w') as f:
         json.dump(settings, f, indent=2)
-    print('  ✓ Removed nanobanana-mcp from settings.json')
+    print('  ✓ Removed nanobanana-mcp from ~/.claude.json')
 else:
-    print('  ✓ No nanobanana-mcp entry in settings.json')
+    print('  ✓ No nanobanana-mcp entry in ~/.claude.json')
 PY
         fi
     fi

--- a/extensions/dataforseo/README.md
+++ b/extensions/dataforseo/README.md
@@ -29,7 +29,7 @@ cd claude-seo
 The installer will:
 1. Prompt for your DataForSEO username and password
 2. Install the skill and agent files
-3. Configure the MCP server in `~/.claude/settings.json`
+3. Configure the MCP server in `~/.claude.json`
 4. Pre-download the `dataforseo-mcp-server` npm package
 
 ## Commands
@@ -133,19 +133,19 @@ When installed, other Claude SEO skills automatically detect DataForSEO availabi
 
 ### MCP server not connecting
 
-1. Check credentials: `cat ~/.claude/settings.json | grep DATAFORSEO`
+1. Check credentials: `cat ~/.claude.json | grep DATAFORSEO`
 2. Test manually: `npx -y dataforseo-mcp-server`
 3. Re-run installer: `./extensions/dataforseo/install.sh`
 
 ### API errors
 
-- **401 Unauthorized**: Check username/password in settings.json
+- **401 Unauthorized**: Check username/password in ~/.claude.json
 - **402 Payment Required**: Add credits at [app.dataforseo.com](https://app.dataforseo.com)
 - **429 Rate Limited**: Wait and retry (DataForSEO has per-second limits)
 
 ### Module not available
 
-If a specific command fails, check that the module is in `ENABLED_MODULES` in your settings.json. All 9 modules should be listed.
+If a specific command fails, check that the module is in `ENABLED_MODULES` in your ~/.claude.json. All 9 modules should be listed.
 
 ## Uninstall
 
@@ -161,7 +161,7 @@ If a specific command fails, check that the module is in `ENABLED_MODULES` in yo
 .\extensions\dataforseo\uninstall.ps1
 ```
 
-This removes the skill, agent, field config, and MCP server entry from settings.json.
+This removes the skill, agent, field config, and MCP server entry from ~/.claude.json.
 
 ## Links
 

--- a/extensions/dataforseo/docs/DATAFORSEO-SETUP.md
+++ b/extensions/dataforseo/docs/DATAFORSEO-SETUP.md
@@ -42,7 +42,7 @@ DataForSEO uses a credit-based system:
 
 ## 4. Manual MCP Configuration
 
-If the installer's auto-configuration fails, add this to `~/.claude/settings.json`:
+If the installer's auto-configuration fails, add this to `~/.claude.json`:
 
 ```json
 {

--- a/extensions/dataforseo/install.ps1
+++ b/extensions/dataforseo/install.ps1
@@ -75,7 +75,10 @@ if (Test-Path "$ScriptDir\skills\seo-dataforseo\SKILL.md") {
 # Set paths
 $SkillDir = "$env:USERPROFILE\.claude\skills\seo-dataforseo"
 $AgentDir = "$env:USERPROFILE\.claude\agents"
-$SettingsFile = "$env:USERPROFILE\.claude\settings.json"
+# MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+# NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+# there, so entries written to settings.json silently never load.
+$McpConfigFile = "$env:USERPROFILE\.claude.json"
 $FieldConfigPath = "$SeoSkillDir\dataforseo-field-config.json"
 
 # Install skill
@@ -93,7 +96,7 @@ Copy-Item -Force "$SourceDir\agents\seo-dataforseo.md" "$AgentDir\seo-dataforseo
 Write-Host "→ Installing field config..." -ForegroundColor Yellow
 Copy-Item -Force "$SourceDir\field-config.json" $FieldConfigPath
 
-# Merge MCP config into settings.json
+# Merge MCP config into ~/.claude.json
 Write-Host "→ Configuring MCP server..." -ForegroundColor Yellow
 
 $python = Get-Command -Name python -ErrorAction SilentlyContinue
@@ -139,12 +142,12 @@ except Exception:
 print('  ok')
 "@
 
-    $result = $pyScript | & $pyExe - $SettingsFile $DfseUsername $DfsePassword $FieldConfigPath 2>&1
+    $result = $pyScript | & $pyExe - $McpConfigFile $DfseUsername $DfsePassword $FieldConfigPath 2>&1
     if ($LASTEXITCODE -eq 0) {
-        Write-Host "  ✓ MCP server configured in settings.json" -ForegroundColor Green
+        Write-Host "  ✓ MCP server configured in ~/.claude.json" -ForegroundColor Green
     } else {
         Write-Host "  ⚠  Could not auto-configure MCP server." -ForegroundColor Yellow
-        Write-Host "  Add the dataforseo server manually to ~\.claude\settings.json"
+        Write-Host "  Add the dataforseo server manually to ~\.claude.json"
     }
 } else {
     Write-Host "  ⚠  Python not found. Configure MCP server manually." -ForegroundColor Yellow

--- a/extensions/dataforseo/install.sh
+++ b/extensions/dataforseo/install.sh
@@ -8,7 +8,10 @@ main() {
     SKILL_DIR="${HOME}/.claude/skills/seo-dataforseo"
     AGENT_DIR="${HOME}/.claude/agents"
     SEO_SKILL_DIR="${HOME}/.claude/skills/seo"
-    SETTINGS_FILE="${HOME}/.claude/settings.json"
+    # MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+    # NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+    # there, so entries written to settings.json silently never load.
+    MCP_CONFIG_FILE="${HOME}/.claude.json"
 
     echo "════════════════════════════════════════"
     echo "║   DataForSEO Extension - Installer   ║"
@@ -105,13 +108,13 @@ main() {
     echo "→ Installing field config..."
     cp "${SOURCE_DIR}/field-config.json" "${SEO_SKILL_DIR}/dataforseo-field-config.json"
 
-    # Merge MCP config into settings.json
+    # Merge MCP config into ~/.claude.json
     echo "→ Configuring MCP server..."
     FIELD_CONFIG_PATH="${SEO_SKILL_DIR}/dataforseo-field-config.json"
 
     # Credentials are passed as argv (never interpolated into the source string)
     # and the settings file is written atomically with 0600 permissions.
-    python3 - "${SETTINGS_FILE}" "${DFSE_USERNAME}" "${DFSE_PASSWORD}" "${FIELD_CONFIG_PATH}" <<'PY'
+    python3 - "${MCP_CONFIG_FILE}" "${DFSE_USERNAME}" "${DFSE_PASSWORD}" "${FIELD_CONFIG_PATH}" <<'PY'
 import json, os, sys, tempfile
 
 settings_path, username, password, field_config = sys.argv[1:5]
@@ -148,11 +151,11 @@ except Exception:
         os.unlink(tmp)
     raise
 
-print('  ✓ MCP server configured in settings.json')
+print('  ✓ MCP server configured in ~/.claude.json')
 PY
     if [ $? -ne 0 ]; then
         echo "  ⚠  Could not auto-configure MCP server."
-        echo "  Add the dataforseo server manually to ~/.claude/settings.json"
+        echo "  Add the dataforseo server manually to ~/.claude.json"
         echo "  See: extensions/dataforseo/docs/DATAFORSEO-SETUP.md"
     fi
 

--- a/extensions/dataforseo/uninstall.ps1
+++ b/extensions/dataforseo/uninstall.ps1
@@ -21,8 +21,8 @@ if (Test-Path $fieldConfig) {
     Remove-Item -Force $fieldConfig
 }
 
-# Remove MCP server entry from settings.json
-$settingsFile = "$env:USERPROFILE\.claude\settings.json"
+# Remove MCP server entry from ~/.claude.json
+$settingsFile = "$env:USERPROFILE\.claude.json"
 if (Test-Path $settingsFile) {
     $python = Get-Command -Name python -ErrorAction SilentlyContinue
     if ($null -eq $python) {
@@ -46,12 +46,12 @@ if 'mcpServers' in settings and 'dataforseo' in settings['mcpServers']:
 "@
         $result = & $pyExe -c $pyScript 2>&1
         if ($LASTEXITCODE -eq 0) {
-            Write-Host "  ✓ Removed dataforseo from settings.json" -ForegroundColor Green
+            Write-Host "  ✓ Removed dataforseo from ~/.claude.json" -ForegroundColor Green
         } else {
-            Write-Host "  ⚠  Could not auto-remove MCP config. Remove 'dataforseo' from ~\.claude\settings.json manually." -ForegroundColor Yellow
+            Write-Host "  ⚠  Could not auto-remove MCP config. Remove 'dataforseo' from ~\.claude.json manually." -ForegroundColor Yellow
         }
     } else {
-        Write-Host "  ⚠  Python not found. Remove 'dataforseo' from ~\.claude\settings.json manually." -ForegroundColor Yellow
+        Write-Host "  ⚠  Python not found. Remove 'dataforseo' from ~\.claude.json manually." -ForegroundColor Yellow
     }
 }
 

--- a/extensions/dataforseo/uninstall.sh
+++ b/extensions/dataforseo/uninstall.sh
@@ -13,10 +13,10 @@ main() {
     # Remove field config
     rm -f "${HOME}/.claude/skills/seo/dataforseo-field-config.json"
 
-    # Remove MCP server entry from settings.json
-    SETTINGS_FILE="${HOME}/.claude/settings.json"
-    if [ -f "${SETTINGS_FILE}" ]; then
-        python3 - "${SETTINGS_FILE}" <<'PY' 2>/dev/null || echo "  ⚠  Could not auto-remove MCP config. Remove 'dataforseo' from ~/.claude/settings.json manually."
+    # Remove MCP server entry from ~/.claude.json
+    MCP_CONFIG_FILE="${HOME}/.claude.json"
+    if [ -f "${MCP_CONFIG_FILE}" ]; then
+        python3 - "${MCP_CONFIG_FILE}" <<'PY' 2>/dev/null || echo "  ⚠  Could not auto-remove MCP config. Remove 'dataforseo' from ~/.claude.json manually."
 import json, os, sys
 settings_path = sys.argv[1]
 with open(settings_path, 'r') as f:
@@ -27,9 +27,9 @@ if 'mcpServers' in settings and 'dataforseo' in settings['mcpServers']:
         del settings['mcpServers']
     with open(settings_path, 'w') as f:
         json.dump(settings, f, indent=2)
-    print('  ✓ Removed dataforseo from settings.json')
+    print('  ✓ Removed dataforseo from ~/.claude.json')
 else:
-    print('  ✓ No dataforseo entry in settings.json')
+    print('  ✓ No dataforseo entry in ~/.claude.json')
 PY
     fi
 

--- a/extensions/firecrawl/README.md
+++ b/extensions/firecrawl/README.md
@@ -56,7 +56,7 @@ When installed, other Claude SEO skills automatically leverage Firecrawl:
 ## Troubleshooting
 
 **MCP not connecting?**
-- Check: `cat ~/.claude/settings.json | python3 -m json.tool | grep firecrawl`
+- Check: `cat ~/.claude.json | python3 -m json.tool | grep firecrawl`
 - Manual config: See [FIRECRAWL-SETUP.md](docs/FIRECRAWL-SETUP.md)
 
 **Credits exhausted?**

--- a/extensions/firecrawl/docs/FIRECRAWL-SETUP.md
+++ b/extensions/firecrawl/docs/FIRECRAWL-SETUP.md
@@ -19,7 +19,7 @@ It will prompt for your API key and configure the MCP server.
 
 ## 3. Manual MCP Configuration
 
-If the installer fails, add this to `~/.claude/settings.json` manually:
+If the installer fails, add this to `~/.claude.json` manually:
 
 ```json
 {

--- a/extensions/firecrawl/install.ps1
+++ b/extensions/firecrawl/install.ps1
@@ -9,7 +9,10 @@ Write-Host ""
 
 $SkillDir = "$env:USERPROFILE\.claude\skills\seo-firecrawl"
 $SeoSkillDir = "$env:USERPROFILE\.claude\skills\seo"
-$SettingsFile = "$env:USERPROFILE\.claude\settings.json"
+# MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+# NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+# there, so entries written to settings.json silently never load.
+$McpConfigFile = "$env:USERPROFILE\.claude.json"
 
 # Check prerequisites
 if (-not (Test-Path $SeoSkillDir)) {
@@ -66,19 +69,19 @@ Copy-Item "$SourceDir\skills\seo-firecrawl\SKILL.md" "$SkillDir\SKILL.md" -Force
 
 # Configure MCP server
 Write-Host "=> Configuring MCP server..." -ForegroundColor Yellow
-$settingsContent = if (Test-Path $SettingsFile) { Get-Content $SettingsFile -Raw | ConvertFrom-Json } else { @{} }
+$settingsContent = if (Test-Path $McpConfigFile) { Get-Content $McpConfigFile -Raw | ConvertFrom-Json } else { @{} }
 if (-not $settingsContent.mcpServers) { $settingsContent | Add-Member -NotePropertyName mcpServers -NotePropertyValue @{} -Force }
 $settingsContent.mcpServers | Add-Member -NotePropertyName 'firecrawl-mcp' -NotePropertyValue @{
     command = 'npx'
     args = @('-y', 'firecrawl-mcp@3.11.0')
     env = @{ FIRECRAWL_API_KEY = $apiKeyPlain }
 } -Force
-$settingsContent | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
+$settingsContent | ConvertTo-Json -Depth 10 | Set-Content $McpConfigFile -Encoding UTF8
 # Restrict the credential-bearing settings file to the current user only.
 try {
-    icacls $SettingsFile /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null
+    icacls $McpConfigFile /inheritance:r /grant:r "${env:USERNAME}:F" | Out-Null
 } catch {
-    Write-Host "  Note: could not restrict settings.json ACL; review manually." -ForegroundColor Yellow
+    Write-Host "  Note: could not restrict ~/.claude.json ACL; review manually." -ForegroundColor Yellow
 }
 Write-Host "  v MCP server configured" -ForegroundColor Green
 

--- a/extensions/firecrawl/install.sh
+++ b/extensions/firecrawl/install.sh
@@ -8,7 +8,10 @@ main() {
     SKILL_DIR="${HOME}/.claude/skills/seo-firecrawl"
     AGENT_DIR="${HOME}/.claude/agents"
     SEO_SKILL_DIR="${HOME}/.claude/skills/seo"
-    SETTINGS_FILE="${HOME}/.claude/settings.json"
+    # MCP servers live in ~/.claude.json (the file `claude mcp add` writes).
+    # NOT ~/.claude/settings.json - `mcpServers` is not a key Claude Code reads
+    # there, so entries written to settings.json silently never load.
+    MCP_CONFIG_FILE="${HOME}/.claude.json"
 
     echo "════════════════════════════════════════"
     echo "║   Firecrawl Extension - Installer    ║"
@@ -78,12 +81,12 @@ main() {
     mkdir -p "${SKILL_DIR}"
     cp "${SOURCE_DIR}/skills/seo-firecrawl/SKILL.md" "${SKILL_DIR}/SKILL.md"
 
-    # Merge MCP config into settings.json
+    # Merge MCP config into ~/.claude.json
     echo "-> Configuring MCP server..."
 
     # Credentials are passed as argv (never interpolated into the source string)
     # and the settings file is written atomically with 0600 permissions.
-    python3 - "${SETTINGS_FILE}" "${FIRECRAWL_API_KEY}" <<'PY'
+    python3 - "${MCP_CONFIG_FILE}" "${FIRECRAWL_API_KEY}" <<'PY'
 import json, os, sys, tempfile
 
 settings_path, api_key = sys.argv[1:3]
@@ -117,11 +120,11 @@ except Exception:
         os.unlink(tmp)
     raise
 
-print('  v MCP server configured in settings.json')
+print('  v MCP server configured in ~/.claude.json')
 PY
     if [ $? -ne 0 ]; then
         echo "  Warning: Could not auto-configure MCP server."
-        echo "  Add the firecrawl-mcp server manually to ~/.claude/settings.json"
+        echo "  Add the firecrawl-mcp server manually to ~/.claude.json"
         echo "  See: extensions/firecrawl/docs/FIRECRAWL-SETUP.md"
     fi
 

--- a/extensions/firecrawl/uninstall.ps1
+++ b/extensions/firecrawl/uninstall.ps1
@@ -4,19 +4,19 @@ $ErrorActionPreference = 'Stop'
 Write-Host "Removing Firecrawl extension..." -ForegroundColor Yellow
 
 $SkillDir = "$env:USERPROFILE\.claude\skills\seo-firecrawl"
-$SettingsFile = "$env:USERPROFILE\.claude\settings.json"
+$McpConfigFile = "$env:USERPROFILE\.claude.json"
 
 if (Test-Path $SkillDir) {
     Remove-Item -Recurse -Force $SkillDir
     Write-Host "v Removed skill files" -ForegroundColor Green
 }
 
-if (Test-Path $SettingsFile) {
-    $settings = Get-Content $SettingsFile -Raw | ConvertFrom-Json
+if (Test-Path $McpConfigFile) {
+    $settings = Get-Content $McpConfigFile -Raw | ConvertFrom-Json
     if ($settings.mcpServers.'firecrawl-mcp') {
         $settings.mcpServers.PSObject.Properties.Remove('firecrawl-mcp')
-        $settings | ConvertTo-Json -Depth 10 | Set-Content $SettingsFile -Encoding UTF8
-        Write-Host "v Removed MCP server from settings.json" -ForegroundColor Green
+        $settings | ConvertTo-Json -Depth 10 | Set-Content $McpConfigFile -Encoding UTF8
+        Write-Host "v Removed MCP server from ~/.claude.json" -ForegroundColor Green
     }
 }
 

--- a/extensions/firecrawl/uninstall.sh
+++ b/extensions/firecrawl/uninstall.sh
@@ -7,10 +7,10 @@ echo "Removing Firecrawl extension..."
 rm -rf "${HOME}/.claude/skills/seo-firecrawl"
 echo "v Removed skill files"
 
-# Remove MCP entry from settings.json
-SETTINGS_FILE="${HOME}/.claude/settings.json"
-if [ -f "${SETTINGS_FILE}" ]; then
-    python3 - "${SETTINGS_FILE}" <<'PY' || echo "  Warning: Could not update settings.json automatically."
+# Remove MCP entry from ~/.claude.json
+MCP_CONFIG_FILE="${HOME}/.claude.json"
+if [ -f "${MCP_CONFIG_FILE}" ]; then
+    python3 - "${MCP_CONFIG_FILE}" <<'PY' || echo "  Warning: Could not update ~/.claude.json automatically."
 import json, os, sys
 
 settings_path = sys.argv[1]
@@ -21,9 +21,9 @@ if 'mcpServers' in settings and 'firecrawl-mcp' in settings['mcpServers']:
     del settings['mcpServers']['firecrawl-mcp']
     with open(settings_path, 'w') as f:
         json.dump(settings, f, indent=2)
-    print('v Removed MCP server from settings.json')
+    print('v Removed MCP server from ~/.claude.json')
 else:
-    print('  MCP server not found in settings.json (already removed)')
+    print('  MCP server not found in ~/.claude.json (already removed)')
 PY
 fi
 


### PR DESCRIPTION
## The bug

The `dataforseo`, `firecrawl`, `ahrefs` and `banana` installers merge their MCP server block into `~/.claude/settings.json`.

Claude Code does not read `mcpServers` from that file. The block is written, the installer prints its success message, and the server never loads — `claude mcp list` does not show it and no tools appear. Reinstalling cannot fix it, because the destination itself is wrong.

MCP servers belong in `~/.claude.json`, which is what `claude mcp add` writes.

## Why it goes unnoticed

Nothing errors. The JSON is valid, the key name looks right, the file is the one most people associate with Claude Code configuration, and the installer reports success. The failure only shows up later as "the extension installed but there are no tools", which reads like a plugin problem rather than a path problem.

## The change

Repoint those four extensions at `~/.claude.json` across install and uninstall scripts (`.sh` and `.ps1`), banana's Python helpers, and the setup docs.

The existing atomic read-modify-write is kept as-is, so unrelated keys in that file are preserved — this matters more than it did for `settings.json`, since `~/.claude.json` also holds project and session state.

Path variables are renamed (`SETTINGS_FILE` → `MCP_CONFIG_FILE`, and the PowerShell equivalents) so the name matches the file it points at, and each write site gets a short comment recording the distinction so it is not lost again.

## Deliberately not changed

`bing-webmaster`, `profound` and `seranking` also write to `settings.json`, but they write the **`env`** key, which *is* supported there. Moving those would break three working extensions. Only the four that write `mcpServers` are touched.

## Verification

Each installer and uninstaller was executed against a sandboxed `HOME` seeded with an unrelated MCP server and an unrelated top-level key:

| Extension | install | uninstall | servers after round trip | unrelated key | `settings.json` created |
|---|---|---|---|---|---|
| dataforseo | 0 | 0 | `pre-existing` only | preserved | no |
| firecrawl | 0 | 0 | `pre-existing` only | preserved | no |
| banana | 0 | 0 | `pre-existing` only | preserved | no |
| ahrefs | 0 | 0 | `pre-existing` only | preserved | no |

Each wrote only its own server on install, removed only its own on uninstall, and left everything else untouched.

Test suite: **410 passed** on `main` before the change and **410 passed** after.

Also fixed: `ahrefs/install.ps1` resolved the old path through `Join-Path` rather than a literal, so a pattern-based search misses it.

## Known limitation

The PowerShell scripts are checked for path and variable consistency, including a definition/use audit — PowerShell has no `set -u`, so an undefined variable would silently become `$null` rather than failing loudly. They were **not executed**; no PowerShell was available on the machine used. The `.sh` and `.py` paths are functionally tested as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
