### PR TITLE
Fix scripts/ path resolution and interpreter for direct skill/agent invocation

### DIFF
--- a/agents/seo-backlinks.md
+++ b/agents/seo-backlinks.md
@@ -6,6 +6,14 @@ maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a backlink profile analyst. When delegated tasks during an SEO audit:
 
 1. Check credentials: `claude-seo run backlinks_auth.py --check --json`

--- a/agents/seo-content.md
+++ b/agents/seo-content.md
@@ -6,6 +6,14 @@ maxTurns: 15
 tools: Read, Bash, Write, Grep
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a Content Quality specialist following Google's September 2025 Quality Rater Guidelines.
 
 When given content to analyze:

--- a/agents/seo-drift.md
+++ b/agents/seo-drift.md
@@ -9,6 +9,14 @@ maxTurns: 15
 tools: Read, Bash, Write, Glob, Grep
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 <!-- Original concept: Dan Colta, SEO Drift Monitor (Pro Hub Challenge) -->
 
 You are an SEO drift analysis specialist. You detect regressions in on-page SEO

--- a/agents/seo-ecommerce.md
+++ b/agents/seo-ecommerce.md
@@ -9,6 +9,14 @@ maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 <!-- Original concept: Matej Marjanovic -- E-commerce DataForSEO Expansion (Pro Hub Challenge) -->
 
 You are an e-commerce SEO analyst specializing in product pages, marketplace

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -6,6 +6,14 @@ maxTurns: 20
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a Generative Engine Optimization (GEO) specialist. When given a URL:
 
 1. Fetch the page and check robots.txt for AI crawler rules

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -6,6 +6,14 @@ maxTurns: 15
 tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 
 1. Check credentials: `claude-seo run google_auth.py --check --json`

--- a/agents/seo-local.md
+++ b/agents/seo-local.md
@@ -6,6 +6,14 @@ maxTurns: 20
 tools: Read, Bash, WebFetch, Glob, Grep, Write
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a Local SEO specialist. When given a URL:
 
 1. Fetch the page and detect business type (brick-and-mortar, SAB, or hybrid) from address visibility, service area language, and Maps embeds

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -6,6 +6,14 @@ maxTurns: 15
 tools: Read, Bash, Write
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a Web Performance specialist focused on Core Web Vitals.
 
 ## Current Metrics (as of 2026)

--- a/agents/seo-sxo.md
+++ b/agents/seo-sxo.md
@@ -9,6 +9,14 @@ maxTurns: 20
 tools: Read, Bash, WebFetch, WebSearch, Glob, Grep, Write
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 <!-- Original concept: Florian Schmitz, SXO Skill (Pro Hub Challenge) -->
 
 You are an SXO (Search Experience Optimization) analyst. Your job is to determine

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -6,6 +6,14 @@ maxTurns: 20
 tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 You are a Technical SEO specialist. When given a URL or set of URLs:
 
 1. Fetch the page(s) and analyze HTML source

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -10,6 +10,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # Full Website SEO Audit
 
 ## Process

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -11,6 +11,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # Backlink Profile Analysis
 
 ## Source Detection

--- a/skills/seo-dataforseo/SKILL.md
+++ b/skills/seo-dataforseo/SKILL.md
@@ -17,6 +17,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # DataForSEO: Live SEO Data (Extension)
 
 Live search data via the DataForSEO MCP server. Provides real-time SERP results

--- a/skills/seo-drift/SKILL.md
+++ b/skills/seo-drift/SKILL.md
@@ -16,6 +16,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # SEO Drift Monitor (April 2026)
 
 Git for your SEO. Capture baselines, detect regressions, track changes over time.

--- a/skills/seo-ecommerce/SKILL.md
+++ b/skills/seo-ecommerce/SKILL.md
@@ -18,6 +18,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # E-commerce SEO Analysis
 
 Comprehensive product page optimization, marketplace intelligence, and

--- a/skills/seo-flow/SKILL.md
+++ b/skills/seo-flow/SKILL.md
@@ -15,6 +15,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # FLOW Framework: Find · Leverage · Optimize · Win
 
 FLOW is an evidence-led SEO operating model built for the AI-search era. Claude SEO

--- a/skills/seo-google/SKILL.md
+++ b/skills/seo-google/SKILL.md
@@ -16,6 +16,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # Google SEO APIs
 
 Direct access to Google's own SEO data. Bridges the gap between crawl-based

--- a/skills/seo-image-gen/SKILL.md
+++ b/skills/seo-image-gen/SKILL.md
@@ -11,6 +11,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # SEO Image Gen: AI Image Generation for SEO Assets (Extension)
 
 Generate production-ready images for SEO use cases using Gemini's image generation

--- a/skills/seo-images/SKILL.md
+++ b/skills/seo-images/SKILL.md
@@ -16,6 +16,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # Image Optimization Analysis
 
 ## Checks

--- a/skills/seo-sxo/SKILL.md
+++ b/skills/seo-sxo/SKILL.md
@@ -17,6 +17,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # Search Experience Optimization (SXO)
 
 SXO bridges the gap between SEO (what Google rewards) and UX (what users need).

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -14,6 +14,14 @@ metadata:
   category: seo
 ---
 
+**Locating scripts:** every `scripts/*.py` path in this file is relative to the plugin's root directory, not this file's own folder — and needs the plugin's bundled virtualenv interpreter (system `python3` is missing dependencies like `requests`/`playwright`). Resolve both once, then reuse for every script call below:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
+```
+
 # Technical SEO Audit
 
 ## Categories


### PR DESCRIPTION
## Summary

Fixes #208.

21 files (11 `skills/*/SKILL.md`, 10 `agents/*.md`) reference `scripts/*.py` with a bare relative path and no indication of where it resolves from — only correct when the caller already has the plugin root as its working directory, which isn't the case when a skill or agent is invoked directly (e.g. via Claude Code's Task/Agent tool, or `/claude-seo:seo-audit` itself) rather than through the `/seo` router. Only 3 files mentioned "the plugin root" at all, and none said how to locate it.

Also fixes a second, compounding bug: system `python3` lacks dependencies the scripts need (e.g. `requests`, imported via `url_safety.py`) — the plugin ships its own `.venv` for exactly this reason, but nothing in the affected files said to use it.

## Fix

Inserts a short, self-locating snippet right after the YAML frontmatter in each of the 21 files:

```bash
PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 -type d -path '*/claude-seo/*/scripts' 2>/dev/null | grep -v '/extensions/' | head -1)")
PY="$PLUGIN_ROOT/.venv/bin/python3"
"$PY" "$PLUGIN_ROOT/scripts/<name>.py" ...
```

Two non-obvious things the resolution command specifically guards against (a naive version breaks on both, only visible once tested against a real install):

- It anchors to `~/.claude/plugins/cache` specifically — `~/.claude/plugins/marketplaces/<owner>-claude-seo/` also has a `scripts/` directory (the marketplace source checkout) but no `.venv`, so a broader search can non-deterministically resolve to the wrong copy.
- It excludes `extensions/*/scripts` (e.g. `extensions/banana/scripts`), which would otherwise also match.

## Test plan

- [x] Confirmed all 21 target files exist at these paths and matched the same broken pattern before the fix
- [x] Verified end-to-end against a real install: ran `render_page.py`, `pagespeed_check.py`, `google_auth.py`, and `backlinks_auth.py` through the exact resolution steps now written into the files — all four execute correctly
- [x] Confirmed the resolution command correctly ignores the marketplace-checkout and `extensions/` false-positive matches described above

## Note on scope

This applies the same fix pattern to every currently-affected file rather than introducing a new shared bootstrap mechanism (e.g. a single `scripts/_bootstrap.sh` sourced by each file), to keep the diff minimal and directly verifiable. Happy to follow up with that refactor separately if you'd prefer to consolidate it — flagged as an alternative in the linked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)