### PR TITLE
feat: add optional Atlas Cloud SEO image extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Optional Atlas Cloud SEO image generation extension with a standard-library
+  client, one-shot submission, bounded polling, safe media downloads, presets,
+  setup documentation, and contract tests.
+
 ## [2.2.4] - 2026-07-20
 
 Community maintenance release following a full review of every open issue and pull request.

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/uninst
 
 ## Extensions
 
-Optional MCP servers add live data to the audit pipeline. Claude SEO ships extensions for 8 servers; the plugin core works without any of them.
+Optional services add live data and generation capabilities to the audit pipeline. Claude SEO ships 9 extensions; the plugin core works without any of them.
 
 ### DataForSEO
 
@@ -406,6 +406,19 @@ SEO image generation (OG previews, blog heroes, product photos, infographics) vi
 ```
 
 Full Banana docs: [extensions/banana/README.md](extensions/banana/README.md).
+
+### Atlas Cloud: SEO image generation
+
+Generate SEO images through an asynchronous API client with single-submit semantics,
+bounded polling, and credential-free media downloads.
+
+```bash
+./extensions/atlas/install.sh
+export ATLASCLOUD_API_KEY="..."
+/seo atlas-image-gen og "Professional SaaS dashboard"
+```
+
+Full Atlas setup: [extensions/atlas/README.md](extensions/atlas/README.md).
 
 ### Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse (new in v2)
 

--- a/extensions/atlas/README.md
+++ b/extensions/atlas/README.md
@@ -1,0 +1,33 @@
+# Atlas Cloud Image Generation Extension
+
+This optional Claude SEO extension adds an executable Atlas Cloud workflow for
+SEO images such as social previews, blog heroes, product images, and
+infographic bases.
+
+## Install
+
+```bash
+./extensions/atlas/install.sh
+export ATLASCLOUD_API_KEY="..."
+```
+
+The installer copies the skill, script, and reference file. It does not store
+the API key.
+
+## Generate
+
+```bash
+claude-seo run --extension atlas generate.py \
+  --prompt "Editorial illustration for a technical SEO guide" \
+  --size '1200*630'
+```
+
+The client submits one asynchronous generation request, polls the returned
+prediction with bounded backoff, and downloads the image without forwarding
+the API key. See `docs/ATLAS-SETUP.md` for setup and troubleshooting.
+
+## Uninstall
+
+```bash
+./extensions/atlas/uninstall.sh
+```

--- a/extensions/atlas/docs/ATLAS-SETUP.md
+++ b/extensions/atlas/docs/ATLAS-SETUP.md
@@ -1,0 +1,49 @@
+# Atlas Cloud Extension Setup
+
+## Requirements
+
+- Claude SEO installed
+- Python 3.10 or newer through the managed Claude SEO runtime
+- An Atlas Cloud API key exposed as `ATLASCLOUD_API_KEY`
+- HTTPS access to `api.atlascloud.ai` and Atlas output hosts
+
+## Install
+
+```bash
+./extensions/atlas/install.sh
+export ATLASCLOUD_API_KEY="..."
+```
+
+Persist the environment variable using your shell's secret manager or runtime
+configuration. Do not put the key in the repository or pass it on the command
+line.
+
+## Verify Without Generation
+
+```bash
+test -n "$ATLASCLOUD_API_KEY" && echo "Atlas Cloud key is configured"
+claude-seo doctor
+```
+
+The verification above does not submit a paid generation request.
+
+## First Generation
+
+```bash
+claude-seo run --extension atlas generate.py \
+  --prompt "Minimal editorial illustration of a website performance audit" \
+  --size '1200*630'
+```
+
+Each invocation performs one paid generation POST. A failed POST is not
+retried automatically. Result polling uses bounded GET requests.
+
+## Troubleshooting
+
+- `ATLASCLOUD_API_KEY is not set`: export the key in the same shell.
+- HTTP 401/403: verify the key and account access; do not print the key.
+- HTTP 429/5xx: stop and decide explicitly whether to make a new request.
+- Poll timeout: inspect the prediction separately before creating another paid
+  request.
+- Output host rejected: do not bypass the allowlist; confirm the current Atlas
+  output domain before updating the client.

--- a/extensions/atlas/install.sh
+++ b/extensions/atlas/install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+    SKILL_DIR="${HOME}/.claude/skills/seo-atlas-image-gen"
+    SEO_SKILL_DIR="${HOME}/.claude/skills/seo"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    if [ ! -d "${SEO_SKILL_DIR}" ]; then
+        echo "x Claude SEO is not installed."
+        echo "  Install Claude SEO before installing this extension."
+        exit 1
+    fi
+
+    if [ -f "${SCRIPT_DIR}/skills/seo-atlas-image-gen/SKILL.md" ]; then
+        SOURCE_DIR="${SCRIPT_DIR}"
+    elif [ -f "${SCRIPT_DIR}/extensions/atlas/skills/seo-atlas-image-gen/SKILL.md" ]; then
+        SOURCE_DIR="${SCRIPT_DIR}/extensions/atlas"
+    else
+        echo "x Cannot find the Atlas extension source files."
+        exit 1
+    fi
+
+    echo "-> Installing Atlas Cloud SEO image generation skill..."
+    mkdir -p "${SKILL_DIR}/scripts" "${SKILL_DIR}/references"
+    cp "${SOURCE_DIR}/skills/seo-atlas-image-gen/SKILL.md" "${SKILL_DIR}/SKILL.md"
+    cp "${SOURCE_DIR}/scripts/"*.py "${SKILL_DIR}/scripts/"
+    cp "${SOURCE_DIR}/references/"*.md "${SKILL_DIR}/references/"
+
+    for installed_doc in "${SKILL_DIR}/SKILL.md" "${SKILL_DIR}/references/"*.md; do
+        [ -f "${installed_doc}" ] || continue
+        temp_doc="${installed_doc}.claude-seo-tmp"
+        sed -e 's#claude-seo run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
+            -e 's#claude-seo setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
+            -e 's#claude-seo doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
+            "${installed_doc}" > "${temp_doc}"
+        mv "${temp_doc}" "${installed_doc}"
+    done
+
+    echo "v Atlas Cloud extension installed."
+    echo "  Export ATLASCLOUD_API_KEY before generating an image."
+    echo "  Usage: /seo atlas-image-gen og \"Professional SaaS dashboard\""
+}
+
+main "$@"

--- a/extensions/atlas/references/seo-image-presets.md
+++ b/extensions/atlas/references/seo-image-presets.md
@@ -1,0 +1,48 @@
+# Atlas Cloud SEO Image Presets
+
+These presets are prompt and output defaults. Confirm current model support
+through the Atlas Cloud model catalog before using a different model or field.
+
+## OG / Social Preview
+
+- Size: `1200*630`
+- Model: `qwen-image-3.0/text-to-image`
+- Composition: one clear subject, high contrast, quiet area for later title text
+- Prompt suffix: `editorial social preview, clean hierarchy, no embedded text`
+
+## Blog Hero
+
+- Size: `1792*1024`
+- Model: `qwen-image-3.0/text-to-image`
+- Composition: wide editorial framing, visual depth, important details near center
+- Prompt suffix: `widescreen editorial illustration, no logo, no embedded text`
+
+## Product Image
+
+- Size: `1536*1024`
+- Model: `qwen-image-3.0/text-to-image`
+- Composition: accurate product silhouette, clean background, controlled lighting
+- Prompt suffix: `professional product photography, accurate materials, clean background`
+
+## Infographic Base
+
+- Size: `1024*1536`
+- Model: `qwen-image-3.0/text-to-image`
+- Composition: simple sections, icons, generous space for real typography added later
+- Prompt suffix: `structured infographic base, minimal generated text, clear visual grouping`
+
+## Square Social Image
+
+- Size: `1024*1024`
+- Model: `qwen-image-3.0/text-to-image`
+- Composition: centered focal point, bold silhouette, legible at thumbnail size
+- Prompt suffix: `square social image, centered composition, no embedded text`
+
+## Prompt Template
+
+```text
+[asset role] for [page topic]. Subject: [concrete subject]. Composition:
+[camera/framing and safe area]. Style: [specific visual style]. Palette: [brand
+colors]. Lighting: [lighting]. Avoid: logos, watermarks, unreadable text, and
+unrelated interface elements.
+```

--- a/extensions/atlas/scripts/generate.py
+++ b/extensions/atlas/scripts/generate.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Generate SEO images through the Atlas Cloud asynchronous image API.
+
+The client uses one POST per invocation, bounded GET polling, and a
+credential-free download request. It intentionally depends only on the Python
+standard library so it can run inside the managed Claude SEO runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlparse
+
+API_BASE = "https://api.atlascloud.ai/api/v1"
+USER_AGENT = "claude-seo-atlas-extension/2.2.4"
+DEFAULT_MODEL = "qwen-image-3.0/text-to-image"
+DEFAULT_SIZE = "1024*1024"
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_IMAGE_BYTES = 30 * 1024 * 1024
+TERMINAL_SUCCESS = {"completed", "succeeded", "success"}
+TERMINAL_FAILURE = {"failed", "canceled", "cancelled", "error"}
+ALLOWED_OUTPUT_HOSTS = {
+    "atlas-img.oss-accelerate-overseas.aliyuncs.com",
+    "cdn.atlascloud.ai",
+    "dashscope-a717.oss-accelerate.aliyuncs.com",
+}
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Reject redirects so credentials and download policy cannot drift."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        raise urllib.error.HTTPError(req.full_url, code, "redirect blocked", headers, fp)
+
+
+_OPENER = urllib.request.build_opener(NoRedirect)
+
+
+def _urlopen(request: urllib.request.Request, timeout: float):
+    return _OPENER.open(request, timeout=timeout)
+
+
+def _emit_error(
+    message: str,
+    *,
+    status: int | None = None,
+    prediction_id: str | None = None,
+) -> None:
+    payload: dict[str, Any] = {"error": True, "message": message}
+    if status is not None:
+        payload["status"] = status
+    if prediction_id is not None:
+        payload["prediction_id"] = prediction_id
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _read_limited(response, limit: int) -> bytes:  # noqa: ANN001
+    data = response.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError(f"response exceeds {limit} bytes")
+    return data
+
+
+def _request_json(
+    method: str,
+    url: str,
+    *,
+    api_key: str,
+    body: dict[str, Any] | None = None,
+    timeout: float = 60,
+) -> dict[str, Any]:
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": USER_AGENT,
+    }
+    data = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with _urlopen(request, timeout) as response:
+            raw = _read_limited(response, MAX_RESPONSE_BYTES)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Atlas Cloud returned HTTP {exc.code}") from None
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Atlas Cloud request failed: {exc.reason}") from None
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Atlas Cloud returned invalid JSON") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError("Atlas Cloud returned an unexpected response")
+    if value.get("code") not in (None, 0, 200):
+        raise RuntimeError(f"Atlas Cloud request failed with code {value.get('code')}")
+    data_value = value.get("data", value)
+    if not isinstance(data_value, dict):
+        raise RuntimeError("Atlas Cloud response data is not an object")
+    return data_value
+
+
+def _prediction_id(value: dict[str, Any]) -> str:
+    prediction_id = value.get("id") or value.get("prediction_id")
+    if not isinstance(prediction_id, str) or not prediction_id.strip():
+        raise RuntimeError("Atlas Cloud response did not include a prediction id")
+    return prediction_id.strip()
+
+
+def submit_prediction(api_key: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    """Submit exactly one generation request."""
+    return _request_json(
+        "POST",
+        f"{API_BASE}/model/generateImage",
+        api_key=api_key,
+        body=payload,
+        timeout=timeout,
+    )
+
+
+def poll_prediction(
+    api_key: str,
+    prediction_id: str,
+    *,
+    max_polls: int,
+    poll_seconds: float,
+    timeout: float,
+) -> dict[str, Any]:
+    encoded_id = quote(prediction_id, safe="")
+    for attempt in range(max_polls):
+        if attempt:
+            time.sleep(min(poll_seconds * (1.5 ** min(attempt - 1, 4)), 15.0))
+        value = _request_json(
+            "GET",
+            f"{API_BASE}/model/prediction/{encoded_id}",
+            api_key=api_key,
+            timeout=timeout,
+        )
+        status = str(value.get("status", "")).lower()
+        if status in TERMINAL_SUCCESS:
+            return value
+        if status in TERMINAL_FAILURE:
+            raise RuntimeError(f"Atlas Cloud prediction ended with status {status}")
+    raise TimeoutError(f"prediction did not complete after {max_polls} polls")
+
+
+def _validate_output_url(value: str) -> str:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not host:
+        raise ValueError("output URL must use HTTPS")
+    if host not in ALLOWED_OUTPUT_HOSTS and not host.endswith(".atlascloud.ai"):
+        raise ValueError(f"output host is not allowed: {host}")
+    if parsed.username or parsed.password or parsed.port not in (None, 443):
+        raise ValueError("output URL contains disallowed authority components")
+    return value
+
+
+def _image_extension(data: bytes) -> str:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return ".png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return ".jpg"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return ".webp"
+    if len(data) >= 12 and data[4:12] in {b"ftypavif", b"ftypavis"}:
+        return ".avif"
+    raise ValueError("downloaded output is not a supported image")
+
+
+def download_image(url: str, destination: Path, timeout: float) -> Path:
+    safe_url = _validate_output_url(url)
+    request = urllib.request.Request(
+        safe_url,
+        headers={
+            "Accept": "image/avif,image/webp,image/png,image/jpeg",
+            "User-Agent": USER_AGENT,
+        },
+        method="GET",
+    )
+    try:
+        with _urlopen(request, timeout) as response:
+            data = _read_limited(response, MAX_IMAGE_BYTES)
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"image download returned HTTP {exc.code}") from None
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"image download failed: {exc.reason}") from None
+    extension = _image_extension(data)
+    output = destination.with_suffix(extension)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temp = output.with_name(f".{output.name}.tmp-{os.getpid()}")
+    try:
+        temp.write_bytes(data)
+        temp.replace(output)
+    finally:
+        temp.unlink(missing_ok=True)
+    return output.resolve()
+
+
+def _output_base(raw: str | None) -> Path:
+    if raw:
+        return Path(raw).expanduser()
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return Path.home() / "Documents" / "claude-seo" / "atlas-generated" / f"atlas-{timestamp}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate an SEO image with Atlas Cloud")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--size", default=DEFAULT_SIZE, help="Width*height, for example 1200*630")
+    parser.add_argument("--count", type=int, default=1, choices=range(1, 5), metavar="1-4")
+    parser.add_argument("--negative-prompt")
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--no-prompt-extend", action="store_true")
+    parser.add_argument("--output", help="Output file base or path")
+    parser.add_argument("--no-download", action="store_true")
+    parser.add_argument("--max-polls", type=int, default=30)
+    parser.add_argument("--poll-seconds", type=float, default=3.0)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    api_key = os.environ.get("ATLASCLOUD_API_KEY", "").strip()
+    if not api_key:
+        _emit_error("ATLASCLOUD_API_KEY is not set")
+        return 2
+    if not 1 <= args.max_polls <= 60:
+        _emit_error("--max-polls must be between 1 and 60")
+        return 2
+    if not 0 <= args.poll_seconds <= 30:
+        _emit_error("--poll-seconds must be between 0 and 30")
+        return 2
+    if not 1 <= args.timeout <= 180:
+        _emit_error("--timeout must be between 1 and 180 seconds")
+        return 2
+
+    payload: dict[str, Any] = {
+        "model": args.model,
+        "prompt": args.prompt,
+        "size": args.size,
+        "n": args.count,
+        "prompt_extend": not args.no_prompt_extend,
+    }
+    if args.negative_prompt:
+        payload["negative_prompt"] = args.negative_prompt
+    if args.seed is not None:
+        if not 0 <= args.seed <= 2_147_483_647:
+            _emit_error("--seed must be between 0 and 2147483647")
+            return 2
+        payload["seed"] = args.seed
+
+    prediction_id: str | None = None
+    try:
+        submitted = submit_prediction(api_key, payload, args.timeout)
+        prediction_id = _prediction_id(submitted)
+        completed = poll_prediction(
+            api_key,
+            prediction_id,
+            max_polls=args.max_polls,
+            poll_seconds=args.poll_seconds,
+            timeout=args.timeout,
+        )
+        outputs = completed.get("outputs")
+        if (
+            not isinstance(outputs, list)
+            or not outputs
+            or not all(isinstance(x, str) for x in outputs)
+        ):
+            raise RuntimeError("completed prediction did not include output URLs")
+        safe_outputs = [_validate_output_url(value) for value in outputs]
+        paths: list[str] = []
+        if not args.no_download:
+            base = _output_base(args.output)
+            for index, url in enumerate(safe_outputs, start=1):
+                target = base if len(safe_outputs) == 1 else base.with_name(f"{base.name}-{index}")
+                paths.append(str(download_image(url, target, args.timeout)))
+        result = {
+            "prediction_id": prediction_id,
+            "status": str(completed.get("status", "completed")),
+            "model": args.model,
+            "size": args.size,
+            "outputs": safe_outputs,
+            "paths": paths,
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except (RuntimeError, TimeoutError, ValueError, OSError) as exc:
+        _emit_error(str(exc), prediction_id=prediction_id)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/atlas/skills/seo-atlas-image-gen/SKILL.md
+++ b/extensions/atlas/skills/seo-atlas-image-gen/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: seo-atlas-image-gen
+description: >
+  Generate SEO images through Atlas Cloud, including social previews, blog
+  heroes, product images, infographics, and custom visuals. Use when the user
+  asks for Atlas Cloud image generation or an Atlas-backed SEO image workflow.
+argument-hint: "[og|hero|product|infographic|custom] <description>"
+user-invocable: true
+license: MIT
+compatibility: "Requires ATLASCLOUD_API_KEY and outbound HTTPS access"
+metadata:
+  author: binyangzhu000-sudo
+  original_author: binyangzhu000-sudo
+  version: "2.2.4"
+  category: seo
+---
+
+# Atlas Cloud SEO Image Generation
+
+Generate an SEO-ready image with Atlas Cloud while keeping each paid request
+explicit. The bundled client performs one generation POST, bounded result
+polling, and a credential-free media download.
+
+## Prerequisites
+
+Install the extension and export an API key in the current shell:
+
+```bash
+./extensions/atlas/install.sh
+export ATLASCLOUD_API_KEY="..."
+```
+
+Do not print, persist, or place the key in command arguments. Confirm the user
+wants a paid generation before running the command.
+
+## Command
+
+```bash
+claude-seo run --extension atlas generate.py \
+  --prompt "Editorial illustration of a technical SEO audit dashboard" \
+  --size '1200*630'
+```
+
+The script returns JSON containing the prediction ID, status, output URLs, and
+local paths. Generated files default to
+`~/Documents/claude-seo/atlas-generated/`.
+
+## Use-Case Defaults
+
+Load `references/seo-image-presets.md` and select the closest preset. Ask for
+clarification when brand, style, or required text is underspecified.
+
+| Use case | Size | Prompt emphasis |
+|---|---:|---|
+| OG/social preview | `1200*630` | Clear focal point and safe text area |
+| Blog hero | `1792*1024` | Editorial composition, no embedded text |
+| Product image | `1536*1024` | Accurate object, clean controlled lighting |
+| Infographic | `1024*1536` | Simple hierarchy and minimal generated text |
+| Square social image | `1024*1024` | Centered composition and mobile legibility |
+
+The default model is `qwen-image-3.0/text-to-image`. Before changing models,
+query the live Atlas model catalog and inspect that model's current schema.
+
+## Generation Workflow
+
+1. Identify the target page, asset role, dimensions, brand constraints, and
+   whether the image may contain text.
+2. Write a concrete visual prompt. Describe subject, composition, lighting,
+   palette, and the empty area required for later typography.
+3. Show the proposed prompt, model, size, and number of images. Get approval
+   before the paid request.
+4. Run one `generate.py` command. Do not automatically retry a failed POST.
+5. The client polls only the returned prediction ID with bounded backoff.
+6. Verify the downloaded file, dimensions, and visual suitability before use.
+7. Provide SEO metadata and placement guidance.
+
+## Optional Parameters
+
+```bash
+# Reproducible single image
+claude-seo run --extension atlas generate.py \
+  --prompt "Minimal geometric illustration for a canonical tags guide" \
+  --size '1200*630' --seed 42
+
+# Keep only the temporary output URL
+claude-seo run --extension atlas generate.py \
+  --prompt "Clean product comparison hero" --no-download
+```
+
+Supported flags include `--model`, `--size`, `--count`, `--negative-prompt`,
+`--seed`, `--no-prompt-extend`, `--output`, `--max-polls`, and
+`--poll-seconds`.
+
+## Post-Generation SEO Checklist
+
+- Verify the asset matches the page intent and contains no unintended text.
+- Write concise alt text that describes the image without keyword stuffing.
+- Rename the file using a descriptive, stable slug.
+- Convert to WebP or AVIF when the publishing stack supports it.
+- Compress social and hero assets without visible quality loss.
+- Add the final absolute URL to `og:image` and relevant `ImageObject` schema.
+- Record width and height in metadata to prevent layout shift.
+
+## Safety and Failure Handling
+
+- The API key is sent only to `api.atlascloud.ai` generation and polling
+  endpoints. It is never sent to output hosts.
+- Generation POST requests are never retried automatically.
+- Polling is bounded by `--max-polls`; timeout is reported as JSON.
+- Redirects are blocked. Downloads require HTTPS and an allowlisted Atlas
+  output host, enforce a byte limit, and validate image signatures.
+- Treat output URLs as temporary and avoid logging signed query parameters.
+- On HTTP 429 or 5xx, report the failure and let the user decide whether to
+  submit a new paid request.
+
+## Response Format
+
+After a successful run, report:
+
+1. Local image path and verified dimensions
+2. Model, prompt, size, and seed if used
+3. Suggested filename and alt text
+4. Suggested `og:image` or `ImageObject` snippet
+5. Any visible quality or brand-compliance concerns

--- a/extensions/atlas/uninstall.sh
+++ b/extensions/atlas/uninstall.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+    echo "-> Uninstalling Atlas Cloud SEO image generation extension..."
+    rm -rf "${HOME}/.claude/skills/seo-atlas-image-gen"
+    echo "v Atlas Cloud extension uninstalled."
+}
+
+main "$@"

--- a/scripts/runtime.py
+++ b/scripts/runtime.py
@@ -24,7 +24,10 @@ RUNTIME_SCHEMA = 1
 LOCK_STALE_SECONDS = 30 * 60
 SCRIPT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*\.py$")
 EXTENSION_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
-MANUAL_EXTENSION_SKILLS = {"banana": "seo-image-gen"}
+MANUAL_EXTENSION_SKILLS = {
+    "atlas": "seo-atlas-image-gen",
+    "banana": "seo-image-gen",
+}
 ALLOWED_CORE_SCRIPTS = frozenset(
     {
         "agent_ux_check.py", "analyze_visual.py", "backlinks_auth.py",

--- a/tests/test_atlas_image_generation.py
+++ b/tests/test_atlas_image_generation.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "extensions" / "atlas" / "scripts" / "generate.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("atlas_generate", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Response:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, size: int = -1) -> bytes:
+        return self.data if size < 0 else self.data[:size]
+
+
+def test_payload_matches_live_qwen_image_schema(monkeypatch, capsys, tmp_path: Path) -> None:
+    module = _load_module()
+    requests = []
+
+    def fake_urlopen(request, _timeout):
+        requests.append(request)
+        if request.get_method() == "POST":
+            return _Response(json.dumps({"code": 200, "data": {"id": "pred-1"}}).encode())
+        if "/prediction/" in request.full_url:
+            payload = {
+                "code": 200,
+                "data": {"status": "completed", "outputs": ["https://cdn.atlascloud.ai/a.png"]},
+            }
+            return _Response(json.dumps(payload).encode())
+        return _Response(b"\x89PNG\r\n\x1a\nimage")
+
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr(module, "_urlopen", fake_urlopen)
+    rc = module.main(
+        ["--prompt", "SEO hero", "--size", "1200*630", "--output", str(tmp_path / "hero")]
+    )
+    assert rc == 0
+    body = json.loads(requests[0].data)
+    assert body == {
+        "model": "qwen-image-3.0/text-to-image",
+        "prompt": "SEO hero",
+        "size": "1200*630",
+        "n": 1,
+        "prompt_extend": True,
+    }
+    assert requests[0].get_header("User-agent") == module.USER_AGENT
+    assert json.loads(capsys.readouterr().out)["prediction_id"] == "pred-1"
+
+
+def test_generation_post_occurs_exactly_once(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    methods = []
+    polls = iter(["processing", "completed"])
+
+    def fake_urlopen(request, _timeout):
+        methods.append(request.get_method())
+        if request.get_method() == "POST":
+            return _Response(b'{"data":{"id":"pred-2"}}')
+        if "/prediction/" in request.full_url:
+            status = next(polls)
+            outputs = ["https://cdn.atlascloud.ai/a.png"] if status == "completed" else None
+            return _Response(json.dumps({"data": {"status": status, "outputs": outputs}}).encode())
+        return _Response(b"\x89PNG\r\n\x1a\nimage")
+
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr(module, "_urlopen", fake_urlopen)
+    monkeypatch.setattr(module.time, "sleep", lambda _value: None)
+    assert (
+        module.main(["--prompt", "x", "--poll-seconds", "0", "--output", str(tmp_path / "x")]) == 0
+    )
+    assert methods.count("POST") == 1
+
+
+def test_download_never_receives_authorization(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    seen_download_headers = None
+
+    def fake_urlopen(request, _timeout):
+        nonlocal seen_download_headers
+        if request.get_method() == "POST":
+            return _Response(b'{"data":{"id":"pred-3"}}')
+        if "/prediction/" in request.full_url:
+            return _Response(
+                b'{"data":{"status":"completed","outputs":["https://cdn.atlascloud.ai/a.png"]}}'
+            )
+        seen_download_headers = dict(request.header_items())
+        return _Response(b"\x89PNG\r\n\x1a\nimage")
+
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+    monkeypatch.setattr(module, "_urlopen", fake_urlopen)
+    assert module.main(["--prompt", "x", "--output", str(tmp_path / "x")]) == 0
+    assert seen_download_headers is not None
+    assert "Authorization" not in seen_download_headers
+
+
+def test_polling_is_bounded(monkeypatch) -> None:
+    module = _load_module()
+    calls = 0
+
+    def fake_request(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        return {"status": "processing"}
+
+    monkeypatch.setattr(module, "_request_json", fake_request)
+    monkeypatch.setattr(module.time, "sleep", lambda _value: None)
+    with pytest.raises(TimeoutError):
+        module.poll_prediction("key", "id", max_polls=3, poll_seconds=0, timeout=1)
+    assert calls == 3
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://cdn.atlascloud.ai/a.png",
+        "https://example.com/a.png",
+        "https://user:pass@cdn.atlascloud.ai/a.png",
+        "https://cdn.atlascloud.ai:444/a.png",
+    ],
+)
+def test_output_url_policy_rejects_unsafe_urls(url: str) -> None:
+    module = _load_module()
+    with pytest.raises(ValueError):
+        module._validate_output_url(url)
+
+
+def test_live_provider_output_host_is_allowlisted() -> None:
+    module = _load_module()
+    url = "https://dashscope-a717.oss-accelerate.aliyuncs.com/generated/a.png"
+    assert module._validate_output_url(url) == url
+
+
+def test_image_signature_validation() -> None:
+    module = _load_module()
+    assert module._image_extension(b"\x89PNG\r\n\x1a\nrest") == ".png"
+    assert module._image_extension(b"\xff\xd8\xffrest") == ".jpg"
+    with pytest.raises(ValueError):
+        module._image_extension(b"<html>not an image</html>")
+
+
+def test_download_uses_detected_image_extension(monkeypatch, tmp_path: Path) -> None:
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "_urlopen",
+        lambda _request, _timeout: _Response(b"RIFF\x00\x00\x00\x00WEBPimage"),
+    )
+    output = module.download_image(
+        "https://cdn.atlascloud.ai/a.png",
+        tmp_path / "seo-image.png",
+        1,
+    )
+    assert output.suffix == ".webp"
+    assert output.read_bytes().startswith(b"RIFF")
+
+
+def test_http_error_body_is_not_exposed(monkeypatch) -> None:
+    module = _load_module()
+
+    def fake_urlopen(request, _timeout):
+        raise HTTPError(request.full_url, 401, "denied secret-body", {}, None)
+
+    monkeypatch.setattr(module, "_urlopen", fake_urlopen)
+    with pytest.raises(RuntimeError, match="HTTP 401") as exc:
+        module._request_json("GET", module.API_BASE, api_key="secret-key")
+    assert "secret" not in str(exc.value)
+
+
+def test_missing_key_fails_before_network(monkeypatch, capsys) -> None:
+    module = _load_module()
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    monkeypatch.setattr(module, "_urlopen", lambda *_args: pytest.fail("network called"))
+    assert module.main(["--prompt", "x"]) == 2
+    assert json.loads(capsys.readouterr().out)["message"] == "ATLASCLOUD_API_KEY is not set"
+
+
+def test_extension_layout_and_runtime_fallback() -> None:
+    skill = ROOT / "extensions" / "atlas" / "skills" / "seo-atlas-image-gen" / "SKILL.md"
+    assert skill.is_file()
+    assert "original_author:" in skill.read_text(encoding="utf-8")
+    assert (ROOT / "extensions" / "atlas" / "docs" / "ATLAS-SETUP.md").is_file()
+    installer = (ROOT / "extensions" / "atlas" / "install.sh").read_text(encoding="utf-8")
+    assert 'mkdir -p "${SKILL_DIR}/scripts" "${SKILL_DIR}/references"' in installer
+    runtime = (ROOT / "scripts" / "runtime.py").read_text(encoding="utf-8")
+    assert '"atlas": "seo-atlas-image-gen"' in runtime


### PR DESCRIPTION
## Summary

- add an optional `atlas` extension for executable SEO image generation
- submit exactly one asynchronous generation request, then use bounded GET polling
- download outputs over HTTPS without forwarding credentials, with redirect, host, size, and image-signature checks
- include SEO presets, setup docs, installer support, managed-runtime fallback, and contract tests

## Validation

- `85 passed` across Atlas, portability, runtime, consistency, installer, manifest, and extension-focused tests
- Ruff lint passed for changed Python files
- portability lint: 34 Skill files, 0 errors/warnings
- consistency check: 379 files, 0 errors/warnings
- `bash -n` and temporary-home install/uninstall smoke passed
- live Atlas model catalog/schema verified for `qwen-image-3.0/text-to-image`
- live generation reached `completed`; credential-free download path verified with an official Atlas sample (1280x720 WebP, 136,046 bytes)

The full suite was also attempted locally. Its live `example.com` case is blocked by this environment's DNS interception (`198.18.0.84`), and a later run stalled in unrelated long-running tests; the focused suites above completed cleanly.

## Type of Change

- [ ] Bug fix
- [x] New feature / sub-skill
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting (not applicable: this extension accepts an image prompt, not a URL; a real Atlas generation was tested)
- [x] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [x] Reference files stay under 200 lines (if modified)
- [x] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change