### PR TITLE
fix(report): stop labelling unsevered top_findings as "Info" in the Critical Issues box

### DIFF
--- a/scripts/google_report.py
+++ b/scripts/google_report.py
@@ -1271,9 +1271,15 @@ def _build_executive_summary(domain, timestamp, data, report_type):
     # Critical issues box
     issues = []
     for item in _coerce_items(summary.get("top_findings")):
-        severity = _finding_severity(item)
         title = _finding_title(item)
-        issues.append(f'<strong>{escape(severity)}:</strong> {escape(title)}')
+        # Only label a severity when the finding actually carries one. Plain-string
+        # top_findings (the shape documented in seo-audit/SKILL.md) have no severity, and
+        # _finding_severity() falls back to "Info" -- which rendered every entry in the
+        # "Critical Issues Found" box as "Info:", understating the whole section.
+        if isinstance(item, dict) and item.get("severity"):
+            issues.append(f'<strong>{escape(str(item["severity"]))}:</strong> {escape(title)}')
+        else:
+            issues.append(escape(title))
 
     failed_audits = mobile.get("failed_audits", [])
     if failed_audits:


### PR DESCRIPTION
The **"Critical Issues Found"** box in generated PDF/HTML reports prefixes every entry with
`Info:` — including genuinely Critical findings.

## Cause

`_finding_severity()` returns `"Info"` for any non-dict item:

```python
def _finding_severity(item):
    if isinstance(item, dict):
        return str(item.get("severity", "Info"))
    return "Info"
```

`skills/seo-audit/SKILL.md` documents the envelope as:

```json
"summary": {
  "top_findings": [],
  "quick_wins": []
}
```

…a plain array, so the common case is a list of **strings** — every one of which picks up
the `"Info"` fallback.

The result is a client-facing audit report presenting its five most serious findings under a
red *"Critical Issues Found"* heading, with each line prefixed `Info:`. The severity label
adds no information (it is constant) and actively contradicts the section heading.

## Fix

Emit the severity prefix only when the finding is a dict that actually carries one;
otherwise render the title alone. Dict-shaped findings with explicit severities are
unaffected.

## Before / after

Real output from a full audit whose `top_findings` are strings:

**Before**
```
Critical Issues Found:
1. Info: Severe keyword cannibalization: 'medspa near me' splits 321 impressions…
2. Info: No Botox service page exists. All 16 /services/ pages cover other treatments…
3. Info: Hero landingPage.webm returns HTTP 404, forcing an 8.51 MB MP4 fallback…
```

**After**
```
Critical Issues Found:
1. Severe keyword cannibalization: 'medspa near me' splits 321 impressions…
2. No Botox service page exists. All 16 /services/ pages cover other treatments…
3. Hero landingPage.webm returns HTTP 404, forcing an 8.51 MB MP4 fallback…
```

## Scope

One file, `scripts/google_report.py`, +8/−2. No behaviour change for envelopes that already
pass dicts with severities.