### PR TITLE
fix(schema): avoid replacement placeholder false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ patches excluded. No breaking command changes. Full suite: 410 passing tests.
 
 ### Fixed
 
+- Schema validation no longer treats words such as "replacement" as unresolved `REPLACE`
+  placeholders, while standalone placeholder tokens remain blocked.
 - GSC queries now honor exact result limits, validate dimensions before API access, support
   dimensionless totals, and report whether aggregate totals are complete.
 - Bing Webmaster backlink commands now use supported endpoints, bounded pagination, deduplication,

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -36,6 +36,8 @@ import re
 import sys
 from typing import List
 
+BARE_PLACEHOLDER = "REPLACE"
+
 
 def validate_jsonld(content: str) -> List[str]:
     """Validate JSON-LD blocks in HTML content."""
@@ -87,7 +89,6 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
         "[Address]",
         "[Your",
         "[INSERT",
-        "REPLACE",
         "[URL]",
         "[Email]",
     ]
@@ -95,6 +96,8 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
     for p in placeholders:
         if p.lower() in text.lower():
             errors.append(f"{prefix}: Contains placeholder text: {p}")
+    if re.search(rf"\b{re.escape(BARE_PLACEHOLDER)}\b", text, re.IGNORECASE):
+        errors.append(f"{prefix}: Contains placeholder text: {BARE_PLACEHOLDER}")
 
     # Check for deprecated types
     schema_type = obj.get("@type", "")

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -37,6 +37,9 @@ import sys
 from typing import List
 
 BARE_PLACEHOLDER = "REPLACE"
+BARE_PLACEHOLDER_PATTERN = re.compile(
+    rf"\b{re.escape(BARE_PLACEHOLDER)}(?:_[A-Z]+)*\b"
+)
 
 
 def validate_jsonld(content: str) -> List[str]:
@@ -96,7 +99,7 @@ def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
     for p in placeholders:
         if p.lower() in text.lower():
             errors.append(f"{prefix}: Contains placeholder text: {p}")
-    if re.search(rf"\b{re.escape(BARE_PLACEHOLDER)}\b", text, re.IGNORECASE):
+    if BARE_PLACEHOLDER_PATTERN.search(text):
         errors.append(f"{prefix}: Contains placeholder text: {BARE_PLACEHOLDER}")
 
     # Check for deprecated types

--- a/tests/test_schema_hook_policy.py
+++ b/tests/test_schema_hook_policy.py
@@ -40,3 +40,11 @@ def test_replacement_text_is_not_treated_as_placeholder(tmp_path):
 
 def test_standalone_replace_still_blocks(tmp_path):
     assert _run(tmp_path, "Product", ',"description":"REPLACE"') == 2
+
+
+def test_replace_verb_is_not_treated_as_placeholder(tmp_path):
+    assert _run(tmp_path, "Product", ',"description":"Replace the cartridge every 6 months"') == 0
+
+
+def test_underscore_replace_placeholder_still_blocks(tmp_path):
+    assert _run(tmp_path, "Product", ',"description":"REPLACE_WITH_URL"') == 2

--- a/tests/test_schema_hook_policy.py
+++ b/tests/test_schema_hook_policy.py
@@ -32,3 +32,11 @@ def test_faqpage_not_blocked(tmp_path):
 
 def test_deprecated_type_still_blocks(tmp_path):
     assert _run(tmp_path, "ClaimReview") == 2
+
+
+def test_replacement_text_is_not_treated_as_placeholder(tmp_path):
+    assert _run(tmp_path, "Product", ',"description":"Replacement coils"') == 0
+
+
+def test_standalone_replace_still_blocks(tmp_path):
+    assert _run(tmp_path, "Product", ',"description":"REPLACE"') == 2


### PR DESCRIPTION
## Summary

Prevent the schema validation hook from blocking legitimate JSON-LD text such as
"Replacement coils" or "Replace the cartridge every 6 months". Genuine uppercase
placeholder tokens remain blocking, including underscore forms such as `REPLACE_ME`
and `REPLACE_WITH_URL`.

Fixes #205.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Test verification (RED -> GREEN)

Prior PR implementation, regression tests only:

```text
FAILED test_replace_verb_is_not_treated_as_placeholder: expected 0, got 2
FAILED test_underscore_replace_placeholder_still_blocks: expected 2, got 0
2 failed, 4 passed
```

Patched branch:

```text
Focused policy suite: 6 passed
Full local CI: 414 passed
Upstream baseline local CI: 410 passed
Changed executable production lines: 100% covered
```

## Checklist

- [ ] Tested with a real URL before submitting (not applicable: local hook validation)
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change
