### PR TITLE
fix(uninstall): report all removed Windows entries

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -119,15 +119,38 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          ./uninstall.ps1
           $skills = Join-Path $env:USERPROFILE ".claude\skills"
           $agents = Join-Path $env:USERPROFILE ".claude\agents"
+          $expectedSkillDirs = @(Get-ChildItem -Path $skills -Directory -Filter "seo" -ErrorAction SilentlyContinue).Count + @(Get-ChildItem -Path $skills -Directory -Filter "seo-*" -ErrorAction SilentlyContinue).Count
+          $expectedAgentFiles = @(Get-ChildItem -Path $agents -File -Filter "seo-*.md" -ErrorAction SilentlyContinue).Count
+          $uninstallOutput = & ./uninstall.ps1 6>&1 | Out-String
+          $expectedSummary = "claude-seo uninstalled ($expectedSkillDirs skill dirs, $expectedAgentFiles agent files)"
+          if ($uninstallOutput -notmatch [regex]::Escape($expectedSummary)) {
+            throw "Uninstaller summary did not report all removed entries. Output: $uninstallOutput"
+          }
           if (Test-Path (Join-Path $skills "seo")) { throw "Orchestrator skill remains" }
           if (Get-ChildItem -Path $skills -Directory -Filter "seo-*" -ErrorAction SilentlyContinue) {
             throw "SEO sub-skill directories remain"
           }
           if (Get-ChildItem -Path $agents -File -Filter "seo-*.md" -ErrorAction SilentlyContinue) {
             throw "SEO agent files remain"
+          }
+
+          # A partial install can contain sub-skills and agents without the
+          # orchestrator. Its removal count must still be accurate.
+          New-Item -ItemType Directory -Force -Path (Join-Path $skills "seo-local"), (Join-Path $skills "seo-maps") | Out-Null
+          New-Item -ItemType File -Force -Path (Join-Path $agents "seo-local.md"), (Join-Path $agents "seo-maps.md") | Out-Null
+          $partialOutput = & ./uninstall.ps1 6>&1 | Out-String
+          $partialSummary = "claude-seo uninstalled (2 skill dirs, 2 agent files)"
+          if ($partialOutput -notmatch [regex]::Escape($partialSummary)) {
+            throw "Partial-install summary was incorrect. Output: $partialOutput"
+          }
+          if (Test-Path (Join-Path $skills "seo-local")) { throw "Partial sub-skill remains" }
+          if (Test-Path (Join-Path $agents "seo-local.md")) { throw "Partial agent remains" }
+
+          $emptyOutput = & ./uninstall.ps1 6>&1 | Out-String
+          if ($emptyOutput -notmatch [regex]::Escape("Nothing to remove")) {
+            throw "Second uninstall did not report an empty install. Output: $emptyOutput"
           }
 
       - name: Remove isolated user profile

--- a/tests/test_windows_uninstaller.py
+++ b/tests/test_windows_uninstaller.py
@@ -1,0 +1,26 @@
+"""Static contracts for the Windows manual uninstaller."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_uninstaller_counts_removed_items_in_main_scope() -> None:
+    """Pipeline child scopes must not lose counts before the summary is printed."""
+    text = (ROOT / "uninstall.ps1").read_text(encoding="utf-8")
+
+    assert "foreach ($subSkill in @(Get-ChildItem" in text
+    assert "foreach ($agentFile in @(Get-ChildItem" in text
+    assert "$removedSkills++" in text
+    assert "$removedAgents++" in text
+    assert "$script:removedSkills++" not in text
+    assert "$script:removedAgents++" not in text
+
+
+def test_windows_smoke_checks_full_partial_and_empty_uninstalls() -> None:
+    text = (ROOT / ".github/workflows/windows-smoke.yml").read_text(encoding="utf-8")
+
+    assert "$expectedSummary" in text
+    assert "-Filter \"seo\" -ErrorAction SilentlyContinue) +" not in text
+    assert "Partial-install summary was incorrect" in text
+    assert "Nothing to remove" in text

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -38,19 +38,19 @@ function Main {
 
     # Remove every seo-* sub-skill directory
     if (Test-Path $SkillDir -PathType Container) {
-        Get-ChildItem -Path $SkillDir -Directory -Filter "seo-*" -ErrorAction SilentlyContinue | ForEach-Object {
-            Remove-Item -Recurse -Force $_.FullName
-            Write-Color Green "  Removed: $($_.FullName)"
-            $script:removedSkills++
+        foreach ($subSkill in @(Get-ChildItem -Path $SkillDir -Directory -Filter "seo-*" -ErrorAction SilentlyContinue)) {
+            Remove-Item -Recurse -Force $subSkill.FullName
+            Write-Color Green "  Removed: $($subSkill.FullName)"
+            $removedSkills++
         }
     }
 
     # Remove every seo-*.md agent file
     if (Test-Path $AgentDir -PathType Container) {
-        Get-ChildItem -Path $AgentDir -File -Filter "seo-*.md" -ErrorAction SilentlyContinue | ForEach-Object {
-            Remove-Item -Force $_.FullName
-            Write-Color Green "  Removed: $($_.FullName)"
-            $script:removedAgents++
+        foreach ($agentFile in @(Get-ChildItem -Path $AgentDir -File -Filter "seo-*.md" -ErrorAction SilentlyContinue)) {
+            Remove-Item -Force $agentFile.FullName
+            Write-Color Green "  Removed: $($agentFile.FullName)"
+            $removedAgents++
         }
     }
 


### PR DESCRIPTION
## Summary

Correct the Windows manual uninstaller summary so it counts every removed sub-skill directory and agent file. Removal behavior shipped in v2.2.5 was correct. This change fixes reporting only.

## Changes

- Replace pipeline child-scope counters with local-scope foreach loops.
- Extend the hosted Windows smoke with dynamic full-install count assertions.
- Cover a partial install without the orchestrator and the empty second-run message.

## Verification

- Full local test suite: 441 passed.
- Focused installer contract suite: 28 passed.
- Ruff check for the added regression test: passed.
- Parsed the Windows smoke workflow with PyYAML: passed.
- Diff whitespace check: passed.
- Hosted CI: all 7 checks passed.
- Hosted Windows smoke passed the full-install dynamic count, partial install without the orchestrator, empty second-run message, and filesystem removal checks.
- The first hosted Windows run failed before product code ran because the test attempted to add DirectoryInfo objects. The assertion now adds separately wrapped counts, and the corrected run passed.

## Risk and rollback

Low risk, revert the merge. This changes only reporting scope and smoke coverage, not which files the uninstaller removes.

## Open items

- No release tag is changed by this reporting-only fix.