### PR TITLE
fix(agent-ux): don't emit a passing score for empty fetched documents (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ patches excluded. No breaking command changes. Full suite: 410 passing tests.
 
 ### Fixed
 
+- `agent_ux_check.py` no longer emits a passing agent-UX score when the fetched
+  document is empty or whitespace-only; the empty fetch is now surfaced as a
+  render error instead of being rewarded ~90/100.
 - GSC queries now honor exact result limits, validate dimensions before API access, support
   dimensionless totals, and report whether aggregate totals are complete.
 - Bing Webmaster backlink commands now use supported endpoints, bounded pagination, deduplication,

--- a/tests/test_phase_j_executable.py
+++ b/tests/test_phase_j_executable.py
@@ -313,6 +313,47 @@ def test_score_deducts_for_div_onclick_and_unnamed_interactives():
     assert any("accessible name" in issue for issue in scored["issues"])
 
 
+def _fake_page(content, *, error=None, a11y=None):
+    """Minimal render_page() result stub for audit() tests."""
+    return {
+        "url": "https://example.test/",
+        "status_code": 200,
+        "error": error,
+        "content": content,
+        "accessibility_tree": a11y,
+    }
+
+
+def test_audit_refuses_score_on_empty_html(monkeypatch):
+    # A successful fetch that returns an empty document must NOT be scored:
+    # every regex count collapses to 0, which score() would otherwise misread
+    # as a clean page and reward ~90/100 (issue #210, Bug 1).
+    monkeypatch.setattr(agent_ux_check, "render_page",
+                        lambda *a, **k: _fake_page(""))
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["score"] is None
+    assert report["render_error"]
+
+
+def test_audit_refuses_score_on_whitespace_only_html(monkeypatch):
+    monkeypatch.setattr(agent_ux_check, "render_page",
+                        lambda *a, **k: _fake_page("   \n\t  "))
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["score"] is None
+    assert report["render_error"]
+
+
+def test_audit_scores_real_html(monkeypatch):
+    # A genuine document with content is still scored normally — the empty
+    # guard must not swallow real pages.
+    html = "<html><body><nav><a href='/'>home</a></nav><main>hi</main></body></html>"
+    monkeypatch.setattr(agent_ux_check, "render_page",
+                        lambda *a, **k: _fake_page(html))
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["render_error"] is None
+    assert report["score"] is not None
+
+
 # ---------------------------------------------------------------------------
 # render_page extension
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes Bug 1 of #210: `scripts/agent_ux_check.py` emitted a **passing ~90/100
agent-UX score for pages it never actually read**.

When `render_page()` succeeds but returns an empty (or whitespace-only) document
— e.g. an edge cache serving a blank body — every regex count in `analyze_html`
collapses to `0`. `score()` only deducts on *non-zero-and-bad* signals, so all
zeros read as "clean page" and the silent fetch failure is rewarded with 90/100.

The fix treats an empty/whitespace-only document as a hard render error: `audit()`
sets `render_error` and returns with `score = None`, so no numeric score is
emitted for a document that was never read. The `--json` and text CLI paths
already exit non-zero when `score is None`, so both now correctly signal failure.

Scope is deliberately limited to Bug 1 (the dangerous one). Bug 2 of #210
(accessibility tree never captured) is a separate `render_page`/Playwright
integration defect that needs real-browser verification, so this PR does not
close #210.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test verification (RED → GREEN)

New tests in `tests/test_phase_j_executable.py` monkeypatch `render_page` (no
network) to return an empty document and assert `audit()` refuses to score it.

**RED** — new tests on the unmodified code (fix reverted):

```
>       assert report["score"] is None
E       assert 90 is None
tests/test_phase_j_executable.py:334: AssertionError
FAILED ...::test_audit_refuses_score_on_empty_html
FAILED ...::test_audit_refuses_score_on_whitespace_only_html
2 failed, 1 passed
```

The `assert 90 is None` failure reproduces the issue's exact symptom.

**GREEN** — same tests with the fix applied:

```
3 passed, 22 deselected in 0.89s
```

**Full suite** (`pytest tests/`, mirrors CI): baseline `410 passed` on `main`,
`413 passed` with this change (410 + 3 new), 0 failures — iso-or-better, no
regressions.

## Checklist

- [x] New/updated tests fail without the fix and pass with it
- [x] Full test suite passes locally (413 passed)
- [x] Python syntax check passes (`py_compile scripts/*.py`)
- [x] CHANGELOG.md updated under `## [2.2.4]` → `### Fixed`
- [x] No new dependencies; no hardcoded values (empty-doc message is a named constant)
