### PR TITLE
fix(pagespeed): skip Lighthouse categories with a null score (TypeError on PSI runs)

### DIFF
--- a/scripts/pagespeed_check.py
+++ b/scripts/pagespeed_check.py
@@ -155,7 +155,12 @@ def run_pagespeed(
     # Lighthouse scores
     lr = data.get("lighthouseResult", {})
     for cat_key, cat_data in lr.get("categories", {}).items():
-        result["lighthouse_scores"][cat_key] = round(cat_data.get("score", 0) * 100)
+        # Lighthouse emits score: null for categories it could not evaluate
+        # (scoreDisplayMode "error"/"notApplicable"). Skip them rather than
+        # multiplying None, and rather than reporting a misleading 0/100.
+        cat_score = cat_data.get("score")
+        if cat_score is not None:
+            result["lighthouse_scores"][cat_key] = round(cat_score * 100)
 
     # Lab metrics from Lighthouse audits
     audits = lr.get("audits", {})

--- a/tests/test_pagespeed_null_category_score.py
+++ b/tests/test_pagespeed_null_category_score.py
@@ -1,0 +1,65 @@
+"""Lighthouse emits `score: null` for categories it could not evaluate
+(scoreDisplayMode "error" or "notApplicable"). `cat_data.get("score", 0)`
+only defaults on a *missing* key, so an explicit null reached the multiply
+and raised TypeError, losing the whole PSI run — including the categories
+that did score.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import pagespeed_check  # noqa: E402
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _psi_payload():
+    return {
+        "analysisUTCTimestamp": "2026-08-29T00:00:00.000Z",
+        "lighthouseResult": {
+            "categories": {
+                "performance": {"score": 0.91},
+                "accessibility": {"score": None},  # not evaluated
+                "seo": {"score": 0.5},
+            },
+            "audits": {},
+        },
+    }
+
+
+def test_null_category_score_does_not_crash_the_run():
+    with mock.patch.object(
+        pagespeed_check.requests, "get", return_value=_Response(_psi_payload())
+    ):
+        result = pagespeed_check.run_pagespeed("https://example.com")
+
+    assert result["error"] is None, result["error"]
+    assert result["lighthouse_scores"]["performance"] == 91
+    assert result["lighthouse_scores"]["seo"] == 50
+
+
+def test_unscored_category_is_omitted_not_reported_as_zero():
+    with mock.patch.object(
+        pagespeed_check.requests, "get", return_value=_Response(_psi_payload())
+    ):
+        result = pagespeed_check.run_pagespeed("https://example.com")
+
+    # A category Lighthouse refused to score is absent, not a 0/100 failure.
+    assert "accessibility" not in result["lighthouse_scores"], result["lighthouse_scores"]


### PR DESCRIPTION
## What

`run_pagespeed()` crashes with `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'` when Lighthouse reports a category it could not evaluate.

`scripts/pagespeed_check.py:158`:

```python
result["lighthouse_scores"][cat_key] = round(cat_data.get("score", 0) * 100)
```

`dict.get(key, default)` only falls back when the key is **missing**. PSI sends the key with an explicit `null` for categories with `scoreDisplayMode` of `"error"` or `"notApplicable"`, so `None * 100` is evaluated and the exception propagates out of `run_pagespeed` — the whole PSI run is lost, including the categories that scored fine.

## Fix

Skip categories without a score, which is the same guard the file already uses for lab metrics ten lines below:

```python
for audit_id in lab_audit_ids:
    audit = audits.get(audit_id, {})
    if audit.get("numericValue") is not None:
        ...
```

Omitting the key is also more truthful than the `or 0` alternative: a category Lighthouse refused to score is not a 0/100 failure, and downstream consumers (`--json`, the score table, `seo-performance`) would otherwise report a red zero for an audit that never ran.

## Tests

Adds `tests/test_pagespeed_null_category_score.py` with a PSI payload mixing scored and `null` categories:

- on `main`, the first test fails with the `TypeError` above
- with this patch both pass, and the second asserts the unscored category is absent rather than `0`

Verified locally against the repo layout (`sys.path` into `scripts/`, `mock.patch.object` on `requests.get`), matching the style of `tests/test_gsc_totals_aggregate.py`.

## Notes

Found while migrating a manual `~/.claude/skills/` install to the plugin. The local 2.2.0 copy had been patched with `(cat_data.get("score") or 0)` — same crash, different fix — so this looks like it bites in practice, not just in theory.
