### PR TITLE
Add lxml_html_clean so setup import-validation passes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ urllib3>=2.7.0,<3.0.0             # High-severity urllib3 advisories GHSA-mf9v-m
 trafilatura>=2.0.0,<3.0.0         # Boilerplate-free content extraction (SPA-safe)
 htmldate>=1.9.0,<2.0.0            # Publication-date extraction for freshness signals
 courlan>=1.3.0,<2.0.0             # trafilatura URL helper; explicit pin avoids transitive drift
+lxml_html_clean>=0.4.0            # justext (via trafilatura) imports lxml.html.clean, split out of lxml>=5.2
 
 # Report generation (for seo-google PDF/Excel reports)
 matplotlib>=3.8.0,<4.0.0              # No known CVEs


### PR DESCRIPTION
## Problem

On a clean install, `/seo setup` (`scripts/runtime.py setup`) fails at the **runtime import validation** step:

```
ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html-clean] or lxml_html_clean directly.
```

`pip install -r requirements.txt` succeeds, then the validation line in `command_setup` —
`import bs4, lxml, playwright, requests, trafilatura` — throws. pip even warns during install:
`WARNING: lxml 6.1.1 does not provide the extra 'html_clean'`. Because `command_setup` deletes the
staged venv on failure, users just see `Claude SEO setup failed: runtime import validation failed with exit code 1`.

Reproduced on Windows 11 / Python 3.11 with a fresh venv built straight from `requirements.txt`.

## Root cause

`lxml >= 5.2` split `lxml.html.clean` out into the standalone **`lxml_html_clean`** package.
`justext` (a transitive dependency of `trafilatura`) still does `from lxml.html.clean import Cleaner`.
`requirements.txt` pins `lxml>=6.1.1,<7.0.0` (no bundled `html.clean`) and never lists `lxml_html_clean`,
so the import always fails:

```
trafilatura/__init__.py -> trafilatura/core.py -> trafilatura/external.py
  -> justext/core.py: from lxml.html.clean import Cleaner
    -> lxml/html/clean.py: raise ImportError("lxml.html.clean module is now a separate project ...")
```

## Fix

Add `lxml_html_clean>=0.4.0` to `requirements.txt`. It restores `lxml.html.clean` for `justext`/`trafilatura`
without changing the lxml security pin.

## Testing

- Fresh venv + `pip install -r requirements.txt`, then `python -c "import bs4, lxml, playwright, requests, trafilatura"`
  → **fails** without this change, **passes** with it (`VALIDATION IMPORT OK`).
- `python scripts/runtime.py setup` then `python scripts/runtime.py doctor --json` →
  `{"ready": true, "browser_ready": true, ...}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
