### PR TITLE
Add Keywords Everywhere (Open PageRank) as a backlinks fallback source

### DIFF
--- a/scripts/backlinks_auth.py
+++ b/scripts/backlinks_auth.py
@@ -44,6 +44,7 @@ CACHE_DIR = os.path.expanduser("~/.cache/claude-seo/commoncrawl")
 SERVICE_AUTH = {
     "moz": "api_key",
     "bing": "api_key",
+    "keywordseverywhere": "api_key",
     "commoncrawl": "none",
     "verify": "none",
 }
@@ -52,6 +53,7 @@ SERVICE_AUTH = {
 SERVICE_NAMES = {
     "moz": "Moz Link Explorer API",
     "bing": "Bing Webmaster Tools API",
+    "keywordseverywhere": "Keywords Everywhere (Open PageRank)",
     "commoncrawl": "Common Crawl Web Graph",
     "verify": "Backlink Verification Crawler",
 }
@@ -72,6 +74,7 @@ def load_config() -> dict:
         "moz_api_key": None,
         "bing_api_key": None,
         "bing_verified_sites": [],
+        "keywordseverywhere_api_key": None,
         "commoncrawl_cache_dir": CACHE_DIR,
     }
 
@@ -92,6 +95,9 @@ def load_config() -> dict:
 
     if not config["bing_api_key"]:
         config["bing_api_key"] = os.environ.get("BING_WEBMASTER_API_KEY")
+
+    if not config["keywordseverywhere_api_key"]:
+        config["keywordseverywhere_api_key"] = os.environ.get("KEYWORDSEVERYWHERE_API_KEY")
 
     # Expand cache dir path
     config["commoncrawl_cache_dir"] = os.path.expanduser(
@@ -168,6 +174,23 @@ def check_credentials(service: str) -> dict:
                 "         Get free key at https://www.bing.com/webmasters"
             )
 
+    elif service == "keywordseverywhere":
+        api_key = config.get("keywordseverywhere_api_key")
+        if api_key:
+            result["available"] = True
+            result["method"] = "api_key_configured"
+            result["verified"] = False
+            result["note"] = (
+                "Keywords Everywhere credentials are configured but not live-verified by --check. "
+                "Run `python scripts/keywordseverywhere_api.py rank example.com --json` to test."
+            )
+        else:
+            result["error"] = (
+                "No Keywords Everywhere API key found. Set KEYWORDSEVERYWHERE_API_KEY "
+                f"environment variable or add 'keywordseverywhere_api_key' to {CONFIG_PATH}\n"
+                "         Get a key from your Keywords Everywhere dashboard"
+            )
+
     elif service == "commoncrawl":
         # Common Crawl is always available (public data, no auth needed)
         result["available"] = True
@@ -216,6 +239,7 @@ def detect_tier() -> dict:
 
     has_moz = bool(config.get("moz_api_key"))
     has_bing = bool(config.get("bing_api_key"))
+    has_kwe = bool(config.get("keywordseverywhere_api_key"))
 
     if has_moz and has_bing:
         return {
@@ -228,7 +252,7 @@ def detect_tier() -> dict:
                 "Bing comparison between registered properties",
                 "Common Crawl domain-level graph",
                 "Backlink verification crawler",
-            ],
+            ] + (["Keywords Everywhere Open PageRank (0-10 domain rank)"] if has_kwe else []),
             "missing": "Add DataForSEO extension for premium backlink data (paid)",
         }
     elif has_moz:
@@ -240,7 +264,7 @@ def detect_tier() -> dict:
                 "Moz referring domains and anchors",
                 "Common Crawl domain-level graph",
                 "Backlink verification crawler",
-            ],
+            ] + (["Keywords Everywhere Open PageRank (0-10 domain rank)"] if has_kwe else []),
             "missing": (
                 "Add Bing Webmaster API key for registered-property link data. "
                 "Free at https://www.bing.com/webmasters"
@@ -253,10 +277,11 @@ def detect_tier() -> dict:
             "capabilities": [
                 "Common Crawl domain-level graph (PageRank, in-degree)",
                 "Backlink verification crawler",
-            ],
+            ] + (["Keywords Everywhere Open PageRank (0-10 domain rank)"] if has_kwe else []),
             "missing": (
                 "Add Moz API key for DA/PA and spam scoring. "
-                "Free at https://moz.com/products/api (2,500 rows/month)"
+                "Free at https://moz.com/products/api (2,500 rows/month). "
+                "Or add a Keywords Everywhere key for a lightweight 0-10 domain rank fallback."
             ),
         }
 
@@ -271,6 +296,12 @@ def get_bing_api_key() -> Optional[str]:
     """Get the Bing Webmaster API key from config or environment."""
     config = load_config()
     return config.get("bing_api_key")
+
+
+def get_keywordseverywhere_api_key() -> Optional[str]:
+    """Get the Keywords Everywhere API key from config or environment."""
+    config = load_config()
+    return config.get("keywordseverywhere_api_key")
 
 
 def get_bing_verified_sites() -> list:
@@ -351,6 +382,25 @@ TIER 2: + BING WEBMASTER TOOLS API (free, verified sites)
             competitor backlink comparison (unique feature!).
   Limitation: Only works for verified sites + their competitors.
 
+OPTIONAL: KEYWORDS EVERYWHERE / OPEN PAGERANK (free signup, single-metric fallback)
+--------------------------------------------------------------------------------------
+  1. Sign in to the Keywords Everywhere dashboard (formerly OpenPageRank)
+  2. Copy your API key (format: opr_live_xxxxxxxxxxxxxxxx)
+  3. Verify current pricing/credit terms in the dashboard before relying on it --
+     not independently confirmed here.
+
+  Configure:
+    export KEYWORDSEVERYWHERE_API_KEY="opr_live_xxxxxxxxxxxxxxxx"
+
+  Or add to """ + CONFIG_PATH + """:
+    {
+      "keywordseverywhere_api_key": "opr_live_xxxxxxxxxxxxxxxx"
+    }
+
+  Provides: A single 0-10 domain rank score, up to 100 domains per request.
+  No referring domains, anchors, or top pages -- use Moz for those. A
+  lightweight Profile Overview fallback when Moz isn't configured.
+
 PREMIUM: DATAFORSEO EXTENSION (paid, most comprehensive)
 ----------------------------------------------------------
   For full commercial-grade backlink data, install the DataForSEO extension:
@@ -376,7 +426,7 @@ def main():
         nargs="?",
         const="all",
         metavar="SERVICE",
-        help="Check credentials. Optionally specify: moz, bing, commoncrawl, verify",
+        help="Check credentials. Optionally specify: moz, bing, keywordseverywhere, commoncrawl, verify",
     )
     parser.add_argument(
         "--setup",

--- a/scripts/keywordseverywhere_api.py
+++ b/scripts/keywordseverywhere_api.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Keywords Everywhere (formerly OpenPageRank) API client for Claude SEO.
+
+Queries the Keywords Everywhere Open PageRank API for a single domain-level
+rank metric (0-10 scale). Cheap, single-endpoint fallback source -- does not
+provide referring domains, anchors, or top pages like Moz.
+
+Usage:
+    python keywordseverywhere_api.py rank example.com --json
+    python keywordseverywhere_api.py rank example.com another.com --json
+"""
+
+import argparse
+import json
+import sys
+import time
+from typing import Optional
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+import os
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _SCRIPTS_DIR)
+try:
+    from backlinks_auth import get_keywordseverywhere_api_key
+    from url_safety import validate_url, normalize_hostname
+except ImportError:
+    print("Error: backlinks_auth.py and url_safety.py required in scripts/", file=sys.stderr)
+    sys.exit(1)
+
+KWE_BASE = "https://openpagerank.keywordseverywhere.com/api/v1.0/getPageRank"
+MAX_DOMAINS = 100
+
+
+def normalize_domain(raw: str) -> Optional[str]:
+    """
+    Reduce a URL or bare domain to a validated public hostname.
+
+    Strips scheme/path, rejects localhost/private/reserved IPs and hosts
+    via the shared SSRF check, and returns None on anything invalid.
+    """
+    lowered = raw.lower()
+    if "://" in lowered and not lowered.startswith(("http://", "https://")):
+        return None
+    candidate = raw if lowered.startswith(("http://", "https://")) else f"https://{raw}"
+    if not validate_url(candidate):
+        return None
+    from urllib.parse import urlparse
+    hostname = urlparse(candidate).hostname
+    return normalize_hostname(hostname) if hostname else None
+
+
+def get_rank(domains: list, api_key: str) -> dict:
+    """
+    Get Open PageRank (0-10 scale) for up to MAX_DOMAINS domains in one call.
+
+    Args:
+        domains: List of already-validated, normalized hostnames.
+        api_key: Keywords Everywhere API key (opr_live_...).
+
+    Returns:
+        Standard response dict with rank data per domain.
+    """
+    headers = {"API-OPR": api_key}
+    params = [("domains[]", d) for d in domains]
+
+    try:
+        response = requests.get(KWE_BASE, headers=headers, params=params, timeout=30)
+
+        if response.status_code == 401 or response.status_code == 403:
+            return {
+                "status": "error",
+                "data": None,
+                "error": "Invalid Keywords Everywhere API key. Check your key in the Keywords Everywhere dashboard.",
+                "metadata": {"source": "keywordseverywhere"},
+            }
+
+        if response.status_code == 429:
+            return {
+                "status": "rate_limited",
+                "data": None,
+                "error": "Keywords Everywhere rate limit exceeded.",
+                "metadata": {"source": "keywordseverywhere", "rate_limited": True},
+            }
+
+        if response.status_code >= 400:
+            try:
+                err_body = response.json()
+                err_msg = err_body.get("message") or err_body.get("error") or response.text
+            except ValueError:
+                err_msg = response.text or f"HTTP {response.status_code}"
+            return {
+                "status": "error",
+                "data": None,
+                "error": f"HTTP {response.status_code}: {err_msg}",
+                "metadata": {"source": "keywordseverywhere"},
+            }
+
+        body = response.json()
+        results = body.get("response") or []
+        ranks = [
+            {
+                "domain": item.get("domain"),
+                "page_rank_decimal": item.get("page_rank_decimal"),
+                "page_rank_integer": item.get("page_rank_integer"),
+                "rank": item.get("rank"),
+            }
+            for item in results
+        ]
+
+        return {
+            "status": "success",
+            "data": {"domains": ranks},
+            "error": None,
+            "metadata": {
+                "source": "keywordseverywhere",
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            },
+        }
+
+    except requests.exceptions.Timeout:
+        return {
+            "status": "error",
+            "data": None,
+            "error": "Request timed out after 30 seconds",
+            "metadata": {"source": "keywordseverywhere"},
+        }
+    except requests.exceptions.RequestException as e:
+        return {
+            "status": "error",
+            "data": None,
+            "error": str(e),
+            "metadata": {"source": "keywordseverywhere"},
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Keywords Everywhere (Open PageRank) API client for Claude SEO"
+    )
+    parser.add_argument("command", choices=["rank"], help="API command: rank (0-10 domain rank)")
+    parser.add_argument("domains", nargs="+", help="Target domain(s) to look up (max 100)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    if len(args.domains) > MAX_DOMAINS:
+        result = {
+            "status": "error",
+            "data": None,
+            "error": f"Too many domains ({len(args.domains)}); max {MAX_DOMAINS} per request.",
+            "metadata": {"source": "keywordseverywhere"},
+        }
+        print(json.dumps(result, indent=2) if args.json else f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    targets = []
+    for d in args.domains:
+        normalized = normalize_domain(d)
+        if not normalized:
+            result = {
+                "status": "error",
+                "data": None,
+                "error": f"Invalid, private, or blocked domain: {d}",
+                "metadata": {"source": "keywordseverywhere"},
+            }
+            print(json.dumps(result, indent=2) if args.json else f"Error: {result['error']}", file=sys.stderr)
+            sys.exit(1)
+        targets.append(normalized)
+
+    api_key = get_keywordseverywhere_api_key()
+    if not api_key:
+        result = {
+            "status": "error",
+            "data": None,
+            "error": "No Keywords Everywhere API key configured. Run: python scripts/backlinks_auth.py --setup",
+            "metadata": {"source": "keywordseverywhere"},
+        }
+        print(json.dumps(result, indent=2) if args.json else f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    result = get_rank(targets, api_key)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        if result["status"] == "success" and result["data"]:
+            for d in result["data"]["domains"]:
+                print(f"  {d.get('domain', '?'):40s} rank={d.get('page_rank_decimal', '?')}/10 ({d.get('rank', '?')})")
+        elif result["error"]:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        else:
+            print("No data returned.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Free: Common Crawl + verify always available. Optional: Moz API, Bing Webmaster, Keywords Everywhere (free signup). Premium: DataForSEO extension."
 metadata:
   author: AgriciDaniel
-  version: "2.3.0"
+  version: "2.2.4"
   category: seo
 ---
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -4,10 +4,10 @@ description: "Backlink profile analysis: referring domains, anchor text distribu
 user-invocable: true
 argument-hint: "<url>"
 license: MIT
-compatibility: "Free: Common Crawl + verify always available. Optional: Moz API, Bing Webmaster (free signup). Premium: DataForSEO extension."
+compatibility: "Free: Common Crawl + verify always available. Optional: Moz API, Bing Webmaster, Keywords Everywhere (free signup). Premium: DataForSEO extension."
 metadata:
   author: AgriciDaniel
-  version: "2.2.4"
+  version: "2.3.0"
   category: seo
 ---
 
@@ -20,8 +20,9 @@ Before analysis, detect available data sources:
 1. **DataForSEO MCP** (premium): Check if `dataforseo_backlinks_summary` tool is available
 2. **Moz API** (free signup): `claude-seo run backlinks_auth.py --check moz --json`
 3. **Bing Webmaster** (free signup): `claude-seo run backlinks_auth.py --check bing --json`
-4. **Common Crawl** (always available): Domain-level graph with PageRank
-5. **Verification Crawler** (always available): Checks if known backlinks still exist
+4. **Keywords Everywhere** (free signup, single-metric): `claude-seo run backlinks_auth.py --check keywordseverywhere --json`
+5. **Common Crawl** (always available): Domain-level graph with PageRank
+6. **Verification Crawler** (always available): Checks if known backlinks still exist
 
 Run `claude-seo run backlinks_auth.py --check --json` to detect all sources at once.
 
@@ -49,6 +50,8 @@ Produce all 7 sections below. Each section lists data sources in preference orde
 **DataForSEO:** `dataforseo_backlinks_summary` → total backlinks, referring domains, domain rank, follow ratio, trend.
 
 **Moz API:** `claude-seo run moz_api.py metrics <url> --json` → Domain Authority, Page Authority, Spam Score, linking root domains, external links.
+
+**Keywords Everywhere:** `claude-seo run keywordseverywhere_api.py rank <domain> --json` → 0-10 domain rank only (no link counts). Use as a fallback when Moz isn't configured; do not use in place of Moz when both are available.
 
 **Common Crawl:** `claude-seo run commoncrawl_graph.py <domain> --json` → PageRank, harmonic centrality, and low-confidence rank/presence data.
 
@@ -222,9 +225,11 @@ the reality is we simply lack data.
 2. Moz configured? → Use for DA/PA/spam/anchors (confidence: 0.85)
 3. Bing configured? → Use for registered-property links and comparison only
    when both properties are accessible (confidence: 0.70)
-4. Always: Common Crawl for domain-level metrics (confidence: 0.50)
-5. Always: Verification crawler for known link checks (confidence: 0.95)
-6. Nothing works? → "Run `/seo backlinks setup` to configure free APIs"
+4. Moz not configured but Keywords Everywhere is? → Use for a Profile Overview
+   rank-only fallback (confidence: 0.60; single metric, no link counts/anchors)
+5. Always: Common Crawl for domain-level metrics (confidence: 0.50)
+6. Always: Verification crawler for known link checks (confidence: 0.95)
+7. Nothing works? → "Run `/seo backlinks setup` to configure free APIs"
 
 ## Pre-Delivery Review (MANDATORY)
 


### PR DESCRIPTION
## Summary
- Adds Keywords Everywhere (formerly OpenPageRank) as an optional, free-signup backlink data source in `seo-backlinks`, following the existing `moz_api.py`/`backlinks_auth.py` credential and source patterns
- Provides a single 0-10 domain rank metric as a lightweight Profile Overview fallback when Moz isn't configured (confidence 0.60, below Moz's 0.85, above Common Crawl's 0.50) — no referring domains/anchors/top pages, use Moz for those
- New `scripts/keywordseverywhere_api.py` client normalizes and SSRF-validates every input domain via the existing `url_safety` module before querying

## Notes
- Reviewed over two rounds by an independent agent review; caught and fixed a scheme-validation gap (`ftp://localhost`-style bypass) and a silent >100-domain truncation before landing
- SKILL.md version left at the repo's locked 2.2.4 to match `plugin.json` and every other skill

## Test plan
- [x] `python -c "import ast; ast.parse(...)"` syntax check on both edited/new Python files
- [ ] Live API call against a real Keywords Everywhere key (not run here — no test key available in this environment)