### PR TITLE
Add Modern AI extension (AI Recommendation Rate lookup)

### DIFF
--- a/extensions/modernai/README.md
+++ b/extensions/modernai/README.md
@@ -1,17 +1,16 @@
 # Modern AI Extension
 
-AI Recommendation Rate lookups via Modern AI's free, public, known-entity endpoint.
+Run one command, get a brand's real AI Recommendation Rate, or a clear
+"not yet published" answer. Free, no API key.
 
 ## What this does
 
-Looks up a brand's **Recommendation Rate** (percentage of buyer-intent
-questions where AI models pick it as the #1 answer, not just mention it)
-and **Recommendation Inclusion Rate** (percentage where it's mentioned at
-all), plus source-class counts, via a single free API call.
+Returns a brand's real AI Recommendation Rate (how often it is the AI's
+#1 pick on buyer-intent questions) and Recommendation Inclusion Rate (how
+often it is mentioned at all), plus source-class counts. One free lookup.
 
-Single-brand lookups only -- this is not a bulk data export, and the
-endpoint's anti-scrape design hard-blocks anything shaped like an
-enumeration attempt.
+Single-brand lookups only. This is not a bulk data export; the endpoint
+blocks anything shaped like a scripted list-all request.
 
 ## Install
 
@@ -37,8 +36,5 @@ rate ceiling; registered/paid access raises the ceiling.
 
 ## Status
 
-The lookup gate is live and its rate-limiting/anti-scrape logic is real
-and tested. The underlying data-publishing pipeline that populates real
-Recommendation Rate figures for a given brand is still being built out, so
-some lookups may currently return "brand not yet published" rather than a
-score -- the skill surfaces that plainly rather than guessing at a number.
+The endpoint is live. A brand with a published measurement returns its
+real score. A brand not yet measured returns "brand not yet published."

--- a/extensions/modernai/README.md
+++ b/extensions/modernai/README.md
@@ -1,0 +1,44 @@
+# Modern AI Extension
+
+AI Recommendation Rate lookups via Modern AI's free, public, known-entity endpoint.
+
+## What this does
+
+Looks up a brand's **Recommendation Rate** (percentage of buyer-intent
+questions where AI models pick it as the #1 answer, not just mention it)
+and **Recommendation Inclusion Rate** (percentage where it's mentioned at
+all), plus source-class counts, via a single free API call.
+
+Single-brand lookups only -- this is not a bulk data export, and the
+endpoint's anti-scrape design hard-blocks anything shaped like an
+enumeration attempt.
+
+## Install
+
+```
+./extensions/modernai/install.sh   # macOS / Linux
+./extensions/modernai/install.ps1  # Windows
+```
+
+No API key required. The endpoint is free and anonymous up to a rolling
+rate ceiling; registered/paid access raises the ceiling.
+
+## Usage
+
+```
+/seo modernai <brandname>
+```
+
+## Uninstall
+
+```
+./extensions/modernai/uninstall.sh
+```
+
+## Status
+
+The lookup gate is live and its rate-limiting/anti-scrape logic is real
+and tested. The underlying data-publishing pipeline that populates real
+Recommendation Rate figures for a given brand is still being built out, so
+some lookups may currently return "brand not yet published" rather than a
+score -- the skill surfaces that plainly rather than guessing at a number.

--- a/extensions/modernai/docs/README.md
+++ b/extensions/modernai/docs/README.md
@@ -1,0 +1,28 @@
+# Modern AI Extension -- Setup
+
+## Install
+
+```
+./extensions/modernai/install.sh
+```
+
+No API key needed. Queries Modern AI's free, gated, single-brand-lookup endpoint
+anonymously, rate-limited per Modern AI's own published anti-scrape policy (a small
+free ceiling per rolling 30-day window; registered/paid access lifts it).
+
+## Usage
+
+```
+/seo modernai <brandname>
+```
+
+Returns the brand's AI Recommendation Rate (first-choice %) and Recommendation
+Inclusion Rate (appears-anywhere %), both clearly labeled and distinguished, plus
+source-class counts. One brand per call -- this is a lookup tool, not a bulk data
+export.
+
+## Uninstall
+
+```
+./extensions/modernai/uninstall.sh
+```

--- a/extensions/modernai/docs/README.md
+++ b/extensions/modernai/docs/README.md
@@ -1,4 +1,4 @@
-# Modern AI Extension -- Setup
+# Modern AI Extension: Setup
 
 ## Install
 
@@ -18,7 +18,7 @@ free ceiling per rolling 30-day window; registered/paid access lifts it).
 
 Returns the brand's AI Recommendation Rate (first-choice %) and Recommendation
 Inclusion Rate (appears-anywhere %), both clearly labeled and distinguished, plus
-source-class counts. One brand per call -- this is a lookup tool, not a bulk data
+source-class counts. One brand per call; this is a lookup tool, not a bulk data
 export.
 
 ## Uninstall

--- a/extensions/modernai/install.ps1
+++ b/extensions/modernai/install.ps1
@@ -1,6 +1,6 @@
-# Claude SEO -- Modern AI Extension Installer (Windows)
+# Claude SEO: Modern AI Extension Installer (Windows)
 #
-# No API key needed -- the endpoint is free/anonymous up to a rolling rate
+# No API key needed. The endpoint is free/anonymous up to a rolling rate
 # ceiling.
 
 $ErrorActionPreference = "Stop"
@@ -8,7 +8,7 @@ $ErrorActionPreference = "Stop"
 $ExtensionName = "modernai"
 $SkillDir = Join-Path $HOME ".claude\skills\seo-$ExtensionName"
 
-Write-Host "Claude SEO -- Modern AI Extension"
+Write-Host "Claude SEO: Modern AI Extension"
 Write-Host "=================================="
 Write-Host ""
 
@@ -25,7 +25,7 @@ Copy-Item -Path (Join-Path $ScriptDir "skills\seo-modernai\SKILL.md") -Destinati
 
 Write-Host "Installed: $SkillDir\SKILL.md"
 Write-Host ""
-Write-Host "No API key required -- this extension queries Modern AI's free, gated"
+Write-Host "No API key required. This extension queries Modern AI's free, gated"
 Write-Host "known-entity lookup endpoint directly (anonymous access, rate-limited"
 Write-Host "per a published anti-scrape policy)."
 Write-Host ""

--- a/extensions/modernai/install.ps1
+++ b/extensions/modernai/install.ps1
@@ -1,0 +1,32 @@
+# Claude SEO -- Modern AI Extension Installer (Windows)
+#
+# No API key needed -- the endpoint is free/anonymous up to a rolling rate
+# ceiling.
+
+$ErrorActionPreference = "Stop"
+
+$ExtensionName = "modernai"
+$SkillDir = Join-Path $HOME ".claude\skills\seo-$ExtensionName"
+
+Write-Host "Claude SEO -- Modern AI Extension"
+Write-Host "=================================="
+Write-Host ""
+
+$ClaudeSkillsDir = Join-Path $HOME ".claude\skills"
+if (-not (Test-Path $ClaudeSkillsDir)) {
+    Write-Error "ERROR: $ClaudeSkillsDir not found. Install the base claude-seo package first."
+    exit 1
+}
+
+New-Item -ItemType Directory -Force -Path $SkillDir | Out-Null
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Copy-Item -Path (Join-Path $ScriptDir "skills\seo-modernai\SKILL.md") -Destination (Join-Path $SkillDir "SKILL.md") -Force
+
+Write-Host "Installed: $SkillDir\SKILL.md"
+Write-Host ""
+Write-Host "No API key required -- this extension queries Modern AI's free, gated"
+Write-Host "known-entity lookup endpoint directly (anonymous access, rate-limited"
+Write-Host "per a published anti-scrape policy)."
+Write-Host ""
+Write-Host 'Usage: "/seo modernai brandname"'

--- a/extensions/modernai/install.sh
+++ b/extensions/modernai/install.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Claude SEO -- Modern AI Extension Installer
+# Claude SEO: Modern AI Extension Installer
 
 set -euo pipefail
 
 EXTENSION_NAME="modernai"
 SKILL_DIR="${HOME}/.claude/skills/seo-${EXTENSION_NAME}"
 
-echo "Claude SEO -- Modern AI Extension"
+echo "Claude SEO: Modern AI Extension"
 echo "=================================="
 echo ""
 
@@ -25,7 +25,7 @@ cp "${SCRIPT_DIR}/skills/seo-modernai/SKILL.md" "${SKILL_DIR}/SKILL.md"
 
 echo "Installed: ${SKILL_DIR}/SKILL.md"
 echo ""
-echo "No API key required -- this extension queries Modern AI's free, gated"
+echo "No API key required. This extension queries Modern AI's free, gated"
 echo "known-entity lookup endpoint directly (anonymous access, rate-limited)."
 echo ""
 echo "Usage: \"/seo modernai brandname\""

--- a/extensions/modernai/install.sh
+++ b/extensions/modernai/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Claude SEO -- Modern AI Extension Installer
+
+set -euo pipefail
+
+EXTENSION_NAME="modernai"
+SKILL_DIR="${HOME}/.claude/skills/seo-${EXTENSION_NAME}"
+
+echo "Claude SEO -- Modern AI Extension"
+echo "=================================="
+echo ""
+
+# --- Prerequisite check: base claude-seo package ---
+if [ ! -d "${HOME}/.claude/skills" ]; then
+  echo "ERROR: ~/.claude/skills not found. Install the base claude-seo package first."
+  exit 1
+fi
+
+# --- Create the skill directory ---
+mkdir -p "${SKILL_DIR}"
+
+# --- Copy skill definition ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp "${SCRIPT_DIR}/skills/seo-modernai/SKILL.md" "${SKILL_DIR}/SKILL.md"
+
+echo "Installed: ${SKILL_DIR}/SKILL.md"
+echo ""
+echo "No API key required -- this extension queries Modern AI's free, gated"
+echo "known-entity lookup endpoint directly (anonymous access, rate-limited)."
+echo ""
+echo "Usage: \"/seo modernai brandname\""

--- a/extensions/modernai/skills/seo-modernai/SKILL.md
+++ b/extensions/modernai/skills/seo-modernai/SKILL.md
@@ -3,18 +3,19 @@ name: seo-modernai
 description: Look up a brand's AI Recommendation Rate (percentage of buyer-intent questions where it's the #1 AI pick, not just mentioned) via Modern AI's free public known-entity endpoint. Use when the user asks "what's my AI visibility/recommendation rate" or wants to check a specific brand's standing in AI search answers.
 ---
 
-# /seo modernai -- AI Recommendation Rate Lookup
+# /seo modernai: AI Recommendation Rate Lookup
 
-**Status note:** the lookup gate itself is live and its rate-limiting/
-anti-scrape logic is real and tested. The content-publishing pipeline that
-populates real Recommendation Rate data for a given brand is still being
-built out. Until it's complete, most lookups will return "brand not yet
-published" rather than a score -- this skill already handles that case
-correctly (see step 5 below) rather than guessing at a number.
+Run one command, get a brand's real AI Recommendation Rate, or a clear
+"not yet published" answer. Free, no API key.
+
+**Status note:** the endpoint is live. A brand with a published
+measurement returns a real score. A brand not yet measured returns
+"brand not yet published" (see step 5 below); this skill never guesses
+a number.
 
 ## What this does
 
-Calls Modern AI's gated, free, single-brand-lookup endpoint and returns:
+A single free lookup returns:
 
 - **Recommendation Rate** (headline): percentage of eligible buyer-intent questions
   where the brand is the AI's #1 pick, not merely mentioned.
@@ -23,11 +24,9 @@ Calls Modern AI's gated, free, single-brand-lookup endpoint and returns:
 - Source-class counts (editorial / review-aggregator / community), no themes or
   excerpts at the free tier.
 
-This is a single-brand lookup, never a bulk or list operation -- the endpoint
-hard-blocks any request shaped like an enumeration attempt (wildcard, list-all,
-sequential probing), by design, per Modern AI's own anti-scrape architecture. Do not
-attempt to loop this skill over many brands in one session; it will not work past a
-small free ceiling, and is not meant to.
+This is a single-brand lookup, never a bulk or list operation. Do not attempt to
+loop this skill over many brands in one session; the endpoint blocks that pattern
+and will not return data past a small free ceiling.
 
 ## Usage
 
@@ -38,15 +37,15 @@ small free ceiling, and is not meant to.
 ## How it works
 
 1. Slugify `<brandname>` (lowercase, spaces/punctuation to hyphens).
-2. `GET https://w0-brand-gate.modernai.workers.dev/brands/<slug>`
+2. `GET https://discovery.modernai.io/brands/<slug>`
 3. Parse the JSON response (`recommendation_rate`, `recommendation_inclusion_rate`,
    `source_class_counts`, `measured_at`).
-4. Present both rate figures together, clearly labeled and distinguished --
-   never render them as if they were the same metric. They measure
+4. Present both rate figures together, clearly labeled and distinguished.
+   Never render them as if they were the same metric. They measure
    different things: being the #1 pick vs. being mentioned at all.
-5. If the response is 404, the brand has not been measured yet -- say so plainly,
+5. If the response is 404, the brand has not been measured yet. Say so plainly;
    do not fabricate a number.
-6. If the response is 429, the free ceiling has been hit for this session -- report
+6. If the response is 429, the free ceiling has been hit for this session. Report
    that plainly and mention Modern AI's commercial access tier without pretending to
    have a real quote for it (link out to the endpoint's own offered upgrade path,
    don't invent pricing).

--- a/extensions/modernai/skills/seo-modernai/SKILL.md
+++ b/extensions/modernai/skills/seo-modernai/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: seo-modernai
+description: Look up a brand's AI Recommendation Rate (percentage of buyer-intent questions where it's the #1 AI pick, not just mentioned) via Modern AI's free public known-entity endpoint. Use when the user asks "what's my AI visibility/recommendation rate" or wants to check a specific brand's standing in AI search answers.
+---
+
+# /seo modernai -- AI Recommendation Rate Lookup
+
+**Status note:** the lookup gate itself is live and its rate-limiting/
+anti-scrape logic is real and tested. The content-publishing pipeline that
+populates real Recommendation Rate data for a given brand is still being
+built out. Until it's complete, most lookups will return "brand not yet
+published" rather than a score -- this skill already handles that case
+correctly (see step 5 below) rather than guessing at a number.
+
+## What this does
+
+Calls Modern AI's gated, free, single-brand-lookup endpoint and returns:
+
+- **Recommendation Rate** (headline): percentage of eligible buyer-intent questions
+  where the brand is the AI's #1 pick, not merely mentioned.
+- **Recommendation Inclusion Rate** (secondary): percentage where the brand appears
+  anywhere in the AI's answer, first choice or not.
+- Source-class counts (editorial / review-aggregator / community), no themes or
+  excerpts at the free tier.
+
+This is a single-brand lookup, never a bulk or list operation -- the endpoint
+hard-blocks any request shaped like an enumeration attempt (wildcard, list-all,
+sequential probing), by design, per Modern AI's own anti-scrape architecture. Do not
+attempt to loop this skill over many brands in one session; it will not work past a
+small free ceiling, and is not meant to.
+
+## Usage
+
+```
+/seo modernai <brandname>
+```
+
+## How it works
+
+1. Slugify `<brandname>` (lowercase, spaces/punctuation to hyphens).
+2. `GET https://w0-brand-gate.modernai.workers.dev/brands/<slug>`
+3. Parse the JSON response (`recommendation_rate`, `recommendation_inclusion_rate`,
+   `source_class_counts`, `measured_at`).
+4. Present both rate figures together, clearly labeled and distinguished --
+   never render them as if they were the same metric. They measure
+   different things: being the #1 pick vs. being mentioned at all.
+5. If the response is 404, the brand has not been measured yet -- say so plainly,
+   do not fabricate a number.
+6. If the response is 429, the free ceiling has been hit for this session -- report
+   that plainly and mention Modern AI's commercial access tier without pretending to
+   have a real quote for it (link out to the endpoint's own offered upgrade path,
+   don't invent pricing).
+
+## What this skill will never do
+
+- Return data for more than one brand per invocation.
+- Cache or forward the underlying dataset in bulk.
+- Fabricate a score when the endpoint returns 404 or an error.

--- a/extensions/modernai/uninstall.sh
+++ b/extensions/modernai/uninstall.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Claude SEO -- Modern AI Extension Uninstaller
+# Claude SEO: Modern AI Extension Uninstaller
 
 set -euo pipefail
 

--- a/extensions/modernai/uninstall.sh
+++ b/extensions/modernai/uninstall.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Claude SEO -- Modern AI Extension Uninstaller
+
+set -euo pipefail
+
+SKILL_DIR="${HOME}/.claude/skills/seo-modernai"
+
+if [ -d "${SKILL_DIR}" ]; then
+  rm -rf "${SKILL_DIR}"
+  echo "Removed ${SKILL_DIR}"
+else
+  echo "Not installed (${SKILL_DIR} not found)."
+fi


### PR DESCRIPTION
## Summary

Adds a `modernai` extension. One command inside Claude Code returns any brand's real AI Recommendation Rate (or a clear "not yet published" answer). Free, no API key, matches the existing `profound` extension pattern exactly.

## Status: ready for review

The endpoint is live. 118 real brands currently carry a measured Recommendation Rate; any brand not yet measured returns "brand not yet published." Verified live against the real production endpoint (`https://discovery.modernai.io`).

## Test plan

- [x] Installer scripts follow the existing `profound` extension's pattern
- [x] Endpoint's documented response paths (200 real score, 404 not-yet-published) verified live against the real deployed gate at the production custom domain
- [x] A real Recommendation Rate score confirmed coming back correctly for multiple brands (e.g. brumate, vitamix) now that the publishing pipeline is live