### PR TITLE
feat(extensions): Outserp — AI answer-engine visibility, drift + content engine extension

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "name": "AgriciDaniel"
   },
   "metadata": {
-    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse). v2.2.5 hardens installation, schema validation, rendered-page and accessibility analysis, runtime portability, and current Google Search guidance."
+    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 9 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Outserp, Bing Webmaster, Unlighthouse). v2.2.5 hardens installation, schema validation, rendered-page and accessibility analysis, runtime portability, and current Google Search guidance."
   },
   "plugins": [
     {
       "name": "claude-seo",
       "source": "./",
-      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions. v2.2.5 hardens installation, schema validation, rendered-page and accessibility analysis, runtime portability, and current Google Search guidance.",
+      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 9 optional MCP extensions. v2.2.5 hardens installation, schema validation, rendered-page and accessibility analysis, runtime portability, and current Google Search guidance.",
       "author": {
         "name": "AgriciDaniel",
         "url": "https://github.com/AgriciDaniel"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ integration + 2 extension mirrors), and 53 Python execution scripts.
 | `/seo bing [cmd] <url>` | Bing Webmaster data and IndexNow (extension) |
 | `/seo profound [cmd]` | LLM brand-citation tracking (extension) |
 | `/seo seranking [cmd]` | AI share-of-voice tracking (extension) |
+| `/seo outserp [cmd]` | AI answer-engine visibility, drift + content engine (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse audits (extension) |
 
 ## Using with Cursor / Cursor Cloud
@@ -167,7 +168,7 @@ skills/                    # 25 sub-skills (auto-discovered)
 agents/                    # 18 subagents
 scripts/                   # 53 Python scripts, including the managed runtime
 schema/                    # JSON-LD templates
-extensions/                # 8 MCP extensions: DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse
+extensions/                # 9 MCP extensions: DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Outserp, Bing Webmaster, Unlighthouse
 ```
 
 ## Key Principles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ claude-seo/
     bing-webmaster/              # Bing Webmaster and IndexNow install scripts
     profound/                    # Profound MCP install scripts
     seranking/                   # SE Ranking MCP install scripts
+    outserp/                     # Outserp MCP install scripts
     unlighthouse/                # Unlighthouse install scripts
   docs/                            # Extended documentation
 ```
@@ -184,6 +185,7 @@ claude-seo/
 | `/seo ahrefs [command] <url>` | Backlinks, organic keywords, and content data via the official Ahrefs MCP (extension) |
 | `/seo seranking [command]` | AI Share-of-Voice across ChatGPT, Gemini, Perplexity, AI Overviews, AI Mode (extension) |
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
+| `/seo outserp [command]` | AI answer-engine visibility, drift + content engine via Outserp (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ claude
 
 ![Claude SEO sub-skill ecosystem: 25 modules grouped into 8 categories (audit, content, schema, technical, AI search, local + maps, commerce + intl, extensions) around the central orchestrator](assets/sub-skills.svg)
 
-32 user-invocable `/seo` commands across the orchestrator, its sub-skills, and 8 MCP extensions. Full reference in [docs/COMMANDS.md](docs/COMMANDS.md).
+33 user-invocable `/seo` commands across the orchestrator, its sub-skills, and 9 MCP extensions. Full reference in [docs/COMMANDS.md](docs/COMMANDS.md).
 
 | Command | Description |
 |---------|-------------|
@@ -177,6 +177,7 @@ claude
 | `/seo ahrefs [command] <url>` | Backlinks, organic keywords, and content data via the official Ahrefs MCP (extension) |
 | `/seo seranking [command]` | AI Share-of-Voice across ChatGPT, Gemini, Perplexity, AI Overviews, AI Mode (extension) |
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
+| `/seo outserp [command]` | AI answer-engine visibility, drift + content engine via Outserp (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
 
@@ -372,7 +373,7 @@ curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/uninst
 
 ## Extensions
 
-Optional MCP servers add live data to the audit pipeline. Claude SEO ships extensions for 8 servers; the plugin core works without any of them.
+Optional MCP servers add live data to the audit pipeline. Claude SEO ships extensions for 9 servers; the plugin core works without any of them.
 
 ### DataForSEO
 
@@ -419,6 +420,18 @@ Five extensions added in Phase E:
 - **Unlighthouse:** MIT-licensed multi-page Lighthouse runner
 
 Setup walkthroughs live under `extensions/<name>/docs/`; integration notes: [docs/MCP-INTEGRATION.md](docs/MCP-INTEGRATION.md).
+
+### Outserp: AI answer-engine visibility + content engine (community, vendor-contributed)
+
+Audits how a domain actually appears in ChatGPT / Perplexity answers (head-to-head competitor appearance counts, gaps, content briefs), tracks citations and mentions over time, scans template defects and SEO drift, and can generate / optimize / publish articles via the remote [Outserp](https://outserp.ai) MCP server (OAuth, no local package).
+
+```bash
+./extensions/outserp/install.sh      # requires Outserp account
+/seo outserp whoami
+/seo outserp audit example.com
+```
+
+Full Outserp docs: [extensions/outserp/README.md](extensions/outserp/README.md).
 
 ## Ecosystem
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -296,6 +296,14 @@ extensions/
 │   ├── skills/seo-profound/SKILL.md
 │   └── docs/PROFOUND-SETUP.md
 │
+├── outserp/                  # Outserp AI answer-engine visibility + content engine
+│   ├── README.md
+│   ├── install.sh
+│   ├── install.ps1
+│   ├── uninstall.sh
+│   ├── skills/seo-outserp/SKILL.md
+│   └── docs/OUTSERP-SETUP.md
+│
 ├── bing-webmaster/           # Bing Webmaster Tools + IndexNow
 │   ├── install.sh
 │   ├── install.ps1
@@ -321,6 +329,7 @@ extensions/
 | **Ahrefs** | `@ahrefs/mcp@0.0.11` | Backlinks and organic keyword data via the official `@ahrefs/mcp` server |
 | **SE Ranking** | SE Ranking API | AI Share-of-Voice across ChatGPT, Gemini, Perplexity, AI Overviews, and AI Mode |
 | **Profound** | Profound API | LLM citation tracking with time-series data |
+| **Outserp** | `https://mcp.outserp.ai/mcp` (remote, OAuth) | AI answer-engine visibility audits (real ChatGPT/Perplexity answers, head-to-head competitor counts), citations/mentions time-series, template-defect + drift scans, article generate/optimize/publish |
 | **Bing Webmaster** | Bing Webmaster Tools API | Bing Webmaster Tools + IndexNow URL submission |
 | **Unlighthouse** | `unlighthouse@0.13.5` | Multi-page Lighthouse runner, runs locally |
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -676,6 +676,24 @@ AI-visibility + SERP via SE Ranking (extension). **Prerequisites:** SE Ranking e
 
 ---
 
+### `/seo outserp [command] <domain|brand>`
+
+AI answer-engine visibility + content engine via Outserp (extension, vendor-contributed). **Prerequisites:** Outserp extension installed (`./extensions/outserp/install.sh`) and OAuth completed via `/mcp`.
+```
+/seo outserp whoami                  # Account, plan, credit balance, projects
+/seo outserp audit <domain>          # AI-search visibility audit: real ChatGPT/Perplexity answers, head-to-head competitor counts, gaps, briefs
+/seo outserp visibility <brand>      # Mention rate per engine + trend
+/seo outserp citations <brand>       # URLs the engines actually cite for the tracked prompt set
+/seo outserp mentions <brand>        # Raw brand/competitor mentions per prompt per engine
+/seo outserp defects <domain>        # Template-defect scanner + hosted SEO drift
+/seo outserp context [update <note>] # Shared project memory + research log
+/seo outserp write <keyword>         # Generate a scored article draft
+/seo outserp optimize <article>      # Re-optimize an existing article
+/seo outserp publish <article>       # Publish to the connected CMS (confirms first)
+```
+
+---
+
 ### `/seo unlighthouse <url>`
 
 Multi-page Lighthouse audit via Unlighthouse (extension, MIT, no API quota). **Prerequisites:** Node 18+ and the unlighthouse npm package (`./extensions/unlighthouse/install.sh`).
@@ -720,5 +738,6 @@ Multi-page Lighthouse audit via Unlighthouse (extension, MIT, no API quota). **P
 | `/seo ahrefs [command] <url>` | Backlinks, organic keywords, and content data via the official Ahrefs MCP (extension) |
 | `/seo seranking [command]` | AI Share-of-Voice across ChatGPT, Gemini, Perplexity, AI Overviews, AI Mode (extension) |
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
+| `/seo outserp [command]` | AI answer-engine visibility, drift + content engine via Outserp (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -72,6 +72,7 @@ The MCP ecosystem for SEO has matured significantly. These are production-ready 
 | **Google Search Console** | `mcp-server-gsc` | Community | By ahonn. Search performance, URL inspection, sitemaps. |
 | **PageSpeed Insights** | `mcp-server-pagespeed` | Community | By enemyrr. Lighthouse audits, CWV metrics, performance scoring. |
 | **DataForSEO** | `dataforseo-mcp-server` | Official extension | 9 modules, 79 tools, 23 commands. Install: `./extensions/dataforseo/install.sh`. See [extension docs](../extensions/dataforseo/README.md). |
+| **Outserp** | `https://mcp.outserp.ai/mcp` | Official extension (remote) | AI answer-engine visibility audits, citation/mention tracking, template-defect + drift scans, article generation/publishing. OAuth. Install: `./extensions/outserp/install.sh`. See [extension docs](../extensions/outserp/README.md). |
 | **kwrds.ai** | kwrds MCP server | Community | Keyword research, search volume, difficulty scoring. |
 | **SEO Review Tools** | SEO Review Tools MCP | Community | Site auditing and on-page analysis API. |
 

--- a/extensions/outserp/README.md
+++ b/extensions/outserp/README.md
@@ -1,0 +1,95 @@
+# Outserp Extension for Claude SEO
+
+AI answer-engine visibility measurement and a content production engine,
+powered by [Outserp](https://outserp.ai). Audits how a domain actually
+appears in ChatGPT and Perplexity answers (head-to-head vs. competitors),
+tracks citations and mentions over time, scans template defects and SEO
+drift, and can generate, optimize, and publish articles.
+
+> Disclosure: this extension is contributed and maintained by the Outserp
+> team. Outserp is a commercial platform; audits and generation spend
+> account credits.
+
+## Prerequisites
+
+- [Claude SEO](https://github.com/AgriciDaniel/claude-seo) installed
+- An Outserp account ([sign up](https://outserp.ai))
+
+## Installation
+
+### macOS / Linux
+
+```bash
+./extensions/outserp/install.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+.\extensions\outserp\install.ps1
+```
+
+The installer registers the remote MCP server
+(`https://mcp.outserp.ai/mcp`). Authentication is OAuth: run `/mcp` in a
+new Claude Code session and sign in. An API key for the REST fallback
+(https://outserp.ai/api-docs, base URL `https://outserp.ai/api/v1`) can
+be provided optionally at install time.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/seo outserp whoami` | Account, plan, credit balance, projects |
+| `/seo outserp audit <domain>` | AI-search visibility audit: real engine answers, head-to-head competitor counts, gaps, briefs |
+| `/seo outserp visibility <brand>` | Mention rate per engine + trend |
+| `/seo outserp citations <brand>` | URLs the engines actually cite |
+| `/seo outserp mentions <brand>` | Raw brand/competitor mentions per prompt |
+| `/seo outserp defects <domain>` | Template-defect scanner + SEO drift |
+| `/seo outserp context [update]` | Shared project memory + research log |
+| `/seo outserp write <keyword>` | Generate an article draft |
+| `/seo outserp optimize <article>` | Re-optimize an existing article |
+| `/seo outserp publish <article>` | Publish to the connected CMS |
+
+## Integration with Claude SEO
+
+- **`/seo geo`** scores on-page citability locally; Outserp reports the
+  actual engine answers and citations for the same pages.
+- **`/seo profound`** / **`/seo seranking`**: triangulate Outserp's
+  measurements against independent vendors.
+- **`/seo drift`** keeps local baselines; `/seo outserp defects` adds the
+  hosted, scheduled template-defect + drift view.
+- **`/seo content`**: run E-E-A-T review on drafts before
+  `/seo outserp publish`.
+
+## Cost
+
+Read-only calls (whoami, summaries, citations, mentions, context) are
+cheap or free; audits, generation, optimization, and publishing spend
+account credits. The skill calls `whoami` first and confirms before any
+credit-spending operation. Pricing: https://outserp.ai/pricing.
+
+## Troubleshooting
+
+**MCP not connecting?**
+- Check: `cat ~/.claude/settings.json | python3 -m json.tool | grep outserp`
+- Re-run `/mcp` in Claude Code to complete OAuth
+- Manual config: see [OUTSERP-SETUP.md](docs/OUTSERP-SETUP.md)
+
+**REST 404s?**
+- The base URL is `https://outserp.ai/api/v1` — do not repeat `/api/v1`
+  in tool paths.
+
+**Insufficient credits?**
+- Check `/seo outserp whoami`, top up at https://outserp.ai
+
+## Uninstall
+
+```bash
+./extensions/outserp/uninstall.sh
+```
+
+## Links
+
+- [Outserp](https://outserp.ai)
+- [API docs](https://outserp.ai/api-docs)
+- [Claude SEO](https://github.com/AgriciDaniel/claude-seo)

--- a/extensions/outserp/docs/OUTSERP-SETUP.md
+++ b/extensions/outserp/docs/OUTSERP-SETUP.md
@@ -1,0 +1,64 @@
+# Outserp extension setup
+
+Outserp (https://outserp.ai) measures how a brand actually appears in AI
+answer engines — live ChatGPT / Perplexity answers, head-to-head
+competitor appearance counts, citations over time — and carries a
+production path (generate → optimize → publish articles). The hosted,
+account-backed complement to claude-seo's local `seo-geo` analysis.
+
+## Sign up
+
+Create an account at https://outserp.ai and add your domain as a project.
+Audits and content generation spend account credits.
+
+## Install
+
+```bash
+./extensions/outserp/install.sh        # Linux / macOS
+.\extensions\outserp\install.ps1       # Windows
+```
+
+Registers the remote MCP server `outserp` → `https://mcp.outserp.ai/mcp`
+in `~/.claude/settings.json` (written atomically, mode 0o600). No
+credential is stored unless you opt into the API-key fallback.
+
+Equivalent manual registration:
+
+```bash
+claude mcp add --transport http outserp https://mcp.outserp.ai/mcp
+```
+
+## OAuth flow
+
+The server authenticates via OAuth. In a new Claude Code session run
+`/mcp`, select `outserp`, and complete the browser sign-in. Verify with:
+
+```
+/seo outserp whoami
+```
+
+## API-key alternative (REST fallback)
+
+If you prefer not to use the MCP server, generate an API key in your
+Outserp account and re-run the installer (it prompts for the key, stored
+as `env.OUTSERP_API_KEY`). REST docs: https://outserp.ai/api-docs.
+
+- Base URL: `https://outserp.ai/api/v1`
+- Paths are relative to that base — do **not** repeat `/api/v1` in the
+  path (`/api/v1/audit`, never `/api/v1/api/v1/audit`).
+
+## Uninstall
+
+```bash
+./extensions/outserp/uninstall.sh
+```
+
+## When to use Outserp vs. Profound / SE Ranking
+
+| Use Outserp | Use Profound / SE Ranking |
+|---|---|
+| Full audit: real engine answers + head-to-head competitor counts + gaps + briefs | Pure citation-rate time-series (Profound) or 5-platform SoV sampling (SE Ranking) |
+| Closing the loop: generate / optimize / publish content from the same audit | Measurement only |
+| Template-defect scanning + hosted SEO drift | Local drift via `/seo drift` |
+
+The three are complementary; install what your workflow needs.

--- a/extensions/outserp/install.ps1
+++ b/extensions/outserp/install.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = "Stop"
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) { throw "Python 3 required" }
+$SkillDir = Join-Path $HOME ".claude/skills"
+$SettingsJson = Join-Path $HOME ".claude/settings.json"
+if (-not (Test-Path (Join-Path $SkillDir "seo"))) { throw "claude-seo not installed" }
+Write-Host "The Outserp MCP server authenticates via OAuth (run /mcp in Claude Code after install)."
+$Key = Read-Host "Outserp API key (optional, press Enter to skip)" -AsSecureString
+$Plain = [System.Net.NetworkCredential]::new("", $Key).Password
+$SourceDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillTarget = Join-Path $SkillDir "seo-outserp"
+New-Item -ItemType Directory -Path $SkillTarget -Force | Out-Null
+Copy-Item (Join-Path $SourceDir "skills/seo-outserp/SKILL.md") `
+          (Join-Path $SkillTarget "SKILL.md") -Force
+$py = @"
+import json, os, sys, tempfile
+path, key = sys.argv[1], sys.argv[2]
+data = {}
+if os.path.exists(path):
+    try: data = json.load(open(path))
+    except: data = {}
+data.setdefault('mcpServers', {})['outserp'] = {'type': 'http', 'url': 'https://mcp.outserp.ai/mcp'}
+if key:
+    data.setdefault('env', {})['OUTSERP_API_KEY'] = key
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or '.', prefix='.settings.', suffix='.json')
+with os.fdopen(fd, 'w') as fh: json.dump(data, fh, indent=2)
+os.replace(tmp, path)
+"@
+$py | python - $SettingsJson $Plain
+Write-Host "Done. Run /mcp in Claude Code to authenticate 'outserp', then: /seo outserp whoami"

--- a/extensions/outserp/install.sh
+++ b/extensions/outserp/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Claude SEO — Outserp (AI answer-engine visibility + content engine) extension installer.
+#
+# Outserp measures actual ChatGPT / Perplexity answers for buyer-intent
+# prompts (head-to-head vs. competitors) and carries a generate → optimize
+# → publish production path. Pairs with seo-profound / seo-seranking for
+# triangulated AI visibility coverage.
+#
+# The Outserp MCP server is remote (https://mcp.outserp.ai/mcp) and
+# authenticates via OAuth — no credential is required at install time.
+# An API key for the REST fallback (https://outserp.ai/api-docs) may be
+# provided optionally.
+set -euo pipefail
+
+main() {
+    SKILL_DIR="${HOME}/.claude/skills"
+    SETTINGS_JSON="${HOME}/.claude/settings.json"
+
+    echo "════════════════════════════════════════"
+    echo "║   Claude SEO — Outserp extension     ║"
+    echo "════════════════════════════════════════"
+
+    command -v python3 >/dev/null 2>&1 || { echo "✗ Python 3 required."; exit 1; }
+    if [ ! -d "${SKILL_DIR}/seo" ]; then
+        echo "✗ claude-seo base plugin not installed."
+        echo "  Install it first: curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh | bash"
+        exit 1
+    fi
+
+    SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+
+    echo "The Outserp MCP server authenticates via OAuth (run /mcp in Claude Code"
+    echo "after install). Optionally, provide an API key for the REST fallback."
+    read -rsp "Outserp API key (optional, press Enter to skip): " OUTSERP_KEY
+    echo
+
+    mkdir -p "${SKILL_DIR}/seo-outserp"
+    cp "${SOURCE_DIR}/skills/seo-outserp/SKILL.md" "${SKILL_DIR}/seo-outserp/SKILL.md"
+    echo "✓ Installed skill: ${SKILL_DIR}/seo-outserp/SKILL.md"
+
+    # Merge MCP config (and optional API key) into ~/.claude/settings.json
+    # atomically. Credentials are passed as argv, never interpolated into
+    # the Python source string.
+    mkdir -p "$(dirname "${SETTINGS_JSON}")"
+    python3 - "${SETTINGS_JSON}" "${OUTSERP_KEY}" <<'PY'
+import json, os, sys, tempfile
+path, key = sys.argv[1], sys.argv[2]
+data = {}
+if os.path.exists(path):
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError:
+        data = {}
+data.setdefault("mcpServers", {})["outserp"] = {
+    "type": "http",
+    "url": "https://mcp.outserp.ai/mcp",
+}
+if key:
+    data.setdefault("env", {})["OUTSERP_API_KEY"] = key
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".",
+                           prefix=".settings.", suffix=".json")
+try:
+    with os.fdopen(fd, "w") as fh:
+        json.dump(data, fh, indent=2)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+print(f"✓ Wrote mcpServers.outserp to {path}")
+if key:
+    print(f"✓ Wrote env.OUTSERP_API_KEY to {path}")
+PY
+
+    echo
+    echo "Done. Open a new Claude Code session, run /mcp to complete the OAuth"
+    echo "flow for 'outserp', then try:"
+    echo "  /seo outserp whoami"
+    echo "  /seo outserp audit example.com"
+    echo
+    echo "Full docs: extensions/outserp/docs/OUTSERP-SETUP.md"
+}
+
+main "$@"

--- a/extensions/outserp/skills/seo-outserp/SKILL.md
+++ b/extensions/outserp/skills/seo-outserp/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: seo-outserp
+description: >
+  Outserp AI answer-engine visibility analyst + content engine (extension).
+  Audits how a domain actually appears in ChatGPT and Perplexity answers,
+  tracks citations/mentions over time, scans template defects and SEO drift,
+  and can generate, optimize, and publish articles through the Outserp
+  platform. Pairs with seo-profound and seo-seranking for triangulated
+  AI visibility coverage.
+user-invocable: true
+argument-hint: "[command] <domain|brand>"
+license: MIT
+compatibility: "Requires the Outserp MCP server (https://mcp.outserp.ai/mcp, OAuth) or an OUTSERP_API_KEY for the REST fallback."
+metadata:
+  version: "2.2.5"
+  category: seo
+  original_author: Meddicle (Outserp — https://outserp.ai; vendor-contributed, disclosed)
+---
+
+# seo-outserp
+
+Outserp measures what AI answer engines actually say — it queries live
+ChatGPT / Perplexity answers for buyer-intent prompts, counts brand vs.
+competitor appearances head-to-head, and tracks the deltas over time.
+It also carries a production path (generate → optimize → publish) so a
+gap found in an audit can be closed from the same session.
+
+This is the piece claude-seo's local analysis deliberately delegates to
+vendors: `seo-geo` scores *citability* of your pages; Outserp reports
+*actual citations and answers* from the engines, as a time-series, like
+the Profound and SE Ranking extensions do — plus the write path.
+
+Disclosure: this extension is contributed by the Outserp team. Outserp is
+a commercial platform; audits and generation spend account credits.
+
+## Prerequisites
+
+- Run `extensions/outserp/install.sh` (or `install.ps1`).
+- An Outserp account (https://outserp.ai). The MCP server authenticates
+  via OAuth: after install, run `/mcp` in Claude Code and complete the
+  browser flow for `outserp`.
+- **Check availability:** before any call, verify an Outserp MCP tool
+  (e.g. `whoami`) is available. If not, tell the user the extension is
+  not installed / not authenticated and point to
+  `extensions/outserp/docs/OUTSERP-SETUP.md`.
+- REST fallback: if the MCP server is unreachable but
+  `~/.claude/settings.json` has `env.OUTSERP_API_KEY`, call the REST API
+  (docs: https://outserp.ai/api-docs) with base URL
+  `https://outserp.ai/api/v1`. Tool paths are relative to that base —
+  never duplicate `/api/v1` in the path (`/api/v1/audit`, not
+  `/api/v1/api/v1/audit`).
+
+## Routing
+
+| Command | Purpose |
+|---|---|
+| `/seo outserp whoami` | Account, plan, credit balance, projects |
+| `/seo outserp audit <domain>` | AI-search visibility audit: real ChatGPT/Perplexity answers, head-to-head competitor counts, gaps, content briefs |
+| `/seo outserp visibility <brand>` | Visibility summary: mention rate per engine + trend |
+| `/seo outserp citations <brand>` | URLs the engines actually cite for the brand's prompt set |
+| `/seo outserp mentions <brand>` | Raw brand/competitor mentions across tracked prompts |
+| `/seo outserp defects <domain>` | Template-defect scanner + SEO drift findings |
+| `/seo outserp context [update <note>]` | Shared project memory + research log (read or append) |
+| `/seo outserp write <keyword>` | Generate a full article draft for a keyword |
+| `/seo outserp optimize <article>` | Re-optimize an existing article against its scoring rubric |
+| `/seo outserp publish <article>` | Publish an article to the connected CMS |
+
+## Commands
+
+### whoami — account + credits
+
+**MCP tool:** `whoami`. Always call this first in a session: it confirms
+authentication, returns the credit balance, and lists the projects the
+account can operate on. If it fails, stop and route the user to setup.
+
+### audit — AI-search visibility audit
+
+**MCP tool:** `run_audit` (domain, optional competitor list).
+
+Runs Outserp's audit of any domain: it asks the engines real buyer-intent
+questions, records the full answers, counts how often the domain vs. each
+competitor appears (head-to-head), and returns the gaps with suggested
+content briefs. Credit-metered — confirm with the user before running,
+and report the spend from `whoami` afterwards.
+
+### visibility / citations / mentions — measurement over time
+
+**MCP tools:** `get_visibility_summary`, `get_citations`, `get_mentions`.
+
+- `get_visibility_summary`: mention rate per engine with trend deltas.
+- `get_citations`: the exact URLs the engines cite for the tracked
+  prompt set — use it to find pages worth pitching or emulating.
+- `get_mentions`: raw mention rows (brand + competitors, per prompt,
+  per engine) when the summary is too coarse.
+
+### defects — template-defect scanner + drift
+
+**MCP tool:** `get_template_defects`. Site-wide defects that repeat
+across a page template (missing BLUF, broken schema, thin sections) plus
+SEO drift since the last scan. For local, git-style baselines prefer
+`/seo drift`; use this for the hosted, scheduled view.
+
+### context — shared project memory
+
+**MCP tools:** `get_project_context`, `update_project_context`.
+
+Outserp projects keep a shared memory + research log that its own agents
+read. Read it at the start of a working session; append durable findings
+(audit conclusions, decisions) so they persist across sessions and tools.
+
+### write / optimize / publish — the production path
+
+**MCP tools:** `generate_article`, `optimize_article`, `publish_article`.
+
+Closes the loop on audit gaps: generate a scored draft for a target
+keyword, re-optimize an underperforming article, and publish to the CMS
+connected in Outserp. Generation and publishing spend credits and create
+public content — always show the user what will be produced/published
+and get an explicit go-ahead before `publish_article`.
+
+## Cost guardrails
+
+- Audits, generation, optimization, and publishing spend account
+  credits; read-only calls (`whoami`, summaries, citations, mentions,
+  context) are cheap or free.
+- Call `whoami` first, report the balance, and confirm before any
+  credit-spending call. Report the new balance after.
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|-----------|
+| Outserp tools not listed | MCP not installed / not connected | Run `./extensions/outserp/install.sh`, restart Claude Code |
+| `401 Unauthorized` | OAuth not completed or API key invalid | Run `/mcp` and authenticate `outserp`; or re-set `OUTSERP_API_KEY` |
+| `402` / insufficient credits | Credit balance exhausted | Check `whoami`, top up at https://outserp.ai |
+| `404 Not Found` on REST calls | `/api/v1` duplicated in the path | Base URL is `https://outserp.ai/api/v1`; paths must not repeat it |
+| `429 Too Many Requests` | Rate limited | Wait 60s, batch fewer prompts per call |
+| Audit returns no competitor data | No competitors configured | Pass a competitor list to `run_audit` or set them in the project |
+
+**Graceful fallback:** if Outserp is unavailable, `seo-geo` covers
+on-page citability locally, and `seo-profound` / `seo-seranking` cover
+citation tracking via their vendors.
+
+## Output conventions
+
+- Cite Outserp on every metric: "Outserp (live)". Audit numbers come
+  from real engine answers at query time, so note the sample date.
+- Visibility rates are percentages of sampled prompts; include the
+  prompt count so the confidence is legible.
+
+## Cross-skill delegation
+
+- For on-page citability scoring and platform-specific GEO tuning of the
+  pages Outserp flags, hand to `seo-geo`.
+- For time-series LLM citation triangulation, cross-check with
+  `seo-profound` (ChatGPT/Perplexity) and `seo-seranking` (adds Gemini,
+  AI Overviews, AI Mode).
+- For local, no-account drift baselines, use `seo-drift`.
+- For E-E-A-T review of drafts before `publish_article`, run
+  `seo-content`.

--- a/extensions/outserp/uninstall.sh
+++ b/extensions/outserp/uninstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="${HOME}/.claude/skills/seo-outserp"
+SETTINGS_JSON="${HOME}/.claude/settings.json"
+[ -d "${SKILL_DIR}" ] && rm -rf "${SKILL_DIR}" && echo "✓ Removed ${SKILL_DIR}"
+if [ -f "${SETTINGS_JSON}" ]; then
+  python3 - "${SETTINGS_JSON}" <<'PY'
+import json, os, sys, tempfile
+path = sys.argv[1]; data = json.load(open(path))
+changed = False
+if "outserp" in data.get("mcpServers", {}):
+    data["mcpServers"].pop("outserp"); changed = True
+    print("✓ Removed mcpServers.outserp")
+if "OUTSERP_API_KEY" in data.get("env", {}):
+    data["env"].pop("OUTSERP_API_KEY"); changed = True
+    print("✓ Cleared env.OUTSERP_API_KEY")
+if changed:
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), prefix=".settings.", suffix=".json")
+    with os.fdopen(fd, "w") as fh: json.dump(data, fh, indent=2)
+    os.chmod(tmp, 0o600); os.replace(tmp, path)
+PY
+fi

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -246,7 +246,8 @@ installer to activate (see each extension's `install.sh`/`install.ps1`):
 
 All optional extensions are reachable through `/seo` subcommands once
 installed: firecrawl, dataforseo, and image-gen, plus `/seo ahrefs`,
-`/seo bing`, `/seo profound`, `/seo seranking`, and `/seo unlighthouse`.
+`/seo bing`, `/seo profound`, `/seo seranking`, `/seo outserp`, and
+`/seo unlighthouse`.
 Each installs as its own sub-skill, so the model also auto-routes to their
 descriptions without the `/seo` prefix.
 


### PR DESCRIPTION
## What this adds

A new optional extension, `extensions/outserp/`, wiring the [Outserp](https://outserp.ai) platform into the `/seo` command family as `/seo outserp [command]`:

- **Measurement of actual AI-engine answers over time** — `run_audit` queries live ChatGPT / Perplexity answers for buyer-intent prompts and returns head-to-head competitor appearance counts, gaps, and content briefs; `get_visibility_summary` / `get_citations` / `get_mentions` track the time-series.
- **Template-defect scanner + hosted SEO drift** (`get_template_defects`) — complements the local `/seo drift` baselines.
- **Shared project memory + research log** (`get_project_context` / `update_project_context`).
- **A production path** — `generate_article` / `optimize_article` / `publish_article`, so an audit gap can be closed from the same session (with explicit user confirmation before anything credit-spending or public).

This is exactly the piece claude-seo's local analysis deliberately delegates to vendors — the same slot the Profound and SE Ranking extensions fill for citation tracking — plus the write path. The SKILL.md cross-references `seo-geo`, `seo-profound`, `seo-seranking`, `seo-drift`, and `seo-content` for triangulation and graceful fallback.

## Pattern conformance

Mirrors the profound / seranking extension pattern:

- `skills/seo-outserp/SKILL.md` (frontmatter per house style incl. `metadata.version: "2.2.5"` and `original_author`, availability check, routing table, cost guardrails, Error Handling table, cross-skill delegation)
- `install.sh` / `install.ps1` / `uninstall.sh` with the safe argv-heredoc credential pattern and atomic 0600 `settings.json` merge (`mcpServers.outserp` → remote `https://mcp.outserp.ai/mcp`, OAuth via `/mcp`; optional `OUTSERP_API_KEY` for the REST fallback — no npm package, so nothing to pin)
- `docs/OUTSERP-SETUP.md` + extension `README.md`

No core logic changed — the only edits outside `extensions/outserp/` are the documented extension-listing conventions: README.md (command table, Extensions section, 8→9 / 32→33 counts), docs/COMMANDS.md, docs/ARCHITECTURE.md (tree + Available Extensions), docs/MCP-INTEGRATION.md, AGENTS.md, CLAUDE.md, the orchestrator's Optional Extensions list in `skills/seo/SKILL.md` (required by `consistency_check.py` routing), and the marketplace.json extension count/list.

## Verification

- `python3 scripts/consistency_check.py` → PASS (0 errors, 0 warnings)
- `python3 scripts/portability_check.py` → 0 errors across 34 SKILL.md files
- `python3 -m pytest tests/` → **441 passed**

## Disclosure

outserp.ai is our product — this is a vendor-contributed extension, stated in the SKILL.md frontmatter (`original_author`), the skill body, and the extension README. MIT-compatible (extension licensed MIT like the repo); the platform itself is a commercial service with bring-your-own account, same as the DataForSEO / Ahrefs / Profound / SE Ranking extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)