### PR TITLE
docs(workflow): record final v2.2.5 verification

### DIFF
--- a/docs/FINAL-VERIFICATION-v2.2.5-2026-08-26.md
+++ b/docs/FINAL-VERIFICATION-v2.2.5-2026-08-26.md
@@ -1,0 +1,158 @@
+# Claude SEO v2.2.5 final verification
+
+Date: 2026-08-26
+
+## Verdict
+
+The public release, reviewed private sync, and production website are functional
+and verified. The authorized v2.2.5 cleanup and post-release maintenance set is
+complete. The score remains below 10/10 because private hosted CI is blocked by
+organization billing, the Windows installer proof used Python 3.14.7 rather
+than the minimum supported Python 3.10, and one public post-release commit
+retains malformed body metadata.
+
+## Scorecard
+
+| Area | Score | Evidence-led status |
+|---|---:|---|
+| Public v2.2.5 behavior | 9.7/10 | 439 tests and post-merge CI passed |
+| Public current main | 9.8/10 | 441 tests, Ruff clean, cross-platform and installer CI green |
+| Public release governance | 9.8/10 | Release metadata is corrected and the tag signature is verified |
+| Private mirror | 9.7/10 | Reviewed maintenance sync is merged; private-only content is preserved |
+| Private hosted CI | 4.0/10 | Jobs cannot start until organization billing is repaired |
+| Live website | 9.8/10 | Production content and deterministic gates passed |
+| Website source durability | 10/10 | Exact deployed source snapshot is committed and pushed |
+| Authorized closure set | 10/10 | All 10 fixed issues and 5 superseded PRs are closed |
+| Overall | **9.1/10** | Simple mean of the eight scored areas above |
+
+## Verified facts
+
+### Public repository
+
+- The annotated `v2.2.5` tag and GitHub Release remain frozen at
+  `2384fdd9429696021d143006a722c7cf1aa76d43`.
+- Public `main` includes reviewed post-release maintenance through
+  `3344796aafe09b061685c3ec50364704fe6f9cad`.
+- Exact-tag rerun: 439 tests passed.
+- Portability: 33 skills, 0 errors, 0 warnings.
+- Consistency: 380 files, 0 errors, 0 warnings.
+- The exact release tree retains 126 historical Ruff findings. Current public
+  `main` is repo-wide Ruff clean without moving or rewriting the release tag.
+- `pip-audit`, strict plugin validation, Bash syntax, secret scan, and diff
+  checks passed.
+- Native Windows and macOS portability jobs passed on Python 3.10.
+- A Windows Server 2025 PowerShell 7 run installed the public v2.2.5 tag,
+  verified runtime health and bundled Google update data, uninstalled it, and
+  verified complete cleanup. The installer selected Python 3.14.7 through
+  `py -3`, so this is not minimum-Python installer proof.
+- The Windows smoke exposed an inaccurate uninstaller summary counter. The
+  reporting-only defect was fixed and verified for full, partial, and empty
+  install states; removal targets and deletion behavior were unchanged.
+- GitHub verifies the annotated tag SSH signature as valid. The tag API records
+  `verified: true` with verification time 2026-08-26T11:44:38Z.
+
+### Private repository
+
+- The annotated private `v2.2.5` tag remains frozen at
+  `d76a8ddf56eda305e0281db795fedeba5e534232`.
+- Private `main` and `v2` include reviewed post-release maintenance through
+  `9f5dd208895362b4bec3a7b06d34d707d617b6a5`.
+- The original private checkout remains at `01ca5c5` with all 12 user-modified
+  skill files preserved.
+- Private marketplace identity, AI Marketing Hub ownership, Pro documentation,
+  and six private research reports remain intact.
+- PR #20 is merged.
+- PR #21 is merged under the explicit maintainer waiver after 441 tests passed,
+  all four patch IDs matched the reviewed public source commits, and an
+  independent review confirmed that private-only content was unchanged.
+- GitHub jobs executed zero steps because organization billing or spending
+  limits prevented startup. This is not a test failure, but hosted verification
+  is unavailable.
+- Actions are enabled, workflows are active, and all actions are allowed. The
+  organization has a $5 hard-stop Actions budget with only $0.218 net August
+  usage. GitHub does not expose payment-card status through the available API,
+  so the exact payment-versus-limit condition requires interactive inspection.
+
+### Production website
+
+- The website presents v2.2.5 consistently.
+- 28 website tests passed.
+- Site quality: 56 pages, 0 hard failures, 0 review items.
+- 208 JSON-LD blocks parsed.
+- Sitemap: 55 unique URLs matching 55 canonical URLs.
+- Network-aware publishing validation passed.
+- Independent audit matched 61 of 61 production pages, crawler files, and assets
+  byte-for-byte before the final count correction.
+- Security headers include CSP, HSTS, frame denial, MIME protection, referrer
+  policy, and permissions policy.
+- The dated site snapshot of 15,113 stars and 2,215 forks was truthful when
+  deployed, and its 15.1K display was correct at that time.
+- Final star refresh: GitHub reported 15,232 stars and 2,240 forks. Production
+  now displays v2.2.5 and the correct one-decimal 15.2K value.
+- The current deployed source is committed to the private website repository at
+  `f77dc34a96237afe8699edb48f3c03c259f5d82e`.
+
+## Refuted or corrected claims
+
+- The consistency count is 380 files, not 379. The website release article,
+  generated crawler corpus, and public GitHub Release now agree.
+- Public and private release commits are not separated by one branding commit.
+  They are separately reviewed histories with documented content differences.
+- The website repository does have a private origin:
+  `AgriciDaniel/claude-seo-website`.
+- Repository-wide Ruff did not pass on the frozen release tag. It passes on
+  current public `main` after a separately reviewed mechanical cleanup.
+- Production deployment and source-control durability are complete.
+
+## Fixes completed in this verification pass
+
+- Fast-forwarded the public checkout to public v2.2.5 while preserving all
+  untracked audit artifacts.
+- Corrected public/private workflow documentation for reviewed divergent SHAs,
+  repository-specific tags, atomic or tag-first release ordering, and no
+  force-sync rule.
+- Corrected website governance docs to name the private origin and record the
+  uncommitted production-source risk.
+- Corrected website verification copy and FAQ parity from 379 to 380 files.
+- Regenerated `llms-full.txt` and reran website and public documentation gates.
+- Committed and pushed all 77 production website source paths to the private
+  website repository after a zero-finding candidate secret scan.
+- Corrected the published v2.2.5 GitHub Release count from 379 to 380.
+- Closed 10 issues verified fixed by #261 and v2.2.5: #256, #250, #246, #210,
+  #208, #205, #188, #187, #186, and #180.
+- Closed five PRs superseded by #261 and v2.2.5: #257, #248, #242, #241, and
+  #240.
+- The closure set was intentionally narrow. Seven issues and 34 other public
+  PRs remain open after this documentation PR is excluded; they were not
+  represented as resolved by the v2.2.5 work.
+- Merged PR #185 after native Windows and macOS portability checks passed.
+- Merged PR #264 after 126 Ruff findings were reduced to zero, 439 tests passed,
+  and an adversarial review caught and corrected stale-base and commit-message
+  defects before merge.
+- Merged PR #265 after the v2.2.5 PowerShell installer, runtime, bundled data,
+  uninstall, and filesystem cleanup all passed on hosted Windows.
+- Merged PR #266 after 441 tests and seven exact-head checks passed. Its first
+  Windows attempt correctly failed in the new test expression before product
+  code executed; the assertion was repaired and the exact rerun passed.
+- Merged private PR #21 and advanced private `v2` by fast-forward after exact
+  patch comparison, 441 private tests, and preservation checks passed. The
+  private v2.2.5 tag was not moved.
+- Updated the live website from 15.1K to 15.2K after the repository crossed the
+  one-decimal threshold. Six production surfaces matched local bytes after
+  deployment, and the private website source commit is `f77dc34`.
+
+## Remaining execution gaps
+
+1. Inspect AI Marketing Hub Billing and plans interactively. Repair the payment
+   state or applicable Actions spending limit, then rerun private CI and the v2
+   audit. The available API does not prove which condition is blocking startup.
+2. If minimum-version installer proof is required, run the Windows installer
+   with only Python 3.10 discoverable. Existing proof covers native Windows on
+   Python 3.14.7 plus cross-platform unit tests on Python 3.10.
+3. Public post-release commit `2651be0` contains literal backslash-n sequences
+   in its body from the squash merge command. Its code and hosted checks are
+   valid. The private cherry-pick message was repaired, but public history was
+   not rewritten to fix metadata.
+
+No history was rewritten and no user changes were discarded. All external
+closures were limited to the exact authorized and independently verified set.

--- a/docs/WORKFLOW-public-private.md
+++ b/docs/WORKFLOW-public-private.md
@@ -3,11 +3,13 @@
 claude-seo is mirrored across two GitHub remotes. This document is the
 canonical reference for how work flows between them.
 
+Release evidence: [v2.2.5 final verification](FINAL-VERIFICATION-v2.2.5-2026-08-26.md).
+
 ## Topology
 
 ```
-                    LOCAL CHECKOUT
-                    (single source of truth)
+                 REVIEWED RELEASE WORK
+                (isolated clean worktree)
                        │
         ┌──────────────┼──────────────┐
         │                             │
@@ -15,13 +17,15 @@ canonical reference for how work flows between them.
   origin (public)              aimh (private)
   AgriciDaniel/claude-seo      AI-Marketing-Hub/claude-seo
   - Release destination        - Daily development
-  - main = released history    - main = synced with public
+  - main = released history    - main = reviewed private release history
   - Tags = release history     - v2 = active development
   - Users discover here        - Dependabot + CI run here
 ```
 
-Both remotes share git history because they were initialized from the
-same local repository. Neither is a GitHub fork of the other.
+Both remotes share historical ancestry because they were initialized from the
+same local repository. Reviewed back-ports, private-only research, and public
+branding mean their current release commits can have different SHAs. Neither
+repository is a GitHub fork of the other.
 
 ## Day-to-day development
 
@@ -40,32 +44,18 @@ git push aimh v2
 The private repo runs Dependabot, GitHub Actions CI, and any pre-release
 test gates. No need to touch the public remote for routine work.
 
-## Promoting a release to public
+## Promoting reviewed release changes
 
-When `v2` (or whatever branch holds the next release) is ready to go public:
-
-1. **Locally**: merge into main and tag.
-   ```bash
-   git checkout main
-   git merge --ff-only v2          # fast-forward only — no merge commits
-   git tag -a v2.0.1 -m "release: v2.0.1"
-   ```
-
-2. **Push to private first** (private should never lag public).
-   ```bash
-   git push aimh main
-   git push aimh v2.0.1
-   ```
-
-3. **Push to public** in tag-before-merge order (avoids the curl|bash
-   outage window where users pull a tag that doesn't yet point at code
-   on main).
-   ```bash
-   git push origin v2.0.1          # tag first
-   git push origin main            # then branch
-   ```
-
-4. **Create the GitHub release** on the public repo only.
+1. Start from an isolated clean worktree for the target repository.
+2. Fast-forward only when ancestry proves it is safe. When release lines have
+   diverged, cherry-pick the exact reviewed commits with `-x`.
+3. Resolve only documented repository-specific differences, then run the full
+   test, portability, consistency, security, and plugin-validation gates.
+4. Compare the final private/public trees and explain every remaining path.
+5. Create an annotated tag on each repository's reviewed release commit.
+6. Push private changes first. Push each tag before moving its repository's
+   `main`, or push the tag and branch atomically, so pinned installers resolve.
+7. Create the GitHub release on the public repository only.
    ```bash
    gh release create v2.0.1 \
      --repo AgriciDaniel/claude-seo \
@@ -73,20 +63,27 @@ When `v2` (or whatever branch holds the next release) is ready to go public:
      --verify-tag
    ```
 
-5. **Publish the release blog post**.
+8. Publish the release blog post.
    ```
    /release-blog
    ```
 
 ## Verification commands
 
+Run these from a maintainer checkout with authenticated access to the private
+repository. Add the private remote once if it is absent:
+
+```bash
+git remote get-url aimh >/dev/null 2>&1 || \
+  git remote add aimh https://github.com/AI-Marketing-Hub/claude-seo.git
+```
+
 ```bash
 # Confirm both remotes are wired up
 git remote -v
 
-# Confirm both remotes' main heads.
-# NOTE: origin/main is aimh/main PLUS one public-branding commit (see below),
-# so the SHAs intentionally differ by exactly that commit. Do NOT force-sync them.
+# Confirm both remotes' main heads, then compare their documented divergence.
+# Equal SHAs are not expected after repository-specific back-ports.
 git ls-remote --heads aimh main
 git ls-remote --heads origin main
 
@@ -99,34 +96,19 @@ git fetch aimh
 git log --oneline aimh/main..aimh/v2
 ```
 
-## Public-branding divergence (the one intentional difference)
+## Reviewed public/private divergence
 
-Since v2.0.0 the two repos are **not** byte-identical. They differ by exactly
-one file on one commit:
+The repositories are intentionally not byte-identical:
 
 | File | `aimh` (private) | `origin` (public) |
 |---|---|---|
 | `.claude-plugin/marketplace.json` `name` | `ai-marketing-hub-claude-seo` | `agricidaniel-claude-seo` |
 | `.claude-plugin/marketplace.json` `owner.name` | `AI Marketing Hub` | `AgriciDaniel` |
 
-Everything else (including `README.md`) is shared and public-first: the
-install block defaults to `AgriciDaniel/claude-seo`, with a Pro swap-note that
-names the private slug. This keeps the public repo free of `ai-marketing-hub`
-slugs while keeping the README a single shared file.
-
-**How the divergence is maintained.** The public-only branding lives as the
-tip commit of `origin/main`, carried on a local `public-main` branch:
-
-```bash
-# public-main = main + one commit that rebrands marketplace.json
-git checkout main && git merge --ff-only v2     # shared canonical
-git checkout public-main && git rebase main      # replay branding onto new base
-git push origin public-main:main                 # public gets canonical + branding
-git push aimh  main                              # private gets canonical only
-```
-
-So `origin/main` = `aimh/main` + 1 commit, by design. The release tag points at
-each repo's own HEAD (`origin` tag includes branding; `aimh` tag does not).
+The private repository can also retain private-only `research/` reports, Pro
+documentation, and links to those materials. Workflow state is repository
+specific. Any other difference must be reviewed and explained before release.
+Never force-sync the repositories to make their SHAs or trees identical.
 
 ## Why two repos?
 
@@ -144,21 +126,24 @@ upgrade.
 
 | Pitfall | Avoid by |
 |---|---|
-| Pushing a tag to `origin` before its commit reaches `origin/main` | Always tag-before-merge: push tag first, then branch |
+| Moving `origin/main` before the release tag exists | Push the tag first, then `main`, or push both atomically |
 | `git push --tags` without specifying remote | Be explicit: `git push aimh --tags` or `git push origin v2.0.1` |
 | Force-pushing to either remote | Don't, except with explicit per-operation authorization |
-| Letting `aimh/main` lag behind `origin/main` | Always push to `aimh` first, then `origin` on release |
+| Assuming `aimh/main` and `origin/main` should have equal SHAs | Compare and explain the reviewed tree differences; never force-sync |
 | Confusing `aimh/v2` with `origin/v2` | `origin` should never have an unreleased `v2` branch |
 
-## State for the v2.2.5 public release (2026-08-25)
+## State after v2.2.5 maintenance (2026-08-26)
 
-- v2.2.5 is the release represented by this branch. Its public tag is created only after the reviewed commit is published.
-- `aimh/main` = shared canonical (public-first README, private marketplace name).
-- `origin/main` = `aimh/main` + the public-branding commit (public marketplace name).
-- The intended public `v2.2.5` tag must point at the reviewed release commit on `origin/main`.
-- Private synchronization for v2.2.5 requires a separate review because this release preserves
-  public branding and intentionally excludes private-only content.
-- `aimh/v2` tracks the shared canonical for ongoing v2.x work.
+- The public v2.2.5 tag is `2384fdd`; reviewed post-release maintenance runs
+  through `3344796` before the documentation update that records this state.
+- The private v2.2.5 tag is `d76a8dd`; reviewed post-release maintenance runs
+  through `9f5dd20` before any matching documentation update.
+- Each repository has a repository-specific annotated `v2.2.5` tag.
+- Private `main` and `v2` include reviewed maintenance through `9f5dd20`.
+- Public `main` includes reviewed maintenance through `3344796` and has no
+  public `v2` branch.
+- The private sync preserves private-only research and the
+  `ai-marketing-hub-claude-seo` marketplace identity.
 
 ## Email-privacy caveat (one-time)
 


### PR DESCRIPTION
## Summary

Record the final evidence-led v2.2.5 verification and correct the public/private maintenance workflow. The documentation reflects reviewed divergent histories, completed website and repository cleanup, native Windows proof, the verified release signature, and remaining external limitations.

## Changes

- Add the permanent v2.2.5 verification and arithmetic scorecard.
- Replace the obsolete one-branding-commit model with reviewed patch comparison.
- Add the authenticated private-remote prerequisite to executable verification commands.
- Record completed release cleanup, the 15.2K live website refresh, Windows smoke, Ruff cleanup, uninstaller regression fix, and private maintenance sync.
- Disclose the remaining 7 issues and 34 other open public PRs outside the authorized closure set.

## Verification

- `python3 -m pytest tests/ -q`: 441 passed in 65.23s.
- `python3 scripts/portability_check.py --strict`: 33 skills, 0 errors, 0 warnings.
- `python3 scripts/consistency_check.py --strict`: passed, 383 files.
- Ruff over all tracked Python files: passed.
- `git diff --cached --check`: passed before commit.
- Added-line em dash and en dash scan: passed.
- GitHub tag API: v2.2.5 SSH signature is valid and verified.
- Website: 28 tests, 56-page strict review, publishing validation, deployment, and 6 byte-parity checks passed.

## Risk and rollback

Low risk, revert the merge. This PR changes documentation only and does not move the v2.2.5 tag or alter runtime behavior.

## Open items

- Inspect private Billing and plans interactively, repair the payment state or applicable spending limit, then rerun private hosted CI.
- Native Windows installer proof used Python 3.14.7; minimum Python 3.10 installer discovery remains unproven.
- Public commit `2651be0` retains malformed body metadata because public history was not rewritten.
- The pre-existing review document, outputs, and temporary artifacts remain untracked and outside this PR.