### PR TITLE
fix: stop flagging SSR/SSG framework pages as SPAs in render_page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `render_page.py` no longer misclassifies SSR/SSG framework pages (Next.js, Nuxt, Svelte,
+  Astro islands) as SPAs. Hydration markers now flip `is_spa` only when the visible body
+  text is also sparse; genuinely empty mount shells and noscript walls still trigger
+  headless rendering unconditionally.
+
 ## [2.2.4] - 2026-07-20
 
 Community maintenance release following a full review of every open issue and pull request.

--- a/scripts/render_page.py
+++ b/scripts/render_page.py
@@ -118,19 +118,29 @@ USER_AGENT = (
     "(KHTML, like Gecko) Chrome/150.0.7871.115 Safari/537.36 ClaudeSEO/2.0"
 )
 
-# Hydration-shell signatures. Any single match flips is_spa to True. These
-# cover the dominant SPA frameworks: React (CRA, Vite, Remix), Next.js,
-# Vue, Nuxt, Svelte, Astro islands, and the "JS required" noscript pattern.
+# Empty-shell signatures. Any single match flips is_spa to True. These only
+# match genuinely empty mount points (React CRA / Vite / Remix, Vue) or the
+# "JS required" noscript pattern — cases where the raw HTML cannot contain
+# the content.
 _SPA_SHELL_PATTERNS = (
     '<div id="root"></div>',
-    '<div id="__next">',
     '<div id="app"></div>',
-    '<div id="__nuxt">',
-    'data-svelte-h=',
-    '<astro-island ',
     'you need to enable javascript',
     'please enable javascript',
 )
+
+# Hydration markers from frameworks that can — and in SSR/SSG mode do —
+# serve content-complete raw HTML: Next.js, Nuxt, Svelte, Astro islands.
+# The marker alone proves the framework is present, not that content is
+# missing (Astro islands pages routinely have byte-identical raw vs
+# rendered text). Flip only when the visible body text is also sparse.
+_SPA_HYDRATION_MARKERS = (
+    '<div id="__next">',
+    '<div id="__nuxt">',
+    'data-svelte-h=',
+    '<astro-island ',
+)
+_HYDRATION_SPARSE_TEXT_MAX = 400
 
 # Builder markers are supporting evidence only. Wix, Webflow, and Squarespace
 # can all serve complete HTML, so auto-render requires multiple same-builder
@@ -260,6 +270,10 @@ def _is_spa(raw_html: Optional[str]) -> bool:
     if any(pattern in lc for pattern in _SPA_SHELL_PATTERNS):
         return True
     visible_text = _visible_body_text(lc)
+    if len(visible_text) < _HYDRATION_SPARSE_TEXT_MAX and any(
+        marker in lc for marker in _SPA_HYDRATION_MARKERS
+    ):
+        return True
     if len(visible_text) < _BUILDER_SPARSE_TEXT_MAX:
         for markers in _BUILDER_FINGERPRINT_GROUPS:
             if sum(marker in lc for marker in markers) >= 2:

--- a/tests/test_render_page.py
+++ b/tests/test_render_page.py
@@ -86,6 +86,42 @@ def test_is_spa_negative(html: str) -> None:
     assert render_page._is_spa(html) is False
 
 
+@pytest.mark.parametrize(
+    "marker_html",
+    [
+        # Astro islands SSR/SSG: raw HTML is content-complete.
+        '<astro-island uid="x" component-url="/c.js"></astro-island>',
+        # Svelte hydration marker on a server-rendered node.
+        '<div data-svelte-h="svelte-abc123">widget</div>',
+        # Next.js SSR: __next wrapper around full server-rendered content.
+        '<div id="__next"><main>app shell</main></div>',
+        # Nuxt SSR.
+        '<div id="__nuxt"><main>app shell</main></div>',
+    ],
+)
+def test_is_spa_ignores_hydration_marker_on_content_complete_page(
+    marker_html: str,
+) -> None:
+    # Hydration markers alone must not force a render when the raw body
+    # already carries substantial visible text (SSR/SSG output).
+    html = (
+        "<html><body><article>"
+        + ("Server rendered industrial marketing copy with real substance. " * 10)
+        + "</article>"
+        + marker_html
+        + "</body></html>"
+    )
+    assert render_page._is_spa(html) is False
+
+
+def test_is_spa_flags_hydration_marker_with_sparse_body() -> None:
+    html = (
+        '<html><body><astro-island uid="x"></astro-island>'
+        "<main>Loading your experience</main></body></html>"
+    )
+    assert render_page._is_spa(html) is True
+
+
 def test_is_spa_detects_sparse_builder_shell_with_multiple_markers() -> None:
     html = (
         '<html><head><meta content="Wix.com Website Builder">'


### PR DESCRIPTION
## Summary

`render_page.py` treated any hydration marker (`<div id="__next">`, `<div id="__nuxt">`, `data-svelte-h=`, `<astro-island `) as proof of a client-rendered SPA and forced headless rendering. Those frameworks routinely serve content-complete raw HTML in SSR/SSG mode (Astro islands pages often have byte-identical raw vs rendered text), so static sites were misreported as `is_spa: true` in audit output and paid an unnecessary Playwright render on every fetch.

Detection is now two-tier:

- **Empty-shell signatures** (bare `<div id="root"></div>` / `<div id="app"></div>` mounts, "enable JavaScript" noscript walls) still flip `is_spa` unconditionally: the raw HTML provably cannot contain the content.
- **Hydration markers** flip `is_spa` only when the visible body text is also sparse (<400 chars), i.e. when the framework is present *and* the content is actually missing.

Found during a live audit of an Astro/Vercel site that was flagged as an SPA despite fully static output. The false positive skews audit findings (JS-rendering dependency is a scored factor) and slows every fetch. Builder-fingerprint logic (Wix/Webflow/Squarespace) is unchanged; genuinely client-rendered pages still render headlessly.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting (Astro/Vercel production site, static output correctly reports `is_spa: false`; empty-shell and sparse-hydration pages still report `true`)
- [x] SKILL.md files stay under 500 lines (if modified) — none modified
- [x] Python scripts output JSON (if modified) — `render_page.py` JSON output unchanged
- [x] Reference files stay under 200 lines (if modified) — none modified
- [x] `set -euo pipefail` used in any new shell scripts — no new shell scripts
- [x] CHANGELOG.md updated with the change

`tests/test_render_page.py` gains coverage for both tiers; full file passes (43 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)