### PR TITLE
fix(geo): stop conflating training crawlers with search crawlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- AI crawler claims are now checked against the crawler that actually governs them.
+  `GPTBot` was documented as "ChatGPT web search" in the `seo-geo` crawler table; it is
+  OpenAI's model-training crawler, while `OAI-SearchBot` is what determines ChatGPT
+  Search citability. `Google-Extended` governs Gemini/Vertex training and grounding only
+  and is no longer treated as a Google Search readiness signal (Google Search, AI
+  Overviews, and AI Mode all follow `Googlebot`). Adds a claim-to-bot mapping table, the
+  missing `OAI-SearchBot` row to the `seo-technical` crawler table, and requires training
+  access and search citability to be reported as separate findings.
+
 ## [2.2.4] - 2026-07-20
 
 Community maintenance release following a full review of every open issue and pull request.

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -27,7 +27,12 @@ You are a Generative Engine Optimization (GEO) specialist. When given a URL:
 
 ## AI Crawlers to Check in robots.txt
 
-Allow for AI search visibility: GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot
+Allow for AI search visibility: OAI-SearchBot, ClaudeBot, PerplexityBot.
+GPTBot is OpenAI's *training* crawler, not the ChatGPT Search crawler -- do not cite
+its status as evidence about ChatGPT Search citability. Likewise Google-Extended
+governs Gemini/Vertex training and grounding only, never Google Search or AI Overviews
+inclusion (those follow Googlebot). Check and report each bot against the specific
+capability it governs.
 Optional block (training only): CCBot, anthropic-ai, cohere-ai
 
 ## Key Citability Signals

--- a/skills/seo-geo/SKILL.md
+++ b/skills/seo-geo/SKILL.md
@@ -152,8 +152,8 @@ Check `robots.txt` for these AI crawlers:
 
 | Crawler | Owner | Purpose | Obeys robots.txt? |
 |---------|-------|---------|---|
-| GPTBot | OpenAI | ChatGPT web search | yes |
-| OAI-SearchBot | OpenAI | OpenAI search features | yes |
+| GPTBot | OpenAI | **Model training only** (NOT ChatGPT Search) | yes |
+| OAI-SearchBot | OpenAI | **ChatGPT Search citability** (the crawler that decides it) | yes |
 | ChatGPT-User | OpenAI | ChatGPT browsing (user-triggered) | no (user-triggered) |
 | ClaudeBot | Anthropic | Claude web features | yes |
 | PerplexityBot | Perplexity | Perplexity AI search | yes |
@@ -161,13 +161,40 @@ Check `robots.txt` for these AI crawlers:
 | anthropic-ai | Anthropic | Claude training | yes |
 | Bytespider | ByteDance | TikTok/Douyin AI | yes |
 | cohere-ai | Cohere | Cohere models | yes |
-| Google-Extended | Google | Gemini/Vertex training & grounding opt-out | yes |
+| Google-Extended | Google | **Gemini/Vertex training & grounding only** (NOT Google Search) | yes |
 | Google-CloudVertexBot | Google | Site-owner-requested Vertex AI Agent crawls | yes |
 | Google-Agent | Google | Agentic browsing (Project Mariner), acts for a user | **no (user-triggered)** |
 | Google-NotebookLM | Google | Fetches individual user-added source URLs | **no (user-triggered)** |
 | Google Messages | Google | User-triggered fetch | **no (user-triggered)** |
 
-**Recommendation:** Allow GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot for AI search visibility. Block CCBot and training crawlers if desired.
+**Recommendation:** Allow OAI-SearchBot, ClaudeBot, and PerplexityBot for AI search
+visibility. GPTBot and CCBot are training crawlers -- allow or block them on licensing
+preference, not on search-visibility grounds.
+
+### Check the right bot for the claim you are making
+
+Two pairs are routinely conflated. **Each claim below may only be supported by its own
+bot's robots.txt status** -- check them separately and report them separately.
+
+| Claim you want to make | Bot to check | Bot that does NOT support this claim |
+|---|---|---|
+| "Content is citable in ChatGPT Search" | `OAI-SearchBot` | `GPTBot` |
+| "Content is available for OpenAI model training" | `GPTBot` | `OAI-SearchBot` |
+| "Content can be used for Gemini/Vertex training & grounding" | `Google-Extended` | `Googlebot` |
+| "Content is eligible for Google Search / AI Overviews" | `Googlebot` | `Google-Extended` |
+
+- **`Google-Extended` governs Gemini and Vertex AI training and grounding use only.
+  It does not affect inclusion in ordinary Google Search, or in AI Overviews and AI
+  Mode, both of which are served from the `Googlebot` index.** Never score
+  `Google-Extended` as a "Google Search readiness" signal, and never cite a blocked
+  `Google-Extended` as evidence that a site is missing from Google Search.
+- **`OAI-SearchBot` is the crawler that determines ChatGPT Search citability.
+  `GPTBot` is OpenAI's separate training crawler.** Checking `GPTBot` access tells
+  you nothing about whether ChatGPT Search can cite the page. A site that blocks
+  `GPTBot` and allows `OAI-SearchBot` is fully citable in ChatGPT Search.
+
+Do not use these names interchangeably in report prose. When reporting crawler access,
+name the specific user-agent that was checked and the specific capability it governs.
 
 > **User-triggered fetchers ignore robots.txt by design** (Google-Agent, Google-NotebookLM, Google Messages, ChatGPT-User). robots.txt cannot block them, use server-side access controls. Google's canonical crawling/robots reference moved to **developers.google.com/crawling** (migrated 2025-11-20); IP-range files now live at `/crawling/ipranges/` and `googlebot.json` was renamed `common-crawlers.json`. Emerging: **Web Bot Auth** (RFC 9421) lets bots authenticate via a `Signature-Agent` header + key directory (used by Google-Agent); reverse-DNS verification remains the fallback.
 
@@ -258,7 +285,10 @@ Generate `GEO-ANALYSIS.md` with:
 
 1. **GEO Readiness Score: XX/100**
 2. **Platform breakdown** (Google AIO, ChatGPT, Perplexity scores)
-3. **AI Crawler Access Status** (which crawlers allowed/blocked)
+3. **AI Crawler Access Status** -- report each crawler separately with the
+   capability it governs. Training access (`GPTBot`, `Google-Extended`, `CCBot`)
+   and search citability (`OAI-SearchBot`, `Googlebot`, `PerplexityBot`,
+   `ClaudeBot`) are distinct findings and must never be merged into one line.
 4. **llms.txt Status** (present, missing, recommendations)
 5. **Brand Mention Analysis** (presence on Wikipedia, Reddit, YouTube, LinkedIn)
 6. **Passage-Level Citability** (optimal 134-167 word blocks identified)

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -39,8 +39,9 @@ As of 2025-2026, AI companies actively crawl the web to train models and power A
 
 | Crawler | Company | robots.txt token | Purpose |
 |---------|---------|-----------------|---------|
-| GPTBot | OpenAI | `GPTBot` | Model training |
-| ChatGPT-User | OpenAI | `ChatGPT-User` | Real-time browsing |
+| GPTBot | OpenAI | `GPTBot` | Model training (NOT ChatGPT Search) |
+| OAI-SearchBot | OpenAI | `OAI-SearchBot` | ChatGPT Search citability |
+| ChatGPT-User | OpenAI | `ChatGPT-User` | Real-time browsing (user-triggered) |
 | ClaudeBot | Anthropic | `ClaudeBot` | Model training |
 | PerplexityBot | Perplexity | `PerplexityBot` | Search index + training |
 | Bytespider | ByteDance | `Bytespider` | Model training |
@@ -49,7 +50,10 @@ As of 2025-2026, AI companies actively crawl the web to train models and power A
 
 **Key distinctions:**
 - Blocking `Google-Extended` prevents Gemini training use but does NOT affect Google Search indexing or AI Overviews (those use `Googlebot`)
-- Blocking `GPTBot` prevents OpenAI training but does NOT prevent ChatGPT from citing your content via browsing (`ChatGPT-User`)
+- Blocking `GPTBot` prevents OpenAI training but does NOT affect ChatGPT Search
+  citability, which is governed by `OAI-SearchBot`, nor user-triggered browsing
+  (`ChatGPT-User`). Check `OAI-SearchBot` for any citability claim; `GPTBot`
+  status is evidence about training use only
 - ~3-5% of websites now use AI-specific robots.txt rules
 
 **Example, selective AI crawler blocking:**

--- a/tests/test_ai_crawler_claims.py
+++ b/tests/test_ai_crawler_claims.py
@@ -1,0 +1,54 @@
+"""Stage 4 gap fixes: schema severity, link heuristics, merge gate, crawler claims."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS = REPO_ROOT / "skills"
+AGENTS = REPO_ROOT / "agents"
+
+
+def _read(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+# ─── AI crawler claims are checked against the right bot ────────────────────
+
+
+def test_gptbot_is_not_described_as_the_chatgpt_search_crawler() -> None:
+    text = _read("skills/seo-geo/SKILL.md")
+    assert "| GPTBot | OpenAI | ChatGPT web search | yes |" not in text
+    assert "OAI-SearchBot" in text
+    assert "ChatGPT Search citability" in text
+
+
+def test_geo_skill_separates_training_crawlers_from_search_crawlers() -> None:
+    text = _read("skills/seo-geo/SKILL.md")
+    assert "Check the right bot for the claim you are making" in text
+    assert "does not affect inclusion in ordinary Google Search" in text
+    assert "tells\n  you nothing about whether ChatGPT Search can cite the page" in text
+
+
+def test_google_extended_is_never_a_google_search_readiness_signal() -> None:
+    """Named claim, checked in both the skill and the agent that runs it."""
+    for rel in ("skills/seo-geo/SKILL.md", "agents/seo-geo.md"):
+        text = _read(rel)
+        assert "Google-Extended" in text, rel
+        lowered = text.lower()
+        assert "not google search" in lowered or "never google search" in lowered, rel
+
+    skill = _read("skills/seo-geo/SKILL.md")
+    assert 'Never score\n  `Google-Extended` as a "Google Search readiness" signal' in skill
+
+
+def test_technical_skill_checks_oai_searchbot_separately_from_gptbot() -> None:
+    text = _read("skills/seo-technical/SKILL.md")
+    assert "| OAI-SearchBot | OpenAI | `OAI-SearchBot` | ChatGPT Search citability |" in text
+    assert "governed by `OAI-SearchBot`" in text
+
+
+def test_geo_output_reports_training_and_citability_separately() -> None:
+    text = _read("skills/seo-geo/SKILL.md")
+    assert "must never be merged into one line" in text


### PR DESCRIPTION
## Summary

Two pairs of AI crawlers were being used interchangeably in the `seo-geo` skill, which
makes the audit assert things its evidence does not support.

**`GPTBot` was listed as "ChatGPT web search".** It is OpenAI's model-training crawler.
`OAI-SearchBot` is the crawler that determines ChatGPT Search citability. The table
implied a site blocking `GPTBot` was not citable in ChatGPT Search, when the opposite is
true — blocking `GPTBot` while allowing `OAI-SearchBot` leaves the site fully citable.

**`Google-Extended` was scoreable as a Google Search signal.** It governs Gemini and
Vertex AI training and grounding only. It does not affect inclusion in Google Search, AI
Overviews, or AI Mode, all of which are served from the `Googlebot` index. The existing
`seo-technical` "Key distinctions" section already stated this correctly, so the two
skills disagreed with each other.

### What changed

- Corrected both rows in the `seo-geo` crawler table.
- Added a claim-to-bot mapping table: for each claim an audit might make, which
  user-agent supports it and which does not.
- Added the missing `OAI-SearchBot` row to the `seo-technical` crawler table — that
  skill performs the robots.txt check but had no way to substantiate a citability claim.
- Corrected the "Allow for AI search visibility" recommendation in both the skill and
  `agents/seo-geo.md`; `GPTBot` and `CCBot` are a licensing decision, not a
  search-visibility one.
- Output section now requires training access and search citability to be reported as
  separate findings rather than merged into one line.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — **N/A, see note below**
- [x] SKILL.md files stay under 500 lines (if modified) — `seo-geo` 344, `seo-technical` 228
- [ ] Python scripts output JSON (if modified) — no Python changed
- [ ] Reference files stay under 200 lines (if modified) — no reference files changed
- [ ] `set -euo pipefail` used in any new shell scripts — no shell scripts added
- [x] CHANGELOG.md updated with the change

**On the real-URL checkbox:** this PR changes skill instructions and reference tables
only — there is no code path a URL would exercise. What I did run instead: the full
suite (398 passed, 1 skipped) plus 5 new tests in `tests/test_ai_crawler_claims.py`
pinning each corrected claim. The two pre-existing `tests/test_sync_flow.py` failures in
my environment are network/TLS related and unrelated to this change; they are deselected
in that count.

The factual claims are checkable against OpenAI's and Google's own crawler documentation
rather than against a crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
