### PR TITLE
fix(schema): validate top-level graph members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ patches excluded. No breaking command changes. Full suite: 410 passing tests.
 
 ### Fixed
 
+- Schema validation now accepts top-level `@graph` containers and validates their member nodes.
 - GSC queries now honor exact result limits, validate dimensions before API access, support
   dimensionless totals, and report whether aggregate totals are complete.
 - Bing Webmaster backlink commands now use supported endpoints, bounded pagination, deduplication,

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -36,6 +36,8 @@ import re
 import sys
 from typing import List
 
+GRAPH_KEY = "@graph"
+
 
 def validate_jsonld(content: str) -> List[str]:
     """Validate JSON-LD blocks in HTML content."""
@@ -58,21 +60,36 @@ def validate_jsonld(content: str) -> List[str]:
             for item in data:
                 errors.extend(_validate_schema_object(item, i))
         elif isinstance(data, dict):
-            errors.extend(_validate_schema_object(data, i))
+            graph = data.get(GRAPH_KEY)
+            if isinstance(graph, list):
+                errors.extend(_validate_schema_context(data, i))
+                for item in graph:
+                    errors.extend(_validate_schema_object(item, i, require_context=False))
+            else:
+                errors.extend(_validate_schema_object(data, i))
 
     return errors
 
 
-def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
+def _validate_schema_context(obj: dict, block_num: int) -> List[str]:
+    """Validate the context declared by a schema document."""
+    prefix = f"Block {block_num}"
+    if "@context" not in obj:
+        return [f"{prefix}: Missing @context"]
+    if obj["@context"] not in ("https://schema.org", "http://schema.org"):
+        return [f"{prefix}: @context should be 'https://schema.org'"]
+    return []
+
+
+def _validate_schema_object(
+    obj: dict, block_num: int, require_context: bool = True
+) -> List[str]:
     """Validate a single schema object."""
     errors = []
     prefix = f"Block {block_num}"
 
-    # Check @context
-    if "@context" not in obj:
-        errors.append(f"{prefix}: Missing @context")
-    elif obj["@context"] not in ("https://schema.org", "http://schema.org"):
-        errors.append(f"{prefix}: @context should be 'https://schema.org'")
+    if require_context:
+        errors.extend(_validate_schema_context(obj, block_num))
 
     # Check @type
     if "@type" not in obj:

--- a/tests/test_schema_hook_policy.py
+++ b/tests/test_schema_hook_policy.py
@@ -7,12 +7,18 @@ confirmed. Genuinely deprecated types must still block the edit (exit 2).
 
 from __future__ import annotations
 
+import runpy
 import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HOOK = ROOT / "hooks" / "validate-schema.py"
+VALIDATE_JSONLD = runpy.run_path(str(HOOK))["validate_jsonld"]
+
+
+def _html(schema: str) -> str:
+    return f'<script type="application/ld+json">{schema}</script>'
 
 
 def _run(tmp_path: Path, schema_type: str, extra: str = "") -> int:
@@ -32,3 +38,34 @@ def test_faqpage_not_blocked(tmp_path):
 
 def test_deprecated_type_still_blocks(tmp_path):
     assert _run(tmp_path, "ClaimReview") == 2
+
+
+def test_graph_container_and_members_are_validated_in_context():
+    assert VALIDATE_JSONLD(
+        _html(
+            '{"@context":"https://schema.org","@graph":['
+            '{"@type":"MedicalBusiness","name":"Clinic"},'
+            '{"@type":"Physician","name":"Doctor"}'
+            "]}"
+        )
+    ) == []
+
+
+def test_graph_members_are_checked():
+    assert VALIDATE_JSONLD(
+        _html('{"@context":"https://schema.org","@graph":[{"@type":"ClaimReview"}]}')
+    ) == [
+        "Block 1: @type 'ClaimReview' is retired June 2025; fact-check rich results discontinued"
+    ]
+
+
+def test_non_graph_context_validation_is_preserved():
+    assert VALIDATE_JSONLD(_html('{"@type":"Organization"}')) == [
+        "Block 1: Missing @context"
+    ]
+    assert VALIDATE_JSONLD(
+        _html('{"@context":"https://example.com","@type":"Organization"}')
+    ) == ["Block 1: @context should be 'https://schema.org'"]
+    assert VALIDATE_JSONLD(
+        _html('{"@context":"https://schema.org","@type":"Organization"}')
+    ) == []


### PR DESCRIPTION
## Summary

Fixes #187.

Top-level JSON-LD graph containers no longer receive a false `Missing type` warning. The hook validates the container context once, then validates each graph member while allowing it to inherit that context.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other

## RED / GREEN

Upstream `origin/main` with only the regression tests:

```text
FAILED tests/test_schema_hook_policy.py::test_graph_container_and_members_are_validated_in_context
FAILED tests/test_schema_hook_policy.py::test_graph_members_are_checked
2 failed, 3 passed
```

Patched branch:

```text
tests/test_schema_hook_policy.py: 5 passed
Full local CI: 413 passed in 42.89s
Baseline local CI: 410 passed in 43.26s
Changed executable coverage: 18/18 lines
```

## Checklist

- [x] Focused JSON-LD fixtures exercise the affected validation path
- [x] Python syntax check and full test suite pass
- [x] Secret scan passes
- [x] CHANGELOG.md updated
- [x] No dependency changes
