### PR TITLE
Allow auditing a local dev server behind CLAUDE_SEO_ALLOW_LOCAL

### DIFF
--- a/scripts/url_safety.py
+++ b/scripts/url_safety.py
@@ -73,6 +73,7 @@ in SECURITY.md.
 from __future__ import annotations
 
 import ipaddress
+import os
 import re
 import socket
 import threading
@@ -180,6 +181,45 @@ def _reject_authority_confusion(url: str, parsed) -> None:
         raise URLSafetyError("URL fragment/userinfo confusion refused")
 
 
+_LOCAL_HOSTNAMES: frozenset[str] = frozenset(
+    {"localhost", "ip6-localhost", "ip6-loopback"}
+)
+
+
+def _allow_local() -> bool:
+    """True when the operator opted into auditing loopback/private hosts.
+
+    Off unless CLAUDE_SEO_ALLOW_LOCAL=1, so the default policy is unchanged.
+    """
+    return os.environ.get("CLAUDE_SEO_ALLOW_LOCAL", "") == "1"
+
+
+def _blocked(hostname: str) -> bool:
+    """Blocklist check with the opt-in loopback carve-out applied.
+
+    Only the loopback names are ever forgiven, and only when the operator
+    opted in. Cloud metadata endpoints stay blocked either way: by name here,
+    and by address in is_safe_ip, which still rejects link-local (so
+    169.254.169.254 remains unreachable).
+    """
+    if hostname not in _BLOCKED_HOSTNAMES:
+        return False
+    return not (_allow_local() and hostname in _LOCAL_HOSTNAMES)
+
+
+def _is_local_dev_ip(ip) -> bool:
+    """Loopback / RFC1918 only - never link-local.
+
+    Python's ipaddress module reports 169.254.0.0/16 as *private*, so a
+    naive "is_loopback or is_private" carve-out would hand back the cloud
+    metadata address 169.254.169.254. Link-local, reserved, multicast and
+    unspecified are therefore excluded explicitly.
+    """
+    if ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified:
+        return False
+    return bool(ip.is_loopback or ip.is_private)
+
+
 def is_safe_ip(ip_str: str) -> bool:
     """Return True iff ``ip_str`` is a public unicast address.
 
@@ -192,6 +232,8 @@ def is_safe_ip(ip_str: str) -> bool:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
         return False
+    if _allow_local() and _is_local_dev_ip(ip):
+        return True
     return not (
         ip.is_private
         or ip.is_loopback
@@ -274,7 +316,7 @@ def validate_url(url: str) -> bool:
         hostname = normalize_hostname(parsed.hostname)
     except URLSafetyError:
         return False
-    if hostname in _BLOCKED_HOSTNAMES:
+    if _blocked(hostname):
         return False
     try:
         ipaddress.ip_address(hostname)
@@ -305,7 +347,7 @@ def validate_url_strict(url: str) -> tuple[str, str]:
         raise URLSafetyError("URL has no hostname")
 
     hostname = normalize_hostname(parsed.hostname)
-    if hostname in _BLOCKED_HOSTNAMES:
+    if _blocked(hostname):
         raise URLSafetyError(f"Blocked hostname: {hostname}")
 
     # If the hostname is an IP literal, validate it directly without DNS.
@@ -533,7 +575,7 @@ def make_safe_playwright_route_handler(
 
             # Hostname-level blocks short-circuit DNS resolution entirely
             # (e.g. attacker.example/redirect -> metadata.google.internal).
-            if normalized in _BLOCKED_HOSTNAMES:
+            if _blocked(normalized):
                 route.abort()
                 return
 

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -595,3 +595,55 @@ def test_load_oauth_token_remediates_legacy_0o644(tmp_path, monkeypatch) -> None
     data = google_auth._load_oauth_token()
     assert data == {"access_token": "x"}
     assert target.stat().st_mode & 0o777 == 0o600
+
+
+# ---------------------------------------------------------------------------
+# CLAUDE_SEO_ALLOW_LOCAL opt-in (auditing a local dev server)
+# ---------------------------------------------------------------------------
+
+
+def test_localhost_blocked_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("CLAUDE_SEO_ALLOW_LOCAL", raising=False)
+    assert url_safety.validate_url("http://localhost:5000/nl") is False
+    with pytest.raises(url_safety.URLSafetyError, match="Blocked hostname"):
+        url_safety.validate_url_strict("http://localhost:5000/nl")
+
+
+def test_localhost_allowed_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_SEO_ALLOW_LOCAL", "1")
+    assert url_safety.validate_url("http://localhost:5000/nl") is True
+    # Strict form resolves DNS; loopback must survive the resolved-IP check too.
+    validated, pinned = url_safety.validate_url_strict("http://localhost:5000/nl")
+    assert validated == "http://localhost:5000/nl"
+    assert pinned.startswith("127.")
+
+
+def test_private_and_loopback_literals_allowed_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_SEO_ALLOW_LOCAL", "1")
+    assert url_safety.is_safe_ip("127.0.0.1") is True
+    assert url_safety.is_safe_ip("192.168.1.10") is True
+
+
+def test_opt_in_does_not_unblock_cloud_metadata_names(monkeypatch) -> None:
+    """The carve-out is loopback-only — metadata endpoints stay blocked."""
+    monkeypatch.setenv("CLAUDE_SEO_ALLOW_LOCAL", "1")
+    for hostname in ("metadata.google.internal", "metadata.goog", "metadata.azure.com"):
+        assert url_safety.validate_url(f"http://{hostname}/") is False
+        with pytest.raises(url_safety.URLSafetyError, match="Blocked hostname"):
+            url_safety.validate_url_strict(f"http://{hostname}/")
+
+
+def test_opt_in_does_not_unblock_link_local_metadata_ip(monkeypatch) -> None:
+    """169.254.169.254 is link-local, which the carve-out never forgives."""
+    monkeypatch.setenv("CLAUDE_SEO_ALLOW_LOCAL", "1")
+    assert url_safety.is_safe_ip("169.254.169.254") is False
+    assert url_safety.validate_url("http://169.254.169.254/latest/meta-data/") is False
+    with pytest.raises(url_safety.URLSafetyError):
+        url_safety.validate_url_strict("http://169.254.169.254/latest/meta-data/")
+
+
+def test_only_the_literal_value_1_opts_in(monkeypatch) -> None:
+    for value in ("", "0", "true", "yes", "TRUE"):
+        monkeypatch.setenv("CLAUDE_SEO_ALLOW_LOCAL", value)
+        assert url_safety.is_safe_ip("127.0.0.1") is False
+        assert url_safety.validate_url("http://localhost:5000/") is False


### PR DESCRIPTION
## Problem

`url_safety` refuses loopback and private addresses unconditionally — no CLI flag, no environment override. The module reads no environment at all today.

That default is correct for a fetcher that follows URLs discovered on crawled pages. But it also means the SEO skills cannot audit a site **before it is deployed**:

```
$ claude-seo run fetch_page.py http://localhost:3000
Error: url_safety: Blocked hostname: localhost
```

For anyone running the skills against a site in development, that is the main workflow — and there is currently no supported way to say "I know, this host is mine". Hosts-file aliasing does not help either, since `validate_url_strict` resolves every A record and rejects the resulting loopback IP.

## Change

An opt-in escape hatch, off unless `CLAUDE_SEO_ALLOW_LOCAL=1`:

- **`_blocked(hostname)`** replaces the three direct `_BLOCKED_HOSTNAMES` membership tests. It forgives only the three loopback names (`localhost`, `ip6-localhost`, `ip6-loopback`), and only when opted in, so cloud metadata hostnames stay blocked in every configuration.
- **`_is_local_dev_ip(ip)`** gates the address check: loopback and RFC1918 only.

The second one is worth a note. `ipaddress` reports `169.254.0.0/16` as **private**, so the obvious `is_loopback or is_private` carve-out silently hands back `169.254.169.254`. Link-local, reserved, multicast and unspecified are therefore excluded explicitly. The test for this caught that exact bug in my first draft, which is why it is in the suite.

Only the literal string `"1"` opts in — `"true"`, `"yes"` and `"0"` do not.

## Default behaviour is unchanged

With the variable unset, every existing code path evaluates exactly as before: `_blocked()` reduces to the old membership test and `_is_local_dev_ip()` is never reached.

## Tests

Six new cases in `tests/test_url_safety.py`:

| Test | Asserts |
|---|---|
| `test_localhost_blocked_by_default` | unset env still blocks, both validators |
| `test_localhost_allowed_when_opted_in` | opted-in path works through `validate_url` **and** `validate_url_strict`, including the resolved-IP pin |
| `test_private_and_loopback_literals_allowed_when_opted_in` | `127.0.0.1`, `192.168.1.10` |
| `test_opt_in_does_not_unblock_cloud_metadata_names` | three metadata hostnames stay blocked while opted in |
| `test_opt_in_does_not_unblock_link_local_metadata_ip` | `169.254.169.254` stays blocked by name and by address |
| `test_only_the_literal_value_1_opts_in` | `""`, `"0"`, `"true"`, `"yes"`, `"TRUE"` do not opt in |

Run on Windows / Python 3.13: **96 passed, 3 failed**. The three failures are the pre-existing `test_{save,load}_oauth_token_*` POSIX-permission cases, which fail identically on a clean checkout of `main` (baseline there: 90 passed, 3 failed).

## Notes

Happy to adjust the variable name, restrict the carve-out to `validate_url_strict` only, or add a line to the docs if you would like this documented alongside `CLAUDE_SEO_PYTHON`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
