### PR TITLE
Improvement to the seo-hreflang skill for detecting tags in the head section

### DIFF
--- a/skills/seo-hreflang/SKILL.md
+++ b/skills/seo-hreflang/SKILL.md
@@ -117,6 +117,10 @@ Best for: Sites with <50 language/region variants per page.
 
 Place in `<head>` section. Every page must include all alternates including itself.
 
+The order doesn't matter; it can also be:
+
+<link href="https://example.com/page" hreflang="en-US" rel="alternate">
+
 ### Method 2: HTTP Headers
 Best for: Non-HTML files (PDFs, documents).
 

--- a/skills/seo-hreflang/SKILL.md
+++ b/skills/seo-hreflang/SKILL.md
@@ -119,7 +119,9 @@ Place in `<head>` section. Every page must include all alternates including itse
 
 The order doesn't matter; it can also be:
 
+```html
 <link href="https://example.com/page" hreflang="en-US" rel="alternate">
+```
 
 ### Method 2: HTTP Headers
 Best for: Non-HTML files (PDFs, documents).


### PR DESCRIPTION
## Summary

The current agent is restrictive when searching for hreflang tags within the head section. It searches for them in exactly this order:

`<link rel="alternate" hreflang="en-US" href="https://example.com/page" />`

But actually, the order doesn't matter; it could also be:

`<link href="https://example.com/page" hreflang="en-US" rel="alternate">`

This update prevents false positives when detecting hreflang tags in the head section. With the original version, if the order of the tags is different... the tool fails to detect them and flags them as a critical error, even though the hreflang tags are actually present.

## Type of Change

- [x ] Bug fix

## Checklist

- [x ] Tested with a real URL before submitting