### PR TITLE
Fix install.ps1 crash on Windows PowerShell 5.1 when python3/python have no args

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -64,7 +64,7 @@ function Invoke-External {
 function Test-PythonCandidate {
     param(
         [Parameter(Mandatory = $true)][string]$Exe,
-        [Parameter(Mandatory = $true)][string[]]$Args
+        [string[]]$Args = @()
     )
 
     $pythonCmd = Get-Command -Name $Exe -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- `Test-PythonCandidate`'s `Args` parameter was declared `Mandatory [string[]]`. Windows PowerShell 5.1 raises `ParameterArgumentValidationErrorEmptyArrayNotAllowed` when a mandatory array parameter is bound to an empty array.
- `Resolve-Python` calls this function with `Args = @()` for the `python3` and `python` candidates (only the `py -3` candidate passes a non-empty array), so `install.ps1` crashed immediately on any Windows 11 / PowerShell 5.1 machine where the `py` launcher isn'\''t installed, before it could even determine whether Python was present.
- Made `Args` optional with a default of `@()` instead of mandatory, which PowerShell accepts.

## Test plan
- [x] Reproduced the crash on a clean Windows 11 / PowerShell 5.1 machine with only the Microsoft Store `python`/`python3` app-execution aliases present (no `py` launcher, no real Python installed): `Test-PythonCandidate : Cannot bind argument to parameter '\''Args'\'' because it is an empty array.`
- [x] Installed real Python 3.12 via winget, applied the fix, and confirmed `install.ps1` runs to completion and installs the skill successfully.