### PR TITLE
Fix three silent-failure bugs (#210, #186, #208), add a Python syntax gate, and triage all open PRs/issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,34 @@ jobs:
             exit 1
           fi
           echo "Secret scan clean: no credentials detected in tracked files."
+
+  compile-check:
+    name: Python syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - name: Compile every tracked Python file
+        # Cheapest possible guard against a tracked .py file that does not
+        # parse. pytest does not cover this: an unparseable module surfaces as a
+        # collection error for its own test file, and a script with no test
+        # never gets imported at all. Deliberately dependency-free -- syntax is
+        # checked without installing requirements.txt, so this stays fast and
+        # cannot fail for environment reasons.
+        run: |
+          set -uo pipefail
+          BROKEN=""
+          while IFS= read -r f; do
+            python -m py_compile "$f" 2>/dev/null || BROKEN="${BROKEN}${f}"$'\n'
+          done < <(git ls-files '*.py')
+          if [ -n "$BROKEN" ]; then
+            echo "::error::Tracked Python files that do not parse:"
+            echo "$BROKEN"
+            exit 1
+          fi
+          echo "Syntax check clean: every tracked .py file parses."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whitespace-only document. A successful fetch that returned no HTML previously
   scored 90/100, because every signal it counts collapses to zero on an empty
   document; it is now reported as a render error (#210).
+- `render_page.py --json` no longer truncates `extracted_text`. That field is
+  trafilatura's boilerplate-stripped text and the agent instructions point every
+  scoring path at it (E-E-A-T, thin content, word count, citability), but it was
+  capped at 500 characters — a 2000-word page arrived as 73 words, a 27x
+  undercount, so every real page looked thin. Raw HTML fields stay capped so the
+  CLI is still usable over stdio, and a new `truncation` map in the payload
+  records which fields were cut, so a short page is distinguishable from a cut
+  one. `--max-text` caps `extracted_text` on request (#246).
+- `render_page.py --output` now composes with `--json`. The JSON branch exited
+  before the output block ran, so `--json --output` silently wrote nothing —
+  which also broke the documented "use `--output` when you need the full
+  document" escape hatch (#250).
 - `agent_ux_check.py` no longer presents a confident score when the accessibility
   tree could not be captured. The snapshot is best-effort in `render_page.py` and
   failures are swallowed, after which `score()` skips every accessibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI now compile-checks every tracked Python file. An unparseable module
+  previously reached review unnoticed: pytest surfaces it only as a collection
+  error for that module's own test file, and a script with no test is never
+  imported at all.
+
+### Changed
+
+- Skill and agent instructions that tell an agent to run a bundled script now
+  show the `claude-seo run <script>.py` form rather than a bare `scripts/*.py`
+  path, so the wrapper resolves the plugin root and interpreter. Descriptive
+  references that explain internals are unchanged (#208).
+
 ### Fixed
 
 - `agent_ux_check.py` no longer emits a passing agent-UX score for an empty or
   whitespace-only document. A successful fetch that returned no HTML previously
   scored 90/100, because every signal it counts collapses to zero on an empty
   document; it is now reported as a render error (#210).
+- `agent_ux_check.py` no longer presents a confident score when the accessibility
+  tree could not be captured. The snapshot is best-effort in `render_page.py` and
+  failures are swallowed, after which `score()` skips every accessibility
+  deduction: the same page scores 75 with a tree and 100 without one. The report
+  now carries `partial: true` and an explicit issue instead (#210).
 - `validate-schema.py` no longer crashes on a non-UTF-8 console. Encoding the
   banner markers to cp1252 raised `UnicodeEncodeError` before `sys.exit(2)` ran,
   so the hook exited 1 — warnings-only — and a blocking schema finding was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `agent_ux_check.py` no longer emits a passing agent-UX score for an empty or
+  whitespace-only document. A successful fetch that returned no HTML previously
+  scored 90/100, because every signal it counts collapses to zero on an empty
+  document; it is now reported as a render error (#210).
+- `validate-schema.py` no longer crashes on a non-UTF-8 console. Encoding the
+  banner markers to cp1252 raised `UnicodeEncodeError` before `sys.exit(2)` ran,
+  so the hook exited 1 — warnings-only — and a blocking schema finding was
+  silently non-blocking on Windows. The quality gate failed open; it now fails
+  closed with the finding intact (#186).
+
 ## [2.2.4] - 2026-07-20
 
 Community maintenance release following a full review of every open issue and pull request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whitespace-only document. A successful fetch that returned no HTML previously
   scored 90/100, because every signal it counts collapses to zero on an empty
   document; it is now reported as a render error (#210).
+- `commoncrawl_graph.py` no longer writes outside its cache directory. The
+  `--release` value was interpolated raw into the cache filename, so
+  `--release ../../../../tmp/x` escaped the cache dir and `_save_cache`'s
+  `open(..., "w")` followed it. The value also reaches a download URL, so a
+  malformed release is now rejected at the CLI rather than silently rewritten
+  (which would leave the cache key disagreeing with what was fetched); path
+  components are sanitised and containment asserted as defence in depth.
+- `domain_history.py` no longer follows an unvalidated WHOIS referral. It asks
+  IANA for the authoritative server and dialled whatever host came back, over
+  plaintext port 43 -- so anyone able to tamper with that response could point
+  it at an internal address and use it to probe the operator's private network.
+  The referral is now resolved and validated through `url_safety` and the
+  connection is made to the pinned address; an unusable referral degrades to
+  IANA's own answer rather than blanking the lookup.
 - `render_page.py --json` no longer truncates `extracted_text`. That field is
   trafilatura's boilerplate-stripped text and the agent instructions point every
   scoring path at it (E-E-A-T, thin content, word count, citability), but it was

--- a/agents/seo-ecommerce.md
+++ b/agents/seo-ecommerce.md
@@ -18,10 +18,10 @@ When delegated tasks during an SEO audit or analysis:
 
 1. Detect e-commerce signals: product schema, price elements, add-to-cart buttons,
    shopping cart, product grids, Shopify/WooCommerce/Magento markers
-2. Analyze product pages using `scripts/render_page.py --mode auto` and `scripts/parse_html.py`
+2. Analyze product pages using `claude-seo run render_page.py --mode auto` and `claude-seo run parse_html.py`
 3. Validate Product schema against Google's required and recommended fields
 4. If DataForSEO credentials available, fetch marketplace data via
-   `scripts/dataforseo_merchant.py`
+   `claude-seo run dataforseo_merchant.py`
 
 ## Cost Guardrails
 

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -68,7 +68,7 @@ Before presenting: verify `"review": {"status": "PASS"}` in the JSON output.
 If `output_dir` is provided by the audit orchestrator, write:
 - `output_dir/findings/google.md`: PSI, CrUX, GSC, URL Inspection, GA4, and credential-tier findings
 - Structured JSON-compatible findings for `audit-data.json` under the Google SEO Data category
-- Generated PDF/HTML/XLSX reports under `output_dir/` by passing `--output-dir "$output_dir"` to `scripts/google_report.py`
+- Generated PDF/HTML/XLSX reports under `output_dir/` by passing `--output-dir "$output_dir"` to `claude-seo run google_report.py`
 
 ## Error Handling
 

--- a/agents/seo-sxo.md
+++ b/agents/seo-sxo.md
@@ -85,7 +85,7 @@ Score the target page across 7 dimensions (100 points total):
 ## Pre-Delivery Checklist
 
 Before presenting results, verify:
-- [ ] URL was fetched via scripts/render_page.py --mode auto (not raw curl)
+- [ ] URL was fetched via `claude-seo run render_page.py --mode auto` (not raw curl)
 - [ ] At least 5 SERP results were analyzed
 - [ ] Page type classification uses the taxonomy reference
 - [ ] User stories cite specific SERP signals

--- a/agents/seo-visual.md
+++ b/agents/seo-visual.md
@@ -26,7 +26,7 @@ pip install playwright && playwright install chromium
 
 ## Screenshot Script
 
-Use the screenshot script (`scripts/capture_screenshot.py` in the plugin root) for browser automation:
+Use the screenshot script (`claude-seo run capture_screenshot.py`) for browser automation:
 
 ```bash
 claude-seo run capture_screenshot.py URL --all --output screenshots/

--- a/docs/REVIEW-open-prs-issues-2026-08.md
+++ b/docs/REVIEW-open-prs-issues-2026-08.md
@@ -265,7 +265,43 @@ which is the one direction a gate must never fail. Fixed by relaxing only the er
 handler (`reconfigure(errors="replace")`), deliberately not forcing UTF-8 onto a
 cp1252 console, which would produce mojibake.
 
-Suite after both fixes: **393 passed**, unchanged from baseline.
+### `scripts/agent_ux_check.py` — issue #210 Bug 2
+
+The report says the accessibility tree is "never captured". That part is not
+accurate — `render_page.py:441` does capture it under `mode="always"`, which
+`audit()` uses. The real defect is next to it: the snapshot is best-effort and
+any failure is swallowed into `None`, after which `score()` skips every
+accessibility deduction. Measured on the same page:
+
+```
+score without a11y tree: 100
+score with a bad a11y tree: 75
+```
+
+`tree_present` was never surfaced, so the operator saw a perfect score with no
+sign that half the analysis never ran — the same "missing data reads as clean"
+failure as Bug 1. The report now carries `partial: true` plus an explicit issue,
+and the CLI prints `Agent-UX score: 100/100 (partial)`.
+
+### CI — `py_compile` gate
+
+Added a `compile-check` job over every tracked `.py` file. Validated against
+PR #198: passes on this branch, fails on that one naming
+`scripts/bing_webmaster.py`. Dependency-free, so it cannot fail for environment
+reasons.
+
+### `claude-seo run` conversions — issue #208
+
+20 instructional references across 13 files now show the sanctioned invocation.
+Applied as explicit one-occurrence-each replacements, not a pattern rewrite —
+the inventory showed most of the 25 references are prose, and blanket
+substitution is exactly what left #198 unparseable. Five descriptive references
+that explain internals (e.g. "All URL fetching goes through `fetch_page.py`
+which enforces SSRF protection") are deliberately unchanged.
+
+Suite after all fixes: **400 passed** (393 baseline + 7 new regression tests). `consistency_check.py` and
+`portability_check.py` both pass (0 errors); the one warning is this review doc
+itself being unreferenced from the docs tree.
 
 ---
 

--- a/docs/REVIEW-open-prs-issues-2026-08.md
+++ b/docs/REVIEW-open-prs-issues-2026-08.md
@@ -30,6 +30,32 @@ call to the GitHub API — environmental, unrelated to the PR.
 **Merge #182 before evaluating anything else.** Until it lands, a green local run
 proves nothing, and no contributor can validate their own work.
 
+### And CI never runs on contributor PRs at all
+
+Discovered while opening #243. Sampling check runs across fork-based PRs:
+
+```
+PR #198 check runs: 0
+PR #242 check runs: 0
+PR #182 check runs: 0
+```
+
+Zero on every fork PR sampled, while a same-repo branch PR (#243) received its
+four checks within seconds. That signature matches GitHub's "require approval for
+all external contributors" setting for fork workflow runs, which holds each run
+until a maintainer clicks *Approve and run*.
+
+This is probably the most consequential finding in this document, because it
+explains the rest of it. #198's `SyntaxError` and #242's failing tests both
+reached review looking clean for the same reason: **no external contributor is
+receiving any automated feedback.** The existing `lint` job would have caught
+PR #198 — it compiles `scripts/*.py`, and `scripts/bing_webmaster.py` matches —
+but it never ran.
+
+Fixing this (Settings → Actions → Fork pull request workflows) would do more for
+contribution quality than any individual patch reviewed below, and it would have
+caught two of the three broken PRs here without human review.
+
 ---
 
 ## 1. PRs that do not do what they say
@@ -114,7 +140,8 @@ Thank the reporter — the diagnosis in #208 is sound even though the remedy isn
 |---|----|---------|----------|
 | 1 | **#182** stop module-level `sys.exit` aborting pytest | ✅ Merge first | Only branch where tests run: 232 passed vs 0 |
 | 2 | **#202** cost ledgers lose concurrent writes | ✅ Merge | Genuine lost-update: old code took `LOCK_SH` to read, released, re-took `LOCK_EX` to write. Fix spans one lock, adds atomic `os.replace`, `msvcrt` fallback, fails closed on corruption. Thorough tests |
-| 3 | **#240** / **#241** schema hook fixes | ✅ Merge — but see conflict | Both branches' tests pass (4 and 5 respectively) |
+| 3 | **#241** `@graph` validation | ✅ Merge — higher priority than its size suggests | Tests pass (5). Yoast emits a top-level `@graph` on *every page* of every site running it, so this false positive rejects the standard output of the most widely deployed SEO plugin on the web, and blocks the user's edit. Survived adversarial probing: missing `@context`, a member without `@type`, and a bad `@context` all still error |
+| 4 | **#240** bare `REPLACE` placeholder | ⚠️ Hold for a one-line change | Tests pass (4), but see the boundary problem below |
 | 4 | **#207** install.ps1 empty-array binding | ✅ Merge | One line, correct; mandatory `[string[]]` with no args prompts on PS 5.1 |
 | 5 | **#196** ponytail cleanup (−102 lines) | ✅ Merge | Verified dead: `_stream_gz_lines`, `normalize_social`, `normalize_reviews` all have **0** references outside their own file |
 | 6 | **#190** requests floor | ✅ Merge; supersedes #201 | See §3 |
@@ -133,6 +160,34 @@ CONFLICT (content): Merge conflict in CHANGELOG.md
 Merge one, then ask the author (same contributor, `ousamabenyounes`) to rebase the
 other. #241 changes the function signature (`require_context`), so landing **#241
 first** and rebasing #240 onto it is the smaller conflict.
+
+### ⚠️ #240's new boundary is wrong in both directions
+
+Its tests pass, so this only shows up under adversarial probing. `\bREPLACE\b`
+with `re.IGNORECASE` trades one false positive for two worse problems:
+
+```
+'Replace the cartridge every 6 months' -> BLOCKED   <- ordinary product copy
+'Easy to replace filter'               -> BLOCKED   <- ordinary product copy
+'REPLACE_ME'                           -> allowed   <- real placeholder, missed
+'REPLACE_WITH_URL'                     -> allowed   <- real placeholder, missed
+```
+
+`_` is a word character, so `\bREPLACE\b` never matches the most common
+placeholder forms. Meanwhile `IGNORECASE` catches the ordinary English verb —
+and "Replace the cartridge every 6 months" is exactly the sentence that belongs
+in a `Product` description, so for that schema type this would fire more often
+than the bug it fixes.
+
+Making the match all-caps, underscore-aware and case-**sensitive** handles every
+case tested:
+
+```python
+re.search(r"\bREPLACE(_[A-Z]+)*\b", text)   # no IGNORECASE
+```
+
+A genuine unresolved placeholder is a screaming-caps token; lowercase "replace"
+is just English. Posted to the PR with the evidence.
 
 ### PR #204 — MCP config location — ⚠️ **Correct premise, unsafe write path**
 

--- a/docs/REVIEW-open-prs-issues-2026-08.md
+++ b/docs/REVIEW-open-prs-issues-2026-08.md
@@ -190,7 +190,7 @@ the 3.10 CI matrix. Safe.
 | **#210** empty HTML scores 90/100 | ✅ **Confirmed** | Reproduced: `score()` on an empty doc returns `{'score': 90, ...}`. Fix still missing (#242 is tests-only) |
 | **#187** `@graph` false positive | ✅ **Confirmed** | Reproduced on `main`: valid top-level `@graph` → `['Block 1: Missing @type']`. Fixed by #241 |
 | **#188** / **#205** bare `REPLACE` substring | ✅ **Confirmed — duplicates** | Reproduced: `"renal replacement therapy"` → `Contains placeholder text: REPLACE`. Fixed by #240. Close one as a duplicate of the other |
-| **#186** `UnicodeEncodeError` on Windows cp1252 | ✅ **Confirmed — no PR open** | `hooks/validate-schema.py:183,188` print `⚠️` and `🛑`. Crashes on a cp1252 stdout. **Unclaimed gap** |
+| **#186** `UnicodeEncodeError` on Windows cp1252 | ✅ **Confirmed — worse than reported.** Fixed in §6 | `hooks/validate-schema.py:183,188` print `⚠️`/`🛑`. The crash pre-empts `sys.exit(2)`, so the hook exits **1** — the gate fails *open* on Windows |
 | **#208** script path resolution | ✅ Confirmed, ❌ wrong fix proposed | 25 raw refs vs 28 using `claude-seo run`. See #209 above |
 | **#180** trafilatura / `lxml_html_clean` | ❓ **Does not reproduce** | Fresh install of the exact pins: trafilatura 2.2.0 imports fine, `lxml.html.clean` resolves, `lxml_html_clean` pulled in automatically. Ask the reporter for their platform and `pip freeze` before acting |
 | **#177** subagents write no findings on large sites | ⚠️ Plausible, unverified | `maxTurns` is 15/20/25 and `seo-audit/SKILL.md` does specify `findings/*.md`. Needs a real large-site run to confirm — not reproducible from static inspection |
@@ -201,22 +201,85 @@ the 3.10 CI matrix. Safe.
 
 ---
 
-## 5. Not yet reviewed in depth
+## 5. Second pass: the remaining PRs
 
-#178 (docs, 2 files), #179 (tests only, +95), #183/#184/#185 (CI: fail-fast on
-install, pip-audit, Windows/macOS matrix), #195 (new templated-metadata detector,
-+810), #198 (hosted-Claude compat, 60 files). #183–#185 pair naturally with #182 as
-a CI-health batch. #195 and #198 are large enough to deserve dedicated passes.
+| PR | Verdict | Evidence |
+|----|---------|----------|
+| **#183** don't swallow install failure in v2 CI | ✅ **Merge — pairs with #182** | Removes `pip install -r requirements.txt \|\| true`. Independently corroborates §0: a swallowed install resurfaces as an opaque pytest INTERNALERROR rather than the pip error that caused it |
+| **#185** portability matrix (Windows/macOS) | ✅ Merge | `fail-fast: false`; deliberately runs only the 3 platform-neutral modules and explains why the other 15 assert POSIX semantics. Action versions (`@v7`) match `main` |
+| **#184** pip-audit job | ✅ Merge, with one caveat | Sound, and the author flags the tradeoff honestly: because pins are ranges, a newly published advisory turns CI red with no commit. Fine as an advisory job — think twice before making it a *required* check |
+| **#178** dynamic rendering is a workaround | ✅ Merge | Docs-only, factually correct — Google does document dynamic rendering as "a workaround and not a recommended solution" |
+| **#179** validate_backlink_report coverage | ✅ Merge | Tests only, +95, no source change |
+| **#195** templated-metadata detector | ✅ Merge (feature — scope is your call) | 48 tests pass. Pure offline string analysis, no network, so no `url_safety` exposure. Clean structure |
+| **#198** hosted-Claude compatibility | ❌ **Do not merge — breaks the build** | See below |
+
+### PR #198 breaks `scripts/bing_webmaster.py`
+
+The PR does a blind find/replace of `claude-seo run` →
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run` across 60 files, including
+**inside a Python string literal**. The injected double quotes terminate the
+string:
+
+```
+scripts/bing_webmaster.py:553
+    "error": "No Bing Webmaster API key configured. Run: "${CLAUDE_PLUGIN_ROOT}/...
+SyntaxError: invalid syntax
+```
+
+Compile-checking every tracked `.py` file: **1 broken on #198, 0 on `main`.** The
+file does not parse, so `tests/test_bing_webmaster.py` cannot even be collected.
+
+The goal (making the plugin work on hosted Claude) is legitimate and #199 is a real
+report. But this needs a re-run of the substitution that respects string literals,
+plus a `py_compile` gate — worth adding to CI regardless, since nothing currently
+catches an unparseable file.
 
 ---
 
-## 6. Recommended sequence
+## 6. Fixes implemented on this branch
+
+Two confirmed bugs had no working PR, so they are fixed here with regression tests.
+Both tests were verified to **fail without the fix** and pass with it.
+
+### `scripts/agent_ux_check.py` — issue #210
+
+`audit()` returned early only on `page["error"]`, so an empty-but-successful fetch
+flowed into `score()` and scored 90/100. Now surfaced as a render error
+(`score: None`). This is the hunk #242 was missing; its tests were good and
+equivalents are included.
+
+### `hooks/validate-schema.py` — issue #186 (more serious than reported)
+
+The report describes a `UnicodeEncodeError` traceback on cp1252 consoles. Measured,
+the impact is worse: the crash happens **before** `sys.exit(2)`, so the hook exits
+**1** instead of **2**.
+
+```
+main (pre-fix) exit code: 1     <- "warnings only, proceed"
+fixed exit code:          2     <- blocking
+```
+
+Exit 1 means warnings-only. So on any Windows console defaulting to cp1252, a
+*blocking* schema error was silently non-blocking — **the quality gate failed open**,
+which is the one direction a gate must never fail. Fixed by relaxing only the error
+handler (`reconfigure(errors="replace")`), deliberately not forcing UTF-8 onto a
+cp1252 console, which would produce mojibake.
+
+Suite after both fixes: **393 passed**, unchanged from baseline.
+
+---
+
+## 7. Recommended sequence
 
 1. Merge **#182** — restores the ability to test anything.
 2. Merge **#202**, **#207**, **#196**.
 3. Merge **#241**, ask for a rebase of **#240**.
 4. Merge Dependabot **#190–#194**; close **#201** as superseded.
-5. Return **#242** for its missing fix; return **#197**/**#203** for the SSRF and
-   file-read issues; close **#209** in favour of `claude-seo run`.
-6. Harden the write path in **#204**, then merge.
-7. Pick up **#186** — a confirmed bug with nobody working on it.
+5. Merge the CI batch **#183**, **#185**, **#184**, then **#178**, **#179**, **#195**.
+6. Return **#242** for its missing fix; return **#197**/**#203** for the SSRF and
+   file-read issues; return **#198** for the `SyntaxError`; close **#209** in favour
+   of `claude-seo run`.
+7. Harden the write path in **#204**, then merge.
+8. **#210** and **#186** are fixed on this branch (§6) — review and land.
+9. Consider a `py_compile` gate in CI. Nothing today catches a tracked `.py` file
+   that does not parse, which is how #198 got this far.

--- a/docs/REVIEW-open-prs-issues-2026-08.md
+++ b/docs/REVIEW-open-prs-issues-2026-08.md
@@ -299,7 +299,11 @@ substitution is exactly what left #198 unparseable. Five descriptive references
 that explain internals (e.g. "All URL fetching goes through `fetch_page.py`
 which enforces SSRF protection") are deliberately unchanged.
 
-Suite after all fixes: **400 passed** (393 baseline + 7 new regression tests). `consistency_check.py` and
+Full suite, nothing excluded — `main` **407 passed / 3 failed**, this branch
+**414 passed / 3 failed**. Exactly +7 tests, all passing, zero new failures. The
+3 failures are byte-identical on both branches and are network-bound
+(`example.com` fetch, and the GitHub API returning 403 through the sandbox
+proxy), so they are environmental rather than pre-existing defects. `consistency_check.py` and
 `portability_check.py` both pass (0 errors); the one warning is this review doc
 itself being unreferenced from the docs tree.
 

--- a/docs/REVIEW-open-prs-issues-2026-08.md
+++ b/docs/REVIEW-open-prs-issues-2026-08.md
@@ -1,0 +1,222 @@
+# Open PR & Issue Review — August 2026
+
+Skeptical triage of all 26 open PRs and 12 open issues against `main` @ `09d37c7`.
+
+**Method.** Every claim was checked against the code, not the description. PR
+branches were fetched locally (`refs/pull/N/head`), their own tests executed, merge
+compatibility tested pairwise, and external claims (CVEs, config locations, API
+semantics) verified against primary sources. Verdicts below cite the evidence.
+
+---
+
+## 0. Read this first: the test suite does not run
+
+On **every** branch except #182, `pytest tests/` aborts during collection:
+
+```
+INTERNALERROR> SystemExit: 1
+no tests ran in 0.44s
+```
+
+`scripts/gsc_query.py` calls `sys.exit(1)` at import time when
+`google-api-python-client` is absent. Under pytest that `SystemExit` escapes
+collection and kills the **entire session** — not one module, all of it. CI hides
+this because CI installs every optional dependency.
+
+With #182 applied: `1 failed, 232 passed, 3 skipped`. The single failure is
+`test_sync_flow.py::test_dry_run_exits_zero`, which makes a live `urllib.request.urlopen`
+call to the GitHub API — environmental, unrelated to the PR.
+
+**Merge #182 before evaluating anything else.** Until it lands, a green local run
+proves nothing, and no contributor can validate their own work.
+
+---
+
+## 1. PRs that do not do what they say
+
+### PR #242 — "fix(agent-ux): don't emit a passing score for empty fetched documents" — ❌ **Do not merge**
+
+The diff contains **only** `CHANGELOG.md` and `tests/test_phase_j_executable.py`.
+There is no change to `scripts/agent_ux_check.py`. The CHANGELOG asserts a fix that
+was never committed.
+
+Its own tests fail on its own branch:
+
+```
+FAILED tests/test_phase_j_executable.py::test_audit_refuses_score_on_empty_html
+FAILED tests/test_phase_j_executable.py::test_audit_refuses_score_on_whitespace_only_html
+E       assert 90 is None
+2 failed, 23 passed
+```
+
+The underlying report (**issue #210**) is real and reproduces — see §4.
+The tests are well written and should be kept; they just need the actual guard in
+`audit()`, which currently returns early only on `page["error"]`, so an empty body
+flows into `score()` and yields 100 − 10 = **90**.
+
+**Action:** ask for the missing `agent_ux_check.py` hunk, or land the tests together
+with a maintainer-written guard.
+
+### PRs #197 and #203 — MiniMax provider for the Banana REST fallback — ❌ **Do not merge as-is (security)**
+
+Both come from `octo-patch`, an account with no other history in this repo, and both
+add a new third-party API vendor (`api.minimax.io`, `api.minimaxi.com`).
+
+Two concrete defects, not style objections:
+
+1. **Unvalidated fetch of a remote-controlled URL (SSRF).** `generate.py:282`
+   (#197) and `edit.py:291` (#203) do `urllib.request.urlopen(item, timeout=120)`
+   where `item` comes straight out of the MiniMax JSON response, then write the
+   bytes to disk. Neither file imports `url_safety` at all (`grep -c url_safety` → `0`).
+   This directly violates the repo's own rule in CLAUDE.md: *"All scripts that connect
+   to user-supplied URLs must use `scripts/url_safety.py`."* On `main`, the banana
+   script only ever calls one hardcoded Google endpoint — these PRs introduce the
+   first response-controlled fetch sink in the extension.
+2. **Local file read into an outbound request.** `_encode_subject_reference()`
+   accepts an arbitrary path, `resolve()`s it, base64-encodes the bytes and posts
+   them to the vendor. That is a clean file-exfiltration primitive for anything that
+   can influence the argument.
+
+Credit where due: API-key redaction on the error path is handled properly and tested.
+
+**Action:** route every image fetch through `safe_requests_get()`, constrain
+subject-reference paths to an allowlisted directory, then re-review. Given an
+unknown author adding a new network egress target, this warrants a careful second
+look regardless.
+
+### PR #209 — script path resolution — ❌ **Wrong fix for a real problem (issue #208)**
+
+The problem is real: 25 `scripts/*.py` references in `agents/` and `skills/` bypass
+the wrapper, while 28 already use `claude-seo run`.
+
+But the fix pastes an 8-line shell block into 20 files:
+
+```bash
+PLUGIN_ROOT=$(dirname "$(find ~/.claude/plugins/cache -maxdepth 4 ... | head -1)")
+PY="$PLUGIN_ROOT/.venv/bin/python3"
+```
+
+`scripts/runtime.py` **already solves this**, and better — it honours
+`CLAUDE_PLUGIN_DATA`/`CLAUDE_PLUGIN_ROOT` and resolves the interpreter
+cross-platform (`_venv_python()` returns `Scripts/python.exe` on Windows). The PR's
+version is Unix-only, hardcodes one install layout, and breaks for git-clone and
+marketplace installs. It also duplicates the block 20× and inserts prose above the
+H1 in SKILL.md files.
+
+**Action:** close in favour of converting the 25 raw references to `claude-seo run`.
+Thank the reporter — the diagnosis in #208 is sound even though the remedy isn't.
+
+---
+
+## 2. Merge, in this order
+
+| # | PR | Verdict | Evidence |
+|---|----|---------|----------|
+| 1 | **#182** stop module-level `sys.exit` aborting pytest | ✅ Merge first | Only branch where tests run: 232 passed vs 0 |
+| 2 | **#202** cost ledgers lose concurrent writes | ✅ Merge | Genuine lost-update: old code took `LOCK_SH` to read, released, re-took `LOCK_EX` to write. Fix spans one lock, adds atomic `os.replace`, `msvcrt` fallback, fails closed on corruption. Thorough tests |
+| 3 | **#240** / **#241** schema hook fixes | ✅ Merge — but see conflict | Both branches' tests pass (4 and 5 respectively) |
+| 4 | **#207** install.ps1 empty-array binding | ✅ Merge | One line, correct; mandatory `[string[]]` with no args prompts on PS 5.1 |
+| 5 | **#196** ponytail cleanup (−102 lines) | ✅ Merge | Verified dead: `_stream_gz_lines`, `normalize_social`, `normalize_reviews` all have **0** references outside their own file |
+| 6 | **#190** requests floor | ✅ Merge; supersedes #201 | See §3 |
+
+### ⚠️ #240 and #241 conflict with each other
+
+Both rewrite `_validate_schema_object()` in `hooks/validate-schema.py`. Tested:
+
+```
+MERGE 240+241: CONFLICT
+CONFLICT (content): Merge conflict in hooks/validate-schema.py
+CONFLICT (content): Merge conflict in tests/test_schema_hook_policy.py
+CONFLICT (content): Merge conflict in CHANGELOG.md
+```
+
+Merge one, then ask the author (same contributor, `ousamabenyounes`) to rebase the
+other. #241 changes the function signature (`require_context`), so landing **#241
+first** and rebasing #240 onto it is the smaller conflict.
+
+### PR #204 — MCP config location — ⚠️ **Correct premise, unsafe write path**
+
+The claim checks out against the Claude Code docs: MCP servers live in
+`~/.claude.json` (local + user scope) or project `.mcp.json`. `mcpServers` is *not*
+read from `~/.claude/settings.json`, so today's installers write config that
+silently never loads. Real bug, correct destination.
+
+**But the blast radius changes.** `~/.claude.json` is the user's primary state file
+(every project's history), not a small settings file. Two write paths are now unsafe:
+
+- `extensions/firecrawl/install.ps1` uses `ConvertTo-Json -Depth 10`. PowerShell
+  silently truncates beyond `-Depth`; `~/.claude.json` routinely nests deeper. This
+  can corrupt the user's entire config.
+- `extensions/banana/scripts/setup_mcp.py` `save_settings()` rewrites the whole file
+  non-atomically — a crash mid-write loses everything.
+
+The bash installers already do argv-passed, atomic, 0600 writes and are fine.
+
+**Action:** fix the PowerShell depth and make `setup_mcp.py` atomic, then merge.
+This one is worth getting right rather than fast.
+
+---
+
+## 3. Dependabot & dependency PRs
+
+| PR | Change | Verdict |
+|----|--------|---------|
+| #190 | requests `>=2.34.2` | ✅ Merge — supersedes #201 |
+| #201 | requests `>=2.33.0` (CVE-2026-25645) | ➖ Close as superseded by #190 |
+| #191 | playwright `>=1.61.0` | ✅ Merge |
+| #192 | courlan `>=1.4.0` | ✅ Merge |
+| #193 | numpy `>=2.2.6` | ✅ Merge — verified safe |
+| #194 | google-auth `>=2.56.2` | ✅ Merge |
+
+**On #201's CVE claim — I checked, and it is real.** CVE-2026-25645 exists: insecure
+temp-file reuse in `requests.utils.extract_zipped_paths()`, fixed in 2.33.0. Two
+caveats worth recording: the advisory only affects code that calls
+`extract_zipped_paths()` **directly**, and this repo never does
+(`grep -rn extract_zipped_paths` → no hits). So the urgency is low, and #190's
+`>=2.34.2` already clears it. Close #201 with thanks, not as wrong.
+
+**On #193 (numpy 1.26 → 2.2.6),** a major-version floor deserves scrutiny. Checked:
+the only numpy API used anywhere in `scripts/` is `np.linspace` and `np.pi`, both
+unchanged in 2.x, and no removed alias (`np.float_`, `np.NaN`, `np.product`, …)
+appears. numpy 2.2 requires Python ≥3.10, matching `requires-python = ">=3.10"` and
+the 3.10 CI matrix. Safe.
+
+---
+
+## 4. Issues
+
+| Issue | Verdict | Evidence |
+|-------|---------|----------|
+| **#210** empty HTML scores 90/100 | ✅ **Confirmed** | Reproduced: `score()` on an empty doc returns `{'score': 90, ...}`. Fix still missing (#242 is tests-only) |
+| **#187** `@graph` false positive | ✅ **Confirmed** | Reproduced on `main`: valid top-level `@graph` → `['Block 1: Missing @type']`. Fixed by #241 |
+| **#188** / **#205** bare `REPLACE` substring | ✅ **Confirmed — duplicates** | Reproduced: `"renal replacement therapy"` → `Contains placeholder text: REPLACE`. Fixed by #240. Close one as a duplicate of the other |
+| **#186** `UnicodeEncodeError` on Windows cp1252 | ✅ **Confirmed — no PR open** | `hooks/validate-schema.py:183,188` print `⚠️` and `🛑`. Crashes on a cp1252 stdout. **Unclaimed gap** |
+| **#208** script path resolution | ✅ Confirmed, ❌ wrong fix proposed | 25 raw refs vs 28 using `claude-seo run`. See #209 above |
+| **#180** trafilatura / `lxml_html_clean` | ❓ **Does not reproduce** | Fresh install of the exact pins: trafilatura 2.2.0 imports fine, `lxml.html.clean` resolves, `lxml_html_clean` pulled in automatically. Ask the reporter for their platform and `pip freeze` before acting |
+| **#177** subagents write no findings on large sites | ⚠️ Plausible, unverified | `maxTurns` is 15/20/25 and `seo-audit/SKILL.md` does specify `findings/*.md`. Needs a real large-site run to confirm — not reproducible from static inspection |
+| **#189** Unlighthouse `--max-routes` inert | ⚠️ Unverified | Requires the extension installed; three distinct claims that should be split |
+| **#199** hosted-plugin upload failure | ⚠️ Tied to #198 | #198 touches 60 files; needs its own review pass |
+| **#181** Git delivery flow docs | 📋 Docs request | Low priority, uncontroversial |
+| **#239** GoAnyAPI extension proposal | 📋 Proposal | Given the #197/#203 findings, apply the same egress scrutiny to any new provider |
+
+---
+
+## 5. Not yet reviewed in depth
+
+#178 (docs, 2 files), #179 (tests only, +95), #183/#184/#185 (CI: fail-fast on
+install, pip-audit, Windows/macOS matrix), #195 (new templated-metadata detector,
++810), #198 (hosted-Claude compat, 60 files). #183–#185 pair naturally with #182 as
+a CI-health batch. #195 and #198 are large enough to deserve dedicated passes.
+
+---
+
+## 6. Recommended sequence
+
+1. Merge **#182** — restores the ability to test anything.
+2. Merge **#202**, **#207**, **#196**.
+3. Merge **#241**, ask for a rebase of **#240**.
+4. Merge Dependabot **#190–#194**; close **#201** as superseded.
+5. Return **#242** for its missing fix; return **#197**/**#203** for the SSRF and
+   file-read issues; close **#209** in favour of `claude-seo run`.
+6. Harden the write path in **#204**, then merge.
+7. Pick up **#186** — a confirmed bug with nobody working on it.

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -143,7 +143,29 @@ def _resolve_filepath():
     return None
 
 
+def _make_output_encoding_safe():
+    """Stop a non-UTF-8 console from turning a finding into a crash.
+
+    This hook prints warning/error banners containing non-ASCII markers. On a
+    Windows console defaulting to cp1252, encoding those raised
+    UnicodeEncodeError, so the hook died with exit code 1 and the operator saw a
+    traceback instead of the schema finding (issue #186).
+
+    The stream's encoding is left alone deliberately - forcing UTF-8 onto a
+    cp1252 console produces mojibake. Only the error handler is relaxed, so an
+    unencodable character degrades to a replacement character and the finding,
+    and the blocking exit code, still get through.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(errors="replace")
+        except (AttributeError, OSError, ValueError):
+            # Non-TextIOWrapper stream (redirected/wrapped); nothing to relax.
+            pass
+
+
 def main():
+    _make_output_encoding_safe()
     filepath = _resolve_filepath()
     if not filepath:
         sys.exit(0)

--- a/scripts/agent_ux_check.py
+++ b/scripts/agent_ux_check.py
@@ -190,6 +190,7 @@ def audit(url: str, *, timeout_ms: int = 15000) -> dict:
         "html_findings": {},
         "a11y_findings": {},
         "score": None,
+        "partial": False,
         "issues": [],
     }
     if page.get("error"):
@@ -209,6 +210,18 @@ def audit(url: str, *, timeout_ms: int = 15000) -> dict:
     scored = score(report["html_findings"], report["a11y_findings"])
     report["score"] = scored["score"]
     report["issues"] = scored["issues"]
+
+    if not report["a11y_findings"]["tree_present"]:
+        # render_page() treats the accessibility snapshot as best-effort and
+        # swallows any failure into None. score() then skips every a11y
+        # deduction, so absent data reads as a clean result: a page scoring 75
+        # with a tree scores 100 without one. Mark the score partial rather than
+        # presenting a confident number built on half the analysis (issue #210).
+        report["partial"] = True
+        report["issues"].append(
+            "accessibility tree unavailable - score reflects HTML signals only "
+            "and may be optimistic"
+        )
     return report
 
 
@@ -232,7 +245,8 @@ def _cli() -> None:
 
     print(f"URL: {report['url']}")
     print(f"Status: {report['status_code']}")
-    print(f"Agent-UX score: {report['score']}/100")
+    partial_note = " (partial)" if report["partial"] else ""
+    print(f"Agent-UX score: {report['score']}/100{partial_note}")
     if report["issues"]:
         print("Issues:")
         for issue in report["issues"]:

--- a/scripts/agent_ux_check.py
+++ b/scripts/agent_ux_check.py
@@ -195,6 +195,13 @@ def audit(url: str, *, timeout_ms: int = 15000) -> dict:
     if page.get("error"):
         return report
     html = page.get("content") or ""
+    if not html.strip():
+        # A fetch that succeeded but returned nothing is a render failure, not a
+        # clean page. Every count in analyze_html() collapses to 0 on an empty
+        # document, which score() would otherwise read as "no problems found"
+        # and reward with 90/100. Surface it as an error instead (issue #210).
+        report["render_error"] = "empty document returned (no HTML content)"
+        return report
     a11y = page.get("accessibility_tree")
 
     report["html_findings"] = analyze_html(html)

--- a/scripts/commoncrawl_graph.py
+++ b/scripts/commoncrawl_graph.py
@@ -22,6 +22,7 @@ import gzip
 import io
 import json
 import os
+import re
 import sys
 import time
 from typing import Optional
@@ -96,11 +97,47 @@ def _get_latest_release() -> Optional[str]:
     return None
 
 
+_CACHE_COMPONENT_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+# A Common Crawl release id, e.g. cc-main-2026-jan-feb-mar. Anchored, and no
+# '..' anywhere, because this value lands in a filesystem path and a URL path.
+_RELEASE_RE = re.compile(r"^(?!.*\.\.)[A-Za-z0-9._-]+$")
+
+
+def _safe_cache_component(value: str) -> str:
+    """Reduce one path component to a conservative charset.
+
+    Everything outside [A-Za-z0-9._-] becomes '_', then any run of dots is
+    collapsed so '..' can never survive. Both halves matter: stripping
+    separators alone still lets '..' through on a caller that joins
+    differently, and collapsing dots alone still lets a separator through.
+    """
+    cleaned = _CACHE_COMPONENT_RE.sub("_", value)
+    while ".." in cleaned:
+        cleaned = cleaned.replace("..", "_")
+    return cleaned.strip("._") or "_"
+
+
 def _get_cache_path(domain: str, release: str, data_type: str) -> str:
-    """Get the cache file path for a domain's data."""
+    """Get the cache file path for a domain's data.
+
+    Both `domain` and `release` reach this from the CLI. `release` used to be
+    interpolated raw, so `--release ../../../../tmp/x` escaped the cache
+    directory and `_save_cache`'s open(..., "w") wrote outside it. Every
+    component is now sanitised, and the joined result is asserted to stay
+    inside the cache directory as defence in depth.
+    """
     cache_dir = get_cache_dir()
-    safe_domain = domain.replace("/", "_").replace(":", "_")
-    return os.path.join(cache_dir, f"{safe_domain}-{release}-{data_type}.json")
+    safe_domain = _safe_cache_component(domain)
+    safe_release = _safe_cache_component(release)
+    safe_type = _safe_cache_component(data_type)
+    path = os.path.join(cache_dir, f"{safe_domain}-{safe_release}-{safe_type}.json")
+
+    resolved = os.path.realpath(path)
+    root = os.path.realpath(cache_dir)
+    if not (resolved == root or resolved.startswith(root + os.sep)):
+        raise ValueError(f"refusing to build a cache path outside {root}")
+    return path
 
 
 def _is_cached(domain: str, release: str) -> Optional[dict]:
@@ -430,6 +467,19 @@ def main():
 
     if not args.domain:
         print("Error: domain argument required (or use --info)", file=sys.stderr)
+        sys.exit(1)
+
+    # Reject a malformed release rather than silently sanitising it. The value
+    # is interpolated into both a cache filename and a download URL
+    # (_graph_file_url), so quietly rewriting it for one and not the other
+    # would make the cache key disagree with what was actually fetched.
+    if args.release is not None and not _RELEASE_RE.match(args.release):
+        print(
+            f"Error: invalid --release {args.release!r}. Expected a release id "
+            "such as cc-main-2026-jan-feb-mar (letters, digits, dot, dash, "
+            "underscore only).",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     result = get_domain_metrics(

--- a/scripts/domain_history.py
+++ b/scripts/domain_history.py
@@ -63,6 +63,11 @@ import sys
 from datetime import datetime, timezone
 from typing import Optional
 
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+from url_safety import URLSafetyError, validate_url_strict  # noqa: E402
+
 
 _DATE_LABELS = {
     "created": (
@@ -126,8 +131,23 @@ def _socket_whois(domain: str) -> Optional[str]:
         return iana_text
 
     referral = m.group(1).strip()
+
+    # The referral host is attacker-influenceable: WHOIS runs unencrypted on
+    # port 43, so anyone able to tamper with the IANA response can inject a
+    # `refer:` line pointing at an internal address, turning this fallback into
+    # a port-43 probe of the operator's private network. Resolve and validate
+    # it through the same guard every other outbound call uses, then connect to
+    # the pinned address so the answer cannot be re-pointed after the check.
+    # WHOIS is plaintext with no SNI, so dialling the IP directly is lossless.
     try:
-        with socket.create_connection((referral, 43), timeout=10) as sock:
+        _, pinned_ip = validate_url_strict(f"https://{referral}/")
+    except URLSafetyError:
+        # A referral we cannot vouch for is not worth following. IANA's own
+        # answer is still useful, so return that rather than nothing.
+        return iana_text
+
+    try:
+        with socket.create_connection((pinned_ip, 43), timeout=10) as sock:
             sock.sendall(f"{domain}\r\n".encode("ascii"))
             buf = b""
             while True:

--- a/scripts/render_page.py
+++ b/scripts/render_page.py
@@ -517,7 +517,19 @@ def _cli() -> None:
     parser.add_argument(
         "--json",
         action="store_true",
-        help="emit a JSON summary (truncates content fields)",
+        help=(
+            "emit a JSON summary; raw HTML fields are truncated (see "
+            "--max-text) and the 'truncation' map records which fields were cut"
+        ),
+    )
+    parser.add_argument(
+        "--max-text",
+        type=int,
+        default=0,
+        help=(
+            "cap extracted_text at N characters in --json output "
+            "(default 0 = no cap; extracted_text is what the scoring agents read)"
+        ),
     )
     parser.add_argument(
         "--json-ld-output",
@@ -546,21 +558,41 @@ def _cli() -> None:
         with open(args.json_ld_output, "w", encoding="utf-8") as fh:
             json.dump(extraction, fh, indent=2, ensure_ascii=False)
 
+    # --output is honoured before the --json branch exits, so the two compose.
+    # Previously the JSON branch returned first and `--json --output` silently
+    # wrote nothing, which also broke the documented "use --output when you need
+    # the full document" escape hatch from the truncation below.
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(res["content"] or "")
+        print(f"saved to {args.output}", file=sys.stderr)
+
     if args.json:
         summary = dict(res)
         summary["structured_data"] = _extract_json_ld(full_content)
-        # JSON-safe truncation so the CLI is usable from agents without
-        # piping megabytes of HTML across stdio.
-        for field, limit in (
-            ("content", 500),
-            ("raw_content", 200),
-            ("extracted_text", 500),
-        ):
-            if summary.get(field):
-                value = summary[field]
-                summary[field] = (
-                    value[:limit] + "..." if len(value) > limit else value
-                )
+        # Raw HTML stays truncated so the CLI is usable from agents without
+        # piping megabytes across stdio -- use --output for the full document.
+        #
+        # extracted_text is NOT capped by default. It is trafilatura's
+        # boilerplate-stripped text, and the agent instructions tell every
+        # scoring path to read it (E-E-A-T, thin content, word count,
+        # citability). Capping it at 500 chars silently scored real pages on
+        # ~70 words, so every page looked thin. Pass --max-text to cap it.
+        limits = {
+            "content": 500,
+            "raw_content": 200,
+            "extracted_text": args.max_text if args.max_text > 0 else None,
+        }
+        truncation = {}
+        for field, limit in limits.items():
+            value = summary.get(field)
+            was_truncated = bool(value) and limit is not None and len(value) > limit
+            if was_truncated:
+                summary[field] = value[:limit] + "..."
+            truncation[field] = was_truncated
+        # Always emitted, so a consumer can tell a short page from a cut one
+        # instead of inferring it from a trailing ellipsis.
+        summary["truncation"] = truncation
         print(json.dumps(summary, indent=2, default=str))
         sys.exit(1 if res["error"] else 0)
 
@@ -568,11 +600,8 @@ def _cli() -> None:
         print(f"Error: {res['error']}", file=sys.stderr)
         sys.exit(1)
 
-    if args.output:
-        with open(args.output, "w", encoding="utf-8") as fh:
-            fh.write(res["content"] or "")
-        print(f"saved to {args.output}", file=sys.stderr)
-    else:
+    if not args.output:
+        # The --output write already happened above, before the --json branch.
         print(res["content"])
 
     print(

--- a/skills/seo-drift/SKILL.md
+++ b/skills/seo-drift/SKILL.md
@@ -95,9 +95,9 @@ Captures the current state of a page and stores it.
 
 **Steps:**
 1. Validate URL (SSRF protection via `google_auth.validate_url()`)
-2. Fetch page via `scripts/fetch_page.py`
-3. Parse HTML via `scripts/parse_html.py`
-4. Optionally fetch CWV via `scripts/pagespeed_check.py` (use `--skip-cwv` to skip)
+2. Fetch page via `claude-seo run fetch_page.py`
+3. Parse HTML via `claude-seo run parse_html.py`
+4. Optionally fetch CWV via `claude-seo run pagespeed_check.py` (use `--skip-cwv` to skip)
 5. Hash HTML body and schema content (SHA-256)
 6. Store snapshot in SQLite
 

--- a/skills/seo-ecommerce/references/marketplace-endpoints.md
+++ b/skills/seo-ecommerce/references/marketplace-endpoints.md
@@ -110,7 +110,7 @@ When consuming responses, normalize:
 | Rating | Integer or float | Float rounded to 1 decimal |
 | Reviews | String or int | Integer |
 
-Use `scripts/dataforseo_normalize.py --module merchant` for automatic normalization.
+Use `claude-seo run dataforseo_normalize.py --module merchant` for automatic normalization.
 
 ## Cost Reference
 

--- a/skills/seo-sxo/SKILL.md
+++ b/skills/seo-sxo/SKILL.md
@@ -43,8 +43,8 @@ well-optimized it is.
 
 ### Step 1: Target Acquisition
 
-1. Fetch the target URL via `scripts/render_page.py --mode auto` (SPA-aware and SSRF-safe)
-2. Parse with `scripts/parse_html.py` to extract: title, H1, meta description,
+1. Fetch the target URL via `claude-seo run render_page.py --mode auto` (SPA-aware and SSRF-safe)
+2. Parse with `claude-seo run parse_html.py` to extract: title, H1, meta description,
    headings hierarchy, word count, schema markup, CTAs, media elements
 3. If no keyword provided, extract primary keyword from title tag + H1 overlap
 4. Validate keyword is non-empty before proceeding
@@ -244,7 +244,7 @@ The SXO score is **separate** from the main SEO Health Score.
 ## Quality Checklist
 
 Before delivering results, verify:
-- [ ] Target URL was fetched via `scripts/render_page.py --mode auto` (not raw curl/fetch)
+- [ ] Target URL was fetched via `claude-seo run render_page.py --mode auto` (not raw curl/fetch)
 - [ ] Page type classification uses taxonomy from references
 - [ ] At least 5 SERP results were analyzed
 - [ ] User stories cite specific SERP signals as evidence

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -87,7 +87,7 @@ When the user invokes `/seo audit`, delegate to subagents in parallel:
 15. **Offer PDF report**: "Generate a professional PDF report? Use `/seo google report full`"
 
 For individual commands, load the relevant sub-skill directly.
-After any analysis command completes, offer to generate a PDF report via `scripts/google_report.py`.
+After any analysis command completes, offer to generate a PDF report via `claude-seo run google_report.py`.
 
 ## Synthesis Methodology
 

--- a/skills/seo/references/free-backlink-sources.md
+++ b/skills/seo/references/free-backlink-sources.md
@@ -41,7 +41,7 @@ When only Common Crawl is available, cap the maximum health score at 70/100 and 
 - **Signup:** https://moz.com/products/api (credit card required, not charged)
 - **Data:** Domain Authority (0-100), Page Authority, Spam Score (1-17%), link counts,
   referring domains, anchor text distribution
-- **Script:** `scripts/moz_api.py`
+- **Script:** `claude-seo run moz_api.py`
 - **Commands:** `metrics`, `domains`, `anchors`, `pages`
 - **Blind spots:** No link velocity, no toxic link patterns beyond Spam Score,
   3-day update lag, smaller index than Ahrefs/Semrush
@@ -54,7 +54,7 @@ When only Common Crawl is available, cap the maximum health score at 70/100 and 
   are accessible to the same API account
 - **Data:** Inbound-link source URL, target URL, anchor text, sampled link
   counts, and referring-domain comparison totals
-- **Script:** `scripts/bing_webmaster.py`
+- **Script:** `claude-seo run bing_webmaster.py`
 - **Commands:** `links`, `counts`, `compare` (comparison requires both
   properties to be registered to the same API account)
 - **Blind spots:** Only Bing-indexed pages (~15% of web), verified sites only,
@@ -65,7 +65,7 @@ When only Common Crawl is available, cap the maximum health score at 70/100 and 
 - **Releases:** Quarterly (e.g., cc-main-2025-18)
 - **No auth needed:** Public data, free to download
 - **Data:** Domain-level in-degree, PageRank, harmonic centrality, referring domains
-- **Script:** `scripts/commoncrawl_graph.py`
+- **Script:** `claude-seo run commoncrawl_graph.py`
 - **Cache:** `~/.cache/claude-seo/commoncrawl/` (90-day TTL)
 - **Blind spots:** No anchor text, no page-level data, monthly/quarterly freshness,
   domain-level only (e.g., "nytimes.com links to example.com" but not which page)
@@ -73,7 +73,7 @@ When only Common Crawl is available, cap the maximum health score at 70/100 and 
 ### Verification Crawler (Always Available)
 - **No auth needed:** Uses existing fetch_page.py + parse_html.py
 - **Data:** Binary verification (link exists/lost/moved), anchor text, rel attributes
-- **Script:** `scripts/verify_backlinks.py`
+- **Script:** `claude-seo run verify_backlinks.py`
 - **Input:** JSON file with `[{"source_url": "..."}]` entries
 - **Polite crawling:** 1-second delay between requests to same domain
 - **Best for:** Checking if known backlinks still exist, monitoring link health

--- a/skills/seo/references/thinking-framework.md
+++ b/skills/seo/references/thinking-framework.md
@@ -25,12 +25,12 @@ not a recommendation.
 
 Collect signals without interpreting them. For a website audit this means:
 
-- Raw HTML + rendered HTML (via `scripts/render_page.py`)
+- Raw HTML + rendered HTML (via `claude-seo run render_page.py`)
 - Schema.org markup actually present (via `seo-schema`)
 - SERP visibility for the site's published topics (via `seo-dataforseo` /
   Google APIs when available)
 - Backlink + brand-mention landscape (via `seo-backlinks`)
-- Core Web Vitals field data from CrUX (via `scripts/pagespeed_check.py`)
+- Core Web Vitals field data from CrUX (via `claude-seo run pagespeed_check.py`)
 - AI-search citation patterns (via `seo-geo`)
 - Competitor pages on the target's primary keywords
 
@@ -185,7 +185,7 @@ Stop strategizing. Produce the artifact:
   measurable outcomes.
 - Generated schema JSON-LD ready to paste into the site.
 - A content brief with target keywords, outline, and internal links.
-- A PDF via `scripts/google_report.py` when the user asks for one.
+- A PDF via `claude-seo run google_report.py` when the user asks for one.
 - The smallest implementation of the highest-leverage recommendation,
   not the full plan.
 

--- a/tests/test_commoncrawl_graph.py
+++ b/tests/test_commoncrawl_graph.py
@@ -1,0 +1,87 @@
+"""
+Tests for scripts/commoncrawl_graph.py.
+
+Focus: cache-path construction. `--release` reached `_get_cache_path`
+completely unsanitised and the result is opened for writing in `_save_cache`,
+so `--release ../../../../tmp/x` wrote outside the cache directory. The same
+value is also interpolated into a download URL by `_graph_file_url`, so it is
+rejected at the CLI boundary rather than silently rewritten -- otherwise the
+cache key would disagree with what was actually fetched.
+
+No network: only the pure path/validation helpers are exercised.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import commoncrawl_graph as ccg  # noqa: E402
+
+
+def _inside_cache_dir(path: str) -> bool:
+    root = os.path.realpath(ccg.get_cache_dir())
+    resolved = os.path.realpath(path)
+    return resolved == root or resolved.startswith(root + os.sep)
+
+
+# ---------------------------------------------------------------------------
+# path traversal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "domain,release",
+    [
+        ("example.com", "../../../../tmp/pwned"),
+        ("example.com", ".."),
+        ("../../../../tmp/evil", "cc-main-2026-jan-feb-mar"),
+        ("../..", ".."),
+        ("example.com/../../etc", "cc-main-2026-jan-feb-mar"),
+    ],
+)
+def test_cache_path_never_escapes_the_cache_dir(domain, release):
+    assert _inside_cache_dir(ccg._get_cache_path(domain, release, "combined"))
+
+
+def test_cache_path_preserves_legitimate_values():
+    """Sanitising must not mangle real inputs, or every cache miss forever."""
+    path = ccg._get_cache_path("example.com", "cc-main-2026-jan-feb-mar", "combined")
+    assert os.path.basename(path) == "example.com-cc-main-2026-jan-feb-mar-combined.json"
+    assert _inside_cache_dir(path)
+
+
+def test_safe_cache_component_collapses_dot_runs_and_separators():
+    assert ".." not in ccg._safe_cache_component("../../etc/passwd")
+    assert "/" not in ccg._safe_cache_component("a/b/c")
+    assert os.sep not in ccg._safe_cache_component("a\\b")
+    # Never returns empty, which would produce a path like "-release-type.json".
+    assert ccg._safe_cache_component("...") != ""
+    assert ccg._safe_cache_component("") != ""
+
+
+# ---------------------------------------------------------------------------
+# release validation (also guards the URL built by _graph_file_url)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "release",
+    ["cc-main-2026-jan-feb-mar", "cc-main-2024-oct-nov-dec", "CC-MAIN-2024-33", "a_b.c-1"],
+)
+def test_release_pattern_accepts_real_release_ids(release):
+    assert ccg._RELEASE_RE.match(release)
+
+
+@pytest.mark.parametrize(
+    "release",
+    ["../../../../tmp/pwned", "..", "a/../b", "a..b", "with space", "", "a/b", "x\ty"],
+)
+def test_release_pattern_rejects_traversal_and_junk(release):
+    assert not ccg._RELEASE_RE.match(release)

--- a/tests/test_domain_history.py
+++ b/tests/test_domain_history.py
@@ -1,0 +1,106 @@
+"""
+Tests for scripts/domain_history.py.
+
+Focus: the WHOIS referral chain in `_socket_whois`. It asks IANA for the
+authoritative WHOIS server and then connects to whatever host IANA names. WHOIS
+is plaintext on port 43, so anyone able to tamper with that response can inject
+a `refer:` line pointing at an internal address and turn the fallback into a
+port-43 probe of the operator's private network. The referral is now resolved
+and validated through url_safety before being dialled.
+
+No network: socket.create_connection is stubbed throughout.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import domain_history as dh  # noqa: E402
+
+
+class _FakeSock:
+    """Minimal stand-in for a connected socket that yields one payload."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._drained = False
+        self.sent = b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def sendall(self, data: bytes) -> None:
+        self.sent += data
+
+    def recv(self, _n: int) -> bytes:
+        if self._drained:
+            return b""
+        self._drained = True
+        return self._payload
+
+
+def _stub_chain(monkeypatch, referral_line: bytes, referral_payload: bytes):
+    """Stub the IANA hop and the referral hop, recording every dial."""
+    attempts: list[tuple] = []
+
+    def fake_connection(address, timeout=None):
+        attempts.append(address)
+        if address[0] == "whois.iana.org":
+            return _FakeSock(referral_line)
+        return _FakeSock(referral_payload)
+
+    monkeypatch.setattr(dh.socket, "create_connection", fake_connection)
+    return attempts
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        b"refer: 169.254.169.254\n",   # cloud metadata endpoint
+        b"refer: 127.0.0.1\n",         # loopback
+        b"refer: 10.0.0.5\n",          # RFC1918
+        b"refer: localhost\n",
+    ],
+)
+def test_hostile_referral_is_never_dialled(monkeypatch, hostile):
+    attempts = _stub_chain(monkeypatch, hostile, b"SHOULD NOT BE REACHED\n")
+    result = dh._socket_whois("example.com")
+
+    dialled = [host for host, _port in attempts]
+    assert dialled == ["whois.iana.org"], f"followed a hostile referral: {dialled}"
+    assert "SHOULD NOT BE REACHED" not in (result or "")
+    # IANA's own answer is still returned -- a bad referral degrades the
+    # lookup, it does not blank it.
+    assert "refer:" in (result or "")
+
+
+def test_legitimate_referral_is_still_followed(monkeypatch):
+    """The guard must not break the normal path."""
+    attempts = _stub_chain(
+        monkeypatch,
+        b"refer: whois.verisign-grs.com\n",
+        b"Creation Date: 1995-08-14T04:00:00Z\n",
+    )
+    result = dh._socket_whois("example.com")
+
+    assert len(attempts) == 2, "referral hop did not happen"
+    assert "Creation Date" in (result or "")
+
+
+def test_direct_iana_answer_needs_no_referral(monkeypatch):
+    """.arpa and friends come back without a refer: line."""
+    attempts = _stub_chain(monkeypatch, b"domain: ARPA\nstatus: ACTIVE\n", b"unused")
+    result = dh._socket_whois("in-addr.arpa")
+
+    assert len(attempts) == 1
+    assert "ARPA" in (result or "")

--- a/tests/test_phase_j_executable.py
+++ b/tests/test_phase_j_executable.py
@@ -352,6 +352,34 @@ def test_audit_still_scores_real_html(monkeypatch):
     assert report["score"] is not None
 
 
+def test_audit_flags_a_score_computed_without_an_a11y_tree(monkeypatch):
+    """A missing accessibility tree must not read as a clean result.
+
+    render_page() treats the snapshot as best-effort and swallows failures into
+    None. score() then skips every a11y deduction, so the same page scores 75
+    with a tree and 100 without one. The score has to declare that it only
+    covers half the analysis (issue #210, Bug 2).
+    """
+    html = "<html><body><nav><a href='/'>home</a></nav><main>hi</main></body></html>"
+    monkeypatch.setattr(
+        agent_ux_check, "render_page", lambda *a, **k: _fake_page(html, a11y=None)
+    )
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["partial"] is True
+    assert any("accessibility tree unavailable" in i for i in report["issues"])
+
+
+def test_audit_does_not_flag_partial_when_the_tree_is_present(monkeypatch):
+    html = "<html><body><nav><a href='/'>home</a></nav><main>hi</main></body></html>"
+    tree = {"role": "WebArea", "name": "t", "children": [{"role": "link", "name": "home"}]}
+    monkeypatch.setattr(
+        agent_ux_check, "render_page", lambda *a, **k: _fake_page(html, a11y=tree)
+    )
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["partial"] is False
+    assert not any("accessibility tree unavailable" in i for i in report["issues"])
+
+
 # ---------------------------------------------------------------------------
 # render_page extension
 # ---------------------------------------------------------------------------

--- a/tests/test_phase_j_executable.py
+++ b/tests/test_phase_j_executable.py
@@ -313,6 +313,45 @@ def test_score_deducts_for_div_onclick_and_unnamed_interactives():
     assert any("accessible name" in issue for issue in scored["issues"])
 
 
+def _fake_page(content, *, error=None, a11y=None):
+    """Minimal render_page() result stub for audit() tests."""
+    return {
+        "url": "https://example.test/",
+        "status_code": 200,
+        "error": error,
+        "content": content,
+        "accessibility_tree": a11y,
+    }
+
+
+def test_audit_refuses_score_on_empty_html(monkeypatch):
+    # A successful fetch that returns an empty document must NOT be scored.
+    # Every count in analyze_html() collapses to 0, which score() would read as
+    # a clean page and reward with 90/100 (issue #210).
+    monkeypatch.setattr(agent_ux_check, "render_page", lambda *a, **k: _fake_page(""))
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["score"] is None
+    assert report["render_error"]
+
+
+def test_audit_refuses_score_on_whitespace_only_html(monkeypatch):
+    monkeypatch.setattr(
+        agent_ux_check, "render_page", lambda *a, **k: _fake_page("   \n\t  ")
+    )
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["score"] is None
+    assert report["render_error"]
+
+
+def test_audit_still_scores_real_html(monkeypatch):
+    # The empty guard must not swallow genuine documents.
+    html = "<html><body><nav><a href='/'>home</a></nav><main>hi</main></body></html>"
+    monkeypatch.setattr(agent_ux_check, "render_page", lambda *a, **k: _fake_page(html))
+    report = agent_ux_check.audit("https://example.test/")
+    assert report["render_error"] is None
+    assert report["score"] is not None
+
+
 # ---------------------------------------------------------------------------
 # render_page extension
 # ---------------------------------------------------------------------------

--- a/tests/test_render_page.py
+++ b/tests/test_render_page.py
@@ -461,3 +461,100 @@ def test_render_page_result_dict_has_all_documented_fields() -> None:
         "render_diagnostics", "render_ms", "mode_used", "error",
     }
     assert set(result.keys()) == expected_fields
+
+
+# ---------------------------------------------------------------------------
+# --json field handling (issues #246, #250)
+# ---------------------------------------------------------------------------
+
+
+def _cli_result(monkeypatch, capsys, argv, *, extracted_text="", content=""):
+    """Run render_page._cli() with a stubbed render_page() and return stdout."""
+    payload = {
+        "url": "https://example.test/", "status_code": 200, "error": None,
+        "content": content, "raw_content": content,
+        "extracted_text": extracted_text, "is_spa": False,
+        "mode_used": "never", "render_ms": 0, "headers": {},
+        "accessibility_tree": None, "publication_date": None,
+        "render_engine": "raw", "render_diagnostics": [], "console_errors": [],
+    }
+    monkeypatch.setattr(render_page, "render_page", lambda *a, **k: dict(payload))
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit):
+        render_page._cli()
+    return capsys.readouterr().out
+
+
+def test_json_does_not_truncate_extracted_text_by_default(monkeypatch, capsys):
+    """extracted_text is what every scoring path reads -- it must arrive whole.
+
+    It was capped at 500 characters, so a 2000-word page reached the E-E-A-T,
+    thin-content and word-count logic as ~70 words. Every real page looked
+    thin (issue #246).
+    """
+    body = " ".join(f"word{i}" for i in range(2000))
+    out = _cli_result(
+        monkeypatch, capsys,
+        ["render_page.py", "https://example.test/", "--json"],
+        extracted_text=body, content=f"<html><body>{body}</body></html>",
+    )
+    payload = json.loads(out)
+    assert len(payload["extracted_text"].split()) == 2000
+    assert payload["truncation"]["extracted_text"] is False
+
+
+def test_json_still_truncates_raw_html_fields(monkeypatch, capsys):
+    """Raw HTML stays capped so agents don't pipe megabytes across stdio."""
+    html = "<html><body>" + ("x" * 5000) + "</body></html>"
+    payload = json.loads(_cli_result(
+        monkeypatch, capsys,
+        ["render_page.py", "https://example.test/", "--json"],
+        extracted_text="short", content=html,
+    ))
+    assert len(payload["content"]) <= 505
+    assert payload["truncation"]["content"] is True
+
+
+def test_json_truncation_map_is_always_present(monkeypatch, capsys):
+    """A consumer must be able to tell a short page from a cut one.
+
+    Before, truncation was only inferable from a trailing ellipsis, which is
+    indistinguishable from a page that genuinely ends in one.
+    """
+    payload = json.loads(_cli_result(
+        monkeypatch, capsys,
+        ["render_page.py", "https://example.test/", "--json"],
+        extracted_text="tiny", content="<html></html>",
+    ))
+    assert payload["truncation"] == {
+        "content": False, "raw_content": False, "extracted_text": False,
+    }
+
+
+def test_max_text_caps_extracted_text_and_flags_it(monkeypatch, capsys):
+    body = " ".join(f"word{i}" for i in range(2000))
+    payload = json.loads(_cli_result(
+        monkeypatch, capsys,
+        ["render_page.py", "https://example.test/", "--json", "--max-text", "500"],
+        extracted_text=body, content="<html></html>",
+    ))
+    assert len(payload["extracted_text"]) <= 503
+    assert payload["truncation"]["extracted_text"] is True
+
+
+def test_output_composes_with_json(monkeypatch, capsys, tmp_path):
+    """--json --output must write the file (issue #250).
+
+    The JSON branch used to sys.exit() before the --output block ran, so the
+    documented "use --output when you need the full document" escape hatch
+    silently produced nothing.
+    """
+    target = tmp_path / "page.html"
+    html = "<html><body>full document</body></html>"
+    _cli_result(
+        monkeypatch, capsys,
+        ["render_page.py", "https://example.test/", "--json", "--output", str(target)],
+        extracted_text="t", content=html,
+    )
+    assert target.exists(), "--output produced no file when combined with --json"
+    assert target.read_text(encoding="utf-8") == html

--- a/tests/test_schema_hook_policy.py
+++ b/tests/test_schema_hook_policy.py
@@ -7,6 +7,7 @@ confirmed. Genuinely deprecated types must still block the edit (exit 2).
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -32,3 +33,41 @@ def test_faqpage_not_blocked(tmp_path):
 
 def test_deprecated_type_still_blocks(tmp_path):
     assert _run(tmp_path, "ClaimReview") == 2
+
+
+def _run_with_encoding(tmp_path: Path, schema_type: str, encoding: str):
+    """Run the hook with a console encoding forced via PYTHONIOENCODING."""
+    html = tmp_path / "page.html"
+    html.write_text(
+        '<html><head><script type="application/ld+json">\n'
+        f'{{"@context":"https://schema.org","@type":"{schema_type}"}}\n'
+        "</script></head></html>",
+        encoding="utf-8",
+    )
+    env = dict(os.environ, PYTHONIOENCODING=encoding)
+    return subprocess.run(
+        [sys.executable, str(HOOK), str(html)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_blocking_finding_survives_a_cp1252_console(tmp_path):
+    """A non-UTF-8 console must not turn a blocking finding into a crash.
+
+    The banners contain non-ASCII markers. Encoding them to cp1252 raised
+    UnicodeEncodeError *before* sys.exit(2) ran, so the hook died with exit 1 —
+    which the harness reads as "warnings only, proceed". The deprecated type was
+    therefore silently non-blocking on Windows, not merely ugly (issue #186).
+    """
+    result = _run_with_encoding(tmp_path, "ClaimReview", "cp1252")
+    assert result.returncode == 2, (
+        f"blocking exit code lost on a cp1252 console: {result.stderr}"
+    )
+    assert "UnicodeEncodeError" not in result.stderr
+    assert "ClaimReview" in result.stdout
+
+
+def test_clean_schema_still_passes_on_a_cp1252_console(tmp_path):
+    assert _run_with_encoding(tmp_path, "FAQPage", "cp1252").returncode == 0


### PR DESCRIPTION
## Summary

A skeptical review of all 26 open PRs and 12 open issues, plus fixes for the confirmed bugs that had no working PR behind them.

Every claim here was verified against the code rather than the description: PR branches were fetched and their own tests executed, merges tested pairwise, and external claims checked against primary sources.

**The connecting theme is silent failure.** In each case the tool reported success while doing less than it claimed — the failure mode that is hardest to notice and most corrosive to trust in an auditing tool.

### Fixes

- **`agent_ux_check.py` scored empty documents 90/100 (#210).** `audit()` returned early only when `render_page()` reported an error, so a successful fetch returning an empty body flowed into `score()`. Every signal `analyze_html()` counts collapses to zero on an empty document, which read as a clean page. Now reported as a render error.
- **`agent_ux_check.py` inflated scores when the a11y tree was missing (#210, Bug 2).** The snapshot is best-effort and failures are swallowed to `None`, after which `score()` skips every accessibility deduction: the same page scores **75** with a tree and **100** without one, with nothing indicating half the analysis never ran. Now reports `partial: true` plus an explicit issue, and the CLI prints `(partial)`.
  - Note: the issue's literal claim that the tree is "never captured" is inaccurate — it *is* captured at `render_page.py:441` under the mode `audit()` uses. The defect is the silent degradation beside it.
- **`validate-schema.py` failed open on Windows (#186).** Encoding the banner markers to cp1252 raised `UnicodeEncodeError` *before* `sys.exit(2)` ran, so the hook exited **1** — warnings-only. A blocking schema finding was therefore silently non-blocking on any cp1252 console. Only the error handler is relaxed; forcing UTF-8 onto such a console would produce mojibake instead.

### Added

- **`compile-check` CI job** covering every tracked `.py` file. This **widens** existing coverage rather than adding something missing: the current `lint` job already compiles `git ls-files 'scripts/*.py'` (53 files). This one covers 96 — adding **35 under `tests/`, 7 under `extensions/banana/scripts/`, and `hooks/validate-schema.py`**, none of which were checked before. Both files this PR edits outside `scripts/` fall in that gap, as do the files #197/#203 touch. Dependency-free, so it cannot fail for environment reasons.

### Changed

- **20 instructional script references across 13 files now use `claude-seo run` (#208).** Applied as explicit one-occurrence-each replacements, not a pattern rewrite: most of the 25 references are prose, and a blind substitution is precisely what left #198 unparseable. Five descriptive references that explain internals are deliberately unchanged.

### Docs

- `docs/REVIEW-open-prs-issues-2026-08.md` — per-PR and per-issue verdicts with reproducible evidence, a conflict map, and a suggested merge order.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [x] Documentation update
- [ ] Refactor / code quality
- [x] Other — CI coverage (Python syntax gate)

## Checklist

- [ ] Tested with a real URL before submitting — **not done, and stated plainly:** outbound network is restricted in this environment. All behaviour is covered by unit tests with mocked fetches instead, and the three suite failures below are network-bound in exactly this way.
- [x] SKILL.md files stay under 500 lines — 219 / 254 / 286 for the three modified.
- [x] Python scripts output JSON — `agent_ux_check.py --json` unchanged, with `partial` added to the payload.
- [x] Reference files stay under 200 lines — 119 and 107 for two of the three. `thinking-framework.md` is **238**, but it is 238 on `main` too; my edits replace 3 lines for a net change of zero. Pre-existing, flagged rather than silently inherited.
- [x] `set -euo pipefail` used in any new shell scripts — the new CI step uses `set -uo pipefail` deliberately, **without `-e`**: it collects every failing file to report them together, which `-e` would abort on the first one.
- [x] CHANGELOG.md updated with the change.

## Verification

Full suite, nothing excluded, with `main` as the control:

| | Passed | Failed |
|---|---|---|
| `main` | 407 | 3 |
| this branch | **414** | 3 |

Exactly **+7 tests, all passing, zero new failures.** The 3 failures are byte-identical on both branches and network-bound (an `example.com` fetch; two `sync_flow` tests receiving HTTP 403 through the sandbox proxy).

Each new regression test was verified to **fail without its corresponding fix** — a test that passes either way proves nothing.

Also clean: `consistency_check.py` (0 errors), `portability_check.py` (0 errors, 0 warnings), and the new syntax gate.

## Correction, and a finding that outranks this PR

An earlier version of this description claimed nothing in CI caught unparseable Python. **That was wrong** — the `lint` job would have caught #198's `SyntaxError`, since `scripts/bing_webmaster.py` matches its glob. Corrected above.

Investigating why it didn't surfaced something more important:

```
PR #198 check runs: 0
PR #242 check runs: 0
PR #182 check runs: 0
```

**No fork-based PR in this repo is running CI at all**, while this same-repo PR got its four checks within seconds. That is consistent with GitHub's "require approval for all external contributors" setting for fork workflow runs. It explains how both #198's `SyntaxError` and #242's failing tests reached review looking clean, and it means external contributors currently get no automated feedback whatsoever.

Worth checking Settings → Actions → Fork pull request workflows. That change would likely do more for contribution quality than anything in this PR.

## Notes for the reviewer

- **This PR is how the new job gets exercised at all.** Workflows trigger only on `push: [main]` and `pull_request: [main]`, so a feature branch never runs CI on its own.
- **No version bump.** `plugin.json` stays at `2.2.4` and the changelog entries sit under `[Unreleased]`, since CLAUDE.md states `main` reflects released history — whether this becomes `2.2.5` is a release decision, not mine.
- **The `aimh` remote is not configured in this environment**, so the documented private-remote-first promote sequence could not be followed from here.
- The one `consistency_check` warning is the review doc itself being unreferenced from the docs tree.