### PR TITLE
fix(pagespeed_check): handle null Lighthouse category score without dropping the page

### DIFF
--- a/scripts/pagespeed_check.py
+++ b/scripts/pagespeed_check.py
@@ -157,7 +157,10 @@ def run_pagespeed(
     # Lighthouse scores
     lr = data.get("lighthouseResult", {})
     for cat_key, cat_data in lr.get("categories", {}).items():
-        result["lighthouse_scores"][cat_key] = round(cat_data.get("score", 0) * 100)
+        raw_score = cat_data.get("score")
+        result["lighthouse_scores"][cat_key] = (
+            round(raw_score * 100) if raw_score is not None else None
+        )
 
     # Lab metrics from Lighthouse audits
     audits = lr.get("audits", {})
@@ -571,7 +574,8 @@ def _print_psi_summary(psi: dict):
     if scores:
         print("\nLighthouse Scores:")
         for cat, score in scores.items():
-            print(f"  {cat}: {score}/100")
+            score_display = f"{score}/100" if score is not None else "N/A (not computable)"
+            print(f"  {cat}: {score_display}")
 
     lab = psi.get("lab_metrics", {})
     if lab:


### PR DESCRIPTION
## Problem

PageSpeed Insights returns `"score": null` (key present, value `None`) for a Lighthouse category it couldn't compute, the typical case is `performance` under `NO_LCP` (no measurable Largest Contentful Paint, e.g. a hero at `opacity:0` on first paint).

`cat_data.get("score", 0)` does not protect against this: `.get()`'s default only applies when the key is *absent*, not when its value is `None`. So `raw_score` is `None`, `None * 100` raises `TypeError`, and the whole `run_pagespeed()` call fails, the page is dropped from the audit entirely, even though its other 3 categories (accessibility, best-practices, seo) were perfectly usable.

## Fix

- Read the raw score first, then guard on `is not None` before multiplying. A non-computable category now stores `None` instead of crashing.
- Adjusted `_print_psi_summary()` so a `None` score prints `N/A (not computable)` instead of `None/100`.

## Verified

- Confirmed the bug is still present on current `main` (line 160) before writing this fix.
- Searched the rest of the file and repo for the same `.get(<key>, <default>) * ...` pattern on score-like fields, no other occurrence found; the other 6 uses of `score` in this file already guard on `is None`.
- Reproduced and fixed locally on 2 pages of a real site that were disappearing from reports (hero at `opacity:0` on first paint → `NO_LCP`). Re-running the audit after the fix: both pages re-appear with 0 errors, their other scores (accessibility/best-practices/seo, 97 and 100) intact.
