### PR TITLE
Remove unused pytest import in test_technical_depth.py

### DIFF
--- a/tests/test_technical_depth.py
+++ b/tests/test_technical_depth.py
@@ -18,8 +18,6 @@ import os
 import sys
 from unittest.mock import patch
 
-import pytest
-
 _SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)


### PR DESCRIPTION
## Summary
- `pytest` was imported in `tests/test_technical_depth.py` but never used anywhere in the file (flagged by `ruff check` as F401).
- Removed the unused import.

## Test plan
- [x] `ruff check tests/test_technical_depth.py` — no more F401 for this import
- [x] `python3 -m pytest tests/test_technical_depth.py -q` — 17 passed