### PR TITLE
fix(content-quality): tokenise CJK so Korean/Japanese/Chinese pages get real scores

### DIFF
--- a/scripts/content_quality.py
+++ b/scripts/content_quality.py
@@ -141,11 +141,23 @@ _AI_PATTERNS: tuple[str, ...] = (
 )
 
 
-_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z'\-]*")
+# Latin words, Hangul eojeol, and CJK/kana characters. Korean is space
+# delimited so a run of syllables is one token; Chinese and Japanese are
+# unspaced, so one ideograph or kana counts as one token.
+_TOKEN_RE = re.compile(
+    r"[A-Za-z][A-Za-z'\-]*"
+    r"|[\uac00-\ud7a3]+"
+    r"|[\u3041-\u3096\u30a1-\u30fa\u30fc]"
+    r"|[\u3400-\u4dbf\u4e00-\u9fff]"
+)
 _NUMBER_RE = re.compile(r"\b\d+(?:[.,]\d+)?(?:%|st|nd|rd|th)?\b")
 # Capitalised multi-word names: rough proper-noun heuristic. Two or more
 # capitalised tokens in a row count as one entity.
 _ENTITY_RE = re.compile(r"\b(?:[A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b")
+# NOTE: CJK scripts have no letter case, so this heuristic finds no entities
+# in Korean/Japanese/Chinese text. Density for those languages therefore rests
+# on _NUMBER_RE alone and skews low. Tokenisation (above) is the load-bearing
+# fix; CJK named-entity detection needs a real model, not a regex.
 
 
 def _count_phrase_hits(text: str, patterns: Iterable[str]) -> list[str]:

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -108,6 +108,53 @@ def test_content_quality_detects_known_ai_patterns(phrase: str) -> None:
     assert result["ai_pattern_score"] > 0
     assert phrase.lower() in [m.lower() for m in result["matches"]["ai_patterns"]]
 
+def test_content_quality_tokenises_korean() -> None:
+    """Hangul is space-delimited, so a run of syllables is one token.
+
+    Before CJK support the Latin-only tokeniser matched nothing in Korean
+    text, so ``tokens`` was 0, ``information_density`` collapsed to 0.0 and
+    every Korean page scored an identical 65 regardless of content.
+    """
+    text = (
+        "한국천문연구원 공표 절기를 기준으로 계산하는 정통 사주팔자 풀이입니다. "
+        "생년월일시를 한 번만 입력하면 천간과 지지, 오행, 대운까지 확인할 수 있습니다."
+    )
+    result = content_quality.analyse(text)
+    assert result["tokens"] > 0, result
+    assert result["unique_tokens"] > 0, result
+
+
+def test_content_quality_tokenises_japanese_and_chinese() -> None:
+    """Japanese and Chinese are unspaced: one kana or ideograph is one token."""
+    for text in ("無料四柱推命で日柱と五行がわかります。", "免费四柱推命，一分钟了解日柱与五行。"):
+        result = content_quality.analyse(text)
+        assert result["tokens"] > 0, (text, result)
+
+
+def test_content_quality_cjk_distinguishes_documents() -> None:
+    """Different Korean documents must not collapse to one identical score."""
+    short = "사주는 자기 이해의 한 관점입니다."
+    long = (
+        "사주팔자는 태어난 연월일시를 천간과 지지로 옮긴 여덟 글자입니다. "
+        "절기를 기준으로 월주를 정하고, 진태양시로 시주를 보정합니다. "
+        "오행의 균형과 십신의 배치를 함께 살펴 전체 흐름을 읽습니다. "
+        "대운은 10년 단위로 바뀌고 세운은 해마다 달라집니다."
+    )
+    assert content_quality.analyse(long)["tokens"] > content_quality.analyse(short)["tokens"]
+
+
+def test_content_quality_latin_scoring_unchanged_by_cjk_support() -> None:
+    """Regression guard: adding CJK ranges must not shift Latin tokenisation."""
+    text = (
+        "Traditional Korean four pillars astrology calculated from the KASI "
+        "published solar terms. Enter your birth date and time once to see the "
+        "heavenly stems, earthly branches, five elements and major luck cycles."
+    )
+    result = content_quality.analyse(text)
+    assert result["tokens"] == len(
+        [w for w in __import__("re").findall(r"[A-Za-z][A-Za-z'\-]*", text)]
+    ), result
+
 
 # ---------------------------------------------------------------------------
 # content_humanize


### PR DESCRIPTION
## The problem

`content_quality.py` tokenises with `_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z'\-]*")`.

Hangul, kana and ideographs match nothing, so **CJK text produces zero tokens**. I measured the same sentence in both languages against v2.2.5:

| input | tokens | unique | density | overall |
|---|---|---|---|---|
| English | 58 | 53 | 0.172 | 70 |
| Korean (same content) | **0** | **0** | **0.0** | 65 |

With `tokens == 0`, `information_density` collapses to `0.0`, `_repetition_score` returns early on `len(tokens) < 4`, and the phrase lists are English — so **every Korean page lands on an identical `overall_quality: 65` with `low-density` + `thin-content`**, no matter what it says.

Content Quality carries the **largest weight in the SEO Health Score (23%)**, so that axis is currently inert for any non-Latin site. `/seo content` and `/seo audit` cannot distinguish a good Korean page from a bad one.

## The change

Three alternations added to the tokeniser:

- **Hangul syllable runs** — Korean is space-delimited, so a run of syllables is one word.
- **kana** and **CJK ideographs** — Chinese and Japanese are unspaced, so one character counts as one token.

Latin tokenisation is byte-for-byte untouched, and a regression test pins it to the original regex's output.

## Result

The same three Korean pages now differentiate instead of collapsing:

| page | before | after |
|---|---|---|
| `/about` | 65 (0 tokens) | **68** (300 tokens) |
| `/learn/…` | 65 (0 tokens) | **70** (273 tokens) |
| `/today` | 65 (0 tokens) | **72** (443 tokens) |

`thin-content` now actually discriminates: it clears on two of the three and stays on the shortest.

## Known limit, documented in the diff

`_ENTITY_RE` is a capitalised-name heuristic, and CJK scripts have no letter case — so entity detection stays at 0 for these languages and density still skews low. I left a `NOTE` beside it rather than papering over it: tokenisation is the load-bearing fix, and CJK named-entity detection needs a model, not a regex.

## Tests

4 added to `tests/test_content_quality.py` following the existing style — Korean tokenisation, JA/ZH tokenisation, document discrimination, and a Latin regression guard.

- Full file: **31 passed**.
- Mutation-checked: reverting the tokeniser fails exactly the 3 CJK tests, and the Latin guard passes both ways as intended.

Tested against a live Korean site (`kongmingsaju.com`) via `render_page.py` → `content_quality.py`, per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)