### PR TITLE
fix(backlinks): enforce the Common-Crawl-only no-score rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The Common-Crawl-only no-score rule is now enforced instead of merely stated. The
+  `seo-backlinks` skill said not to produce a numeric health score when only Common Crawl
+  data is available, while `skills/seo/references/free-backlink-sources.md` told the agent
+  to "cap the maximum health score at 70/100" in the same case. The reference gave the more
+  actionable of two contradictory instructions, which is the likely reason the rule was
+  violated in practice. The guidance now agrees across both files, and
+  `validate_backlink_report.py` gains a `source_score_consistency` check that fails a
+  report carrying a number with no scoreable source (Moz, Bing, or DataForSEO), or a
+  `source: not-assessed` finding carrying a score.
+
 ## [2.2.4] - 2026-07-20
 
 Community maintenance release following a full review of every open issue and pull request.

--- a/scripts/validate_backlink_report.py
+++ b/scripts/validate_backlink_report.py
@@ -235,6 +235,102 @@ def validate_health_score(scoring_factors: dict) -> list:
     return issues
 
 
+# Sources that can support a numeric backlink health score. Common Crawl is
+# deliberately absent: it provides rank/presence signals only, not the
+# referring-domain quality, anchor, or toxicity data a score implies.
+SCOREABLE_SOURCES = ("moz_data", "bing_data", "dataforseo_data")
+
+# Finding sources that mean "we did not measure this".
+UNMEASURED_SOURCES = ("not-assessed", "not_assessed")
+
+
+def _is_numeric_score(value) -> bool:
+    """True when value is a real number (bool excluded) or a numeric string."""
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value.strip())
+        except (TypeError, ValueError):
+            return False
+        return True
+    return False
+
+
+def _scoreable_sources_present(report_data: dict) -> list:
+    """Return the scoreable sources that actually carry data in this report."""
+    present = []
+    for key in SCOREABLE_SOURCES:
+        value = report_data.get(key)
+        if isinstance(value, dict):
+            if value and not value.get("error"):
+                present.append(key)
+        elif value:
+            present.append(key)
+    return present
+
+
+def validate_source_score_consistency(report_data: dict) -> list:
+    """Enforce: never emit a numeric score for data that was not measured.
+
+    Two failure modes, both observed in real audits despite the instruction
+    already existing in the skill:
+
+    1. Common Crawl is the only source available, but a numeric health score is
+       still produced.
+    2. A finding is marked `source: not-assessed` yet carries a score.
+    """
+    issues = []
+
+    scoring_factors = report_data.get("scoring_factors") or {}
+    score = scoring_factors.get("score") if isinstance(scoring_factors, dict) else None
+
+    scoreable = _scoreable_sources_present(report_data)
+    has_cc = bool(report_data.get("cc_data"))
+
+    if _is_numeric_score(score) and not scoreable:
+        detail = (
+            "Common Crawl was the only source available"
+            if has_cc else "no backlink data source was available"
+        )
+        issues.append({
+            "severity": "error",
+            "field": "health_score",
+            "message": (
+                f"Numeric score ({score}) produced when {detail}. Common Crawl "
+                "supplies rank/presence signals only and MUST NOT be scored. "
+                "Report 'Not Assessed' with no numeric value."
+            ),
+            "fix": "Set the score to null and report Not Assessed.",
+        })
+
+    findings = report_data.get("findings")
+    if isinstance(findings, list):
+        for i, finding in enumerate(findings):
+            if not isinstance(finding, dict):
+                continue
+            source = str(finding.get("source", "")).strip().lower()
+            if source not in UNMEASURED_SOURCES:
+                continue
+            for field in ("score", "value", "health_score"):
+                if _is_numeric_score(finding.get(field)):
+                    issues.append({
+                        "severity": "error",
+                        "field": f"findings[{i}].{field}",
+                        "message": (
+                            f"Finding '{finding.get('title', 'untitled')}' is "
+                            f"source: not-assessed but carries a numeric "
+                            f"{field} ({finding[field]}). A not-assessed finding "
+                            "MUST NOT be scored."
+                        ),
+                        "fix": f"Omit {field} or set it to null.",
+                    })
+
+    return issues
+
+
 def validate_report(report_data: dict) -> dict:
     """
     Run all validations on a backlink report.
@@ -267,6 +363,10 @@ def validate_report(report_data: dict) -> dict:
     if report_data.get("scoring_factors"):
         all_issues.extend(validate_health_score(report_data["scoring_factors"]))
 
+    # Always run: this gate must fire even when the agent supplies no
+    # scoring_factors block at all.
+    all_issues.extend(validate_source_score_consistency(report_data))
+
     # Classify
     errors = [i for i in all_issues if i["severity"] == "error"]
     warnings = [i for i in all_issues if i["severity"] == "warning"]
@@ -289,6 +389,7 @@ def validate_report(report_data: dict) -> dict:
             "checks_run": [
                 "schema_claims", "verification_results", "h1_claims",
                 "cc_claims", "reciprocal_links", "health_score",
+                "source_score_consistency",
             ],
         },
     }

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -184,9 +184,40 @@ Calculate a 0-100 score. When mixing sources, apply confidence weighting:
   Show individual factor scores that ARE available with their source and confidence.
   Recommend: "Configure Moz API (free) for a scoreable profile. Run `/seo backlinks setup`"
 
-When only CC is available, do not produce a numeric score; report low-confidence rank/presence data only.
-A numeric score with fewer than 4 data sources is **misleading**, it implies poor health when
-the reality is we simply lack data.
+### MUST NOT: score what you did not measure
+
+**When Common Crawl is the only available source, you MUST NOT produce a numeric
+score of any kind** -- not a health score, not a per-factor score, not an
+"approximate" or "estimated" figure. Common Crawl supplies rank and presence
+signals only. Report low-confidence rank/presence data and the literal string
+`Not Assessed` in place of every number.
+
+**A finding written with `source: not-assessed` MUST NOT carry a numeric score.**
+
+A numeric score with fewer than 4 data sources is **misleading**: it implies poor
+health when the reality is that we simply lack data.
+
+### Validation gate (required, not optional)
+
+This rule has been stated in this skill before and was violated anyway, so it is
+now checkable. **Before writing any backlink output, run the validator:**
+
+```bash
+claude-seo run validate_backlink_report.py --report <report>.json --json
+```
+
+Pass the sources you actually collected (`cc_data`, `moz_data`, `bing_data`,
+`dataforseo_data`, `scoring_factors`, and your `findings` list). The
+`source_score_consistency` check fails the report with `status: FAIL` when:
+
+- a numeric score is present but no scoreable source (Moz, Bing, or DataForSEO)
+  supplied data -- i.e. the Common-Crawl-only case, and
+- any finding marked `source: not-assessed` carries a numeric `score`, `value`,
+  or `health_score`.
+
+**If the validator returns `status: FAIL`, do not present the report.** Fix the
+findings -- replace the offending numbers with `Not Assessed` -- and re-run until
+it passes.
 
 ## Output Format
 

--- a/skills/seo/references/free-backlink-sources.md
+++ b/skills/seo/references/free-backlink-sources.md
@@ -30,8 +30,20 @@ When merging data from multiple sources, apply confidence weights to each metric
 weighted_score = Σ(source_score × confidence × factor_weight) / Σ(confidence × factor_weight)
 ```
 
-When only Common Crawl is available, cap the maximum health score at 70/100 and note
-"limited to domain-level metrics" in the report.
+**When only Common Crawl is available, do not produce a health score at all.**
+Not a capped one, not an "approximate" one. Common Crawl supplies domain-level
+rank and presence signals only -- it carries none of the referring-domain quality,
+anchor, or toxicity data a health score claims to summarise, so any number derived
+from it reads as "this profile is weak" when the truth is "we have no data."
+
+Report `Not Assessed` in place of the score, surface the rank/presence data that
+Common Crawl *does* support as low-confidence findings, and note "limited to
+domain-level metrics" in the report. The same applies to any finding written with
+`source: not-assessed`.
+
+This is enforced, not advisory: `claude-seo run validate_backlink_report.py` fails
+a report (`status: FAIL`) that carries a number in either case. See the
+`seo-backlinks` skill's "MUST NOT: score what you did not measure" section.
 
 ## Source Details
 

--- a/tests/test_backlink_score_gate.py
+++ b/tests/test_backlink_score_gate.py
@@ -6,6 +6,7 @@ anyway. These tests pin it to something checkable.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -108,3 +109,36 @@ def test_source_score_consistency_runs_without_a_scoring_factors_block() -> None
 
     assert result["status"] == "FAIL"
     assert "source_score_consistency" in result["metadata"]["checks_run"]
+
+
+# ─── Repo-wide: no competing instruction to score unmeasured data ───────────
+
+FREE_SOURCES_REF = REPO_ROOT / "skills" / "seo" / "references" / "free-backlink-sources.md"
+
+
+def test_shared_reference_does_not_contradict_the_no_score_rule() -> None:
+    """The reference used to say 'cap the maximum health score at 70/100'.
+
+    That instructed a number in exactly the Common-Crawl-only case the skill
+    forbids, and gave the more actionable of the two competing instructions --
+    the likely reason the rule was violated despite being written down.
+    """
+    text = FREE_SOURCES_REF.read_text(encoding="utf-8")
+    assert "cap the maximum health score" not in text
+    assert "70/100" not in text
+    assert "do not produce a health score at all" in text
+    assert "Not Assessed" in text
+
+
+def test_no_skill_or_reference_instructs_capping_a_score_for_missing_data() -> None:
+    """Guard the whole class, not just the one line that was found."""
+    pattern = re.compile(
+        r"cap\s+(?:the\s+)?(?:maximum\s+)?[a-z ]*score\s+(?:at|to)\s+\d+",
+        re.I,
+    )
+    offenders = []
+    for root in (REPO_ROOT / "skills", REPO_ROOT / "agents"):
+        for path in root.rglob("*.md"):
+            if pattern.search(path.read_text(encoding="utf-8")):
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert not offenders, f"score-capping instruction reintroduced in: {offenders}"

--- a/tests/test_backlink_score_gate.py
+++ b/tests/test_backlink_score_gate.py
@@ -1,0 +1,110 @@
+"""Backlink scoring: never emit a number for data that was not measured.
+
+The rule already existed as prose in the skill and was violated in a real audit
+anyway. These tests pin it to something checkable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = str(REPO_ROOT / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import validate_backlink_report as vbr  # noqa: E402
+
+
+# ─── Backlink score gating ───────────────────────────────────────────────────
+
+BACKLINKS_SKILL = REPO_ROOT / "skills" / "seo-backlinks" / "SKILL.md"
+
+
+def test_backlinks_skill_states_must_not_and_names_the_validator() -> None:
+    text = BACKLINKS_SKILL.read_text(encoding="utf-8")
+    assert "MUST NOT" in text
+    assert "validate_backlink_report.py" in text
+    assert "status: FAIL" in text
+
+
+def test_common_crawl_only_numeric_score_fails_validation() -> None:
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1234, "in_degree": 57},
+        "scoring_factors": {"score": 42, "factors_with_data": 2, "total_factors": 7},
+    })
+
+    assert result["status"] == "FAIL"
+    messages = [i["message"] for i in result["data"]["issues"]]
+    assert any("Common Crawl was the only source available" in m for m in messages)
+
+
+def test_common_crawl_only_without_a_score_passes() -> None:
+    """Not Assessed is the correct output, and it must validate cleanly."""
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1234, "in_degree": 57},
+        "scoring_factors": {"score": None, "factors_with_data": 2, "total_factors": 7},
+        "findings": [
+            {"title": "Backlink profile", "source": "not-assessed", "score": None},
+        ],
+    })
+
+    errors = [i for i in result["data"]["issues"] if i["severity"] == "error"]
+    assert errors == []
+
+
+def test_not_assessed_finding_with_a_numeric_score_fails_validation() -> None:
+    result = vbr.validate_report({
+        "moz_data": {"domain_authority": 30},
+        "findings": [
+            {"title": "Referring domain quality", "source": "not-assessed", "score": 55},
+        ],
+    })
+
+    assert result["status"] == "FAIL"
+    messages = [i["message"] for i in result["data"]["issues"]]
+    assert any("MUST NOT be scored" in m for m in messages)
+
+
+def test_numeric_score_string_is_still_caught() -> None:
+    """A score serialised as a string is the same misleading number."""
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1},
+        "scoring_factors": {"score": "42"},
+    })
+    assert result["status"] == "FAIL"
+
+
+def test_score_is_allowed_once_a_scoreable_source_has_data() -> None:
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1},
+        "moz_data": {"domain_authority": 41},
+        "scoring_factors": {"score": 68, "factors_with_data": 5, "total_factors": 7},
+    })
+
+    errors = [i for i in result["data"]["issues"] if i["severity"] == "error"]
+    assert errors == []
+
+
+def test_errored_source_does_not_count_as_available() -> None:
+    """A Moz call that failed must not unlock scoring."""
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1},
+        "moz_data": {"error": "401 unauthorized"},
+        "scoring_factors": {"score": 68},
+    })
+
+    assert result["status"] == "FAIL"
+
+
+def test_source_score_consistency_runs_without_a_scoring_factors_block() -> None:
+    """The gate must fire even when the agent omits scoring_factors entirely."""
+    result = vbr.validate_report({
+        "findings": [
+            {"title": "Anchor text", "source": "not-assessed", "health_score": 12},
+        ],
+    })
+
+    assert result["status"] == "FAIL"
+    assert "source_score_consistency" in result["metadata"]["checks_run"]


### PR DESCRIPTION
## Summary

`skills/seo-backlinks/SKILL.md` already said not to produce a numeric health score when
only Common Crawl data is available. The rule was violated in a real audit anyway, and
the reason turns out not to be that it was skimmed past.

**The repo contradicted itself.** `skills/seo/references/free-backlink-sources.md:33`
said:

> When only Common Crawl is available, cap the maximum health score at 70/100 and note
> "limited to domain-level metrics" in the report.

That instructs a number — with a specific cap and a specific caption — in exactly the
case the skill forbids one. Faced with a prohibition and a competing actionable
instruction, the agent followed the actionable one. The output reads as "this backlink
profile is weak" when the truth is "we have no data."

### What changed

**1. The two files now agree.** `free-backlink-sources.md` no longer instructs a capped
score. Common Crawl supplies domain-level rank and presence signals and none of the
referring-domain quality, anchor, or toxicity data a health score claims to summarise,
so the guidance is now `Not Assessed` with the rank/presence data surfaced as
low-confidence findings.

**2. The skill states it unambiguously.** The rule is a bolded **MUST NOT** rather than
descriptive prose at the end of a section.

**3. It is enforced rather than trusted.** `scripts/validate_backlink_report.py` gains
`validate_source_score_consistency()`, which fails a report (`status: FAIL`) when:

- a numeric score is present but no scoreable source (Moz, Bing, or DataForSEO) supplied
  data — the Common-Crawl-only case; or
- a finding marked `source: not-assessed` carries a numeric `score`, `value`, or
  `health_score`.

String-encoded numbers (`"42"`) and errored-out sources (a Moz call that returned 401)
are both handled, and the check runs even when the caller supplies no `scoring_factors`
block at all. The skill now requires a passing validator run before any backlink output
is presented.

Worth noting: this validator already existed with a related data-sufficiency gate, but
nothing in the repo invoked it. That is the other half of why the instruction never held.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting — **see note below**
- [x] SKILL.md files stay under 500 lines (if modified) — `seo-backlinks` 298
- [x] Python scripts output JSON (if modified) — `validate_backlink_report.py` unchanged in that respect
- [x] Reference files stay under 200 lines (if modified) — `free-backlink-sources.md` 119
- [ ] `set -euo pipefail` used in any new shell scripts — no shell scripts added
- [x] CHANGELOG.md updated with the change

**On the real-URL checkbox:** the validator operates on a report JSON, not a URL. What I
ran instead, which I think is the more relevant check — a simulated credential-less run
against an empty `HOME`:

```
$ backlinks_auth.py --check --json   # moz: unavailable, bing: unavailable, commoncrawl: available
$ validate_backlink_report.py --report cc-only-with-score.json --json
status: FAIL
  health_score       :: Numeric score (58) produced when Common Crawl was the only source available…
  findings[0].score  :: Finding 'Backlink Health' is source: not-assessed but carries a numeric score (58)…
$ validate_backlink_report.py --report cc-only-not-assessed.json --json
status: PASS
```

Plus the full suite (403 passed, 1 skipped) and 10 new cases in
`tests/test_backlink_score_gate.py`. The two guards against the reference-file
contradiction were verified by restoring the original line and confirming they fail,
rather than trusting a green run. The two pre-existing `tests/test_sync_flow.py` failures
in my environment are network/TLS related and unrelated to this change; they are
deselected in that count.

## Note for the maintainer

This touches `CHANGELOG.md` under a new `## [Unreleased]` heading, as does my other open
PR (#259). Whichever merges second will conflict there — happy to rebase that one, or
drop the changelog hunk from either if you would rather batch them yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
