### PR TITLE
Add Creaitor GEO as a first-class /seo extension

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ integration + 2 extension mirrors), and 53 Python execution scripts.
 | `/seo profound [cmd]` | LLM brand-citation tracking (extension) |
 | `/seo seranking [cmd]` | AI share-of-voice tracking (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse audits (extension) |
+| `/seo creaitor [cmd] <url>` | GEO visibility, citations, audits via Creaitor (extension) |
 
 ## Using with Cursor / Cursor Cloud
 
@@ -167,7 +168,7 @@ skills/                    # 25 sub-skills (auto-discovered)
 agents/                    # 18 subagents
 scripts/                   # 53 Python scripts, including the managed runtime
 schema/                    # JSON-LD templates
-extensions/                # 8 MCP extensions: DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse
+extensions/                # 9 MCP extensions: DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse, Creaitor
 ```
 
 ## Key Principles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The main `/seo` Quick Reference now exposes all separately installed optional
+  extension commands: Ahrefs, SE Ranking, Profound, Bing, and Unlighthouse.
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Creaitor extension** (`extensions/creaitor/`, 9th optional extension): the
+  `seo-creaitor` skill reads GEO visibility, LLM citations, cited sources,
+  tracked prompts, audits, recommendations, competitors, and health scores for a
+  domain configured in a [Creaitor](https://app.creaitor.ai) workspace, via
+  `/seo creaitor [command] <url>`. URLs resolve through `list_domains` (scheme /
+  `www.` / trailing-slash normalized) and fail closed rather than guessing.
+  Read commands never trigger a paid run; `audit --run`, `prompts --run`,
+  citations `--export`, and `llms-txt` execute only on explicit invocation and
+  require the token's `geo:execute` ability.
+- Creaitor installers (`install.sh`, `install.ps1`, `uninstall.sh`) register the
+  remote MCP server `creaitor-geo` (`type: http`) in the Claude user config
+  `~/.claude.json` — not `settings.json`, which holds local-process servers. The
+  token is prompted without echo, passed to the config writer through the
+  environment rather than argv or interpolated source, and written atomically at
+  mode `0600` with the rest of the config preserved; a `~/.claude.json` that is
+  not a readable JSON object aborts the install instead of being replaced.
+  `CREAITOR_MCP_URL` overrides the endpoint for self-hosted or staging use.
+
 ### Fixed
 
 - The main `/seo` Quick Reference now exposes all separately installed optional
-  extension commands: Ahrefs, SE Ranking, Profound, Bing, and Unlighthouse.
+  extension commands: Ahrefs, SE Ranking, Profound, Bing, Unlighthouse, and
+  Creaitor.
 
 ## [2.2.5] - 2026-08-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ claude-seo/
     profound/                    # Profound MCP install scripts
     seranking/                   # SE Ranking MCP install scripts
     unlighthouse/                # Unlighthouse install scripts
+    creaitor/                    # Creaitor remote MCP install scripts
   docs/                            # Extended documentation
 ```
 
@@ -186,6 +187,7 @@ claude-seo/
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
+| `/seo creaitor [command] <url>` | GEO visibility, citations, audits, and recommendations via Creaitor (extension) |
 
 ## Development Rules
 
@@ -233,7 +235,7 @@ Part of the Claude Code skill family:
 1. **Progressive Disclosure**: Metadata always loaded, instructions on activation, resources on demand
 2. **Industry Detection**: Auto-detect SaaS, e-commerce, local, publisher, agency
 3. **Parallel Execution**: Full audits spawn up to 15 subagents simultaneously
-4. **Extension System**: DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, and Unlighthouse extensions
+4. **Extension System**: DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse, and Creaitor extensions
 
 ## Repository Topology (public + private)
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ claude
 
 ![Claude SEO sub-skill ecosystem: 25 modules grouped into 8 categories (audit, content, schema, technical, AI search, local + maps, commerce + intl, extensions) around the central orchestrator](assets/sub-skills.svg)
 
-32 user-invocable `/seo` commands across the orchestrator, its sub-skills, and 8 MCP extensions. Full reference in [docs/COMMANDS.md](docs/COMMANDS.md).
+33 user-invocable `/seo` commands across the orchestrator, its sub-skills, and 9 MCP extensions. Full reference in [docs/COMMANDS.md](docs/COMMANDS.md).
 
 | Command | Description |
 |---------|-------------|
@@ -179,6 +179,7 @@ claude
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
+| `/seo creaitor [command] <url>` | GEO visibility, citations, audits, and recommendations via Creaitor (extension) |
 
 ## Features
 
@@ -345,7 +346,7 @@ Two real boundaries worth being upfront about.
 
 **Heavy client-side hydration timing.** Phase A's headless renderer handles most SPAs out of the box (`--render auto` detects empty `<div id="root">` shells and switches to Playwright). Edge cases that still produce noisy findings: pages with hydration tied to scroll position past the fold, pages that fetch critical content after user interaction (modal opens, tab clicks), pages with race-condition-prone third-party widget mounts. For these, manually triggering the `seo-visual` subagent and comparing its Playwright snapshot to the raw-HTML subagents' findings is the recommended workflow.
 
-**Local-only without enrichment.** The free tier makes no third-party API calls by default (audits still fetch the target URLs you point them at). Adding Google API credentials (Tier 0 through 3) unlocks real field data and live indexation status; without them, Core Web Vitals are lab estimates only and indexation is inferred from page-level signals. Adding MCP extensions (Ahrefs, DataForSEO, SE Ranking, Profound) similarly unlocks competitive and AI-citation data but requires their respective accounts.
+**Local-only without enrichment.** The free tier makes no third-party API calls by default (audits still fetch the target URLs you point them at). Adding Google API credentials (Tier 0 through 3) unlocks real field data and live indexation status; without them, Core Web Vitals are lab estimates only and indexation is inferred from page-level signals. Adding MCP extensions (Ahrefs, DataForSEO, SE Ranking, Profound, Creaitor) similarly unlocks competitive and AI-citation data but requires their respective accounts.
 
 ## Requirements
 
@@ -417,6 +418,23 @@ Five extensions added in Phase E:
 - **Profound:** LLM citation tracker with time-series data
 - **Bing Webmaster:** Bing Webmaster Tools plus IndexNow unified
 - **Unlighthouse:** MIT-licensed multi-page Lighthouse runner
+
+### Creaitor
+
+GEO visibility for a domain you track in [Creaitor](https://app.creaitor.ai):
+which prompts surface it, which LLMs cite it, which sources they cite instead,
+plus stored audits and prioritized recommendations. Wires Creaitor's remote MCP
+endpoint into `~/.claude.json` as `creaitor-geo`.
+
+```bash
+./extensions/creaitor/install.sh
+/seo creaitor overview https://example.com
+```
+
+Needs a Creaitor personal access token ([app.creaitor.ai/user/api-tokens](https://app.creaitor.ai/user/api-tokens)).
+`geo:read` covers every default read command; `geo:execute` is only needed for
+explicit runs, generation, or exports. The skill never invokes execute-tier
+tools as a follow-up to a read command. Setup: [extensions/creaitor/docs/CREAITOR-SETUP.md](extensions/creaitor/docs/CREAITOR-SETUP.md).
 
 Setup walkthroughs live under `extensions/<name>/docs/`; integration notes: [docs/MCP-INTEGRATION.md](docs/MCP-INTEGRATION.md).
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -687,6 +687,43 @@ Multi-page Lighthouse audit via Unlighthouse (extension, MIT, no API quota). **P
 
 ---
 
+### `/seo creaitor [command] <url>`
+
+GEO visibility, LLM citations, audits, and recommendations via the Creaitor remote MCP server (extension). **Prerequisites:** Creaitor extension installed (`./extensions/creaitor/install.sh`) and a Creaitor personal access token from https://app.creaitor.ai/user/api-tokens. The URL is resolved to a domain already configured in your Creaitor workspace; the command fails with the list of configured domains if there is no match.
+
+**Read commands** (`geo:read`, no run quota consumed):
+```
+/seo creaitor domains                          # Domains configured in the workspace
+/seo creaitor overview <url>                   # Health score + analytics + open recommendations
+/seo creaitor visibility <url>                 # AI-answer visibility and per-prompt results
+/seo creaitor citations <url>                  # Where the domain is cited, by prompt and model
+/seo creaitor sources <url>                    # Sources the LLMs cited (yours and others')
+/seo creaitor prompts <url>                    # Tracked prompts/queries for the domain
+/seo creaitor audit <url>                      # Latest stored audit (no new run)
+/seo creaitor recommendations <url>            # Open recommendations with priority
+/seo creaitor competitors <url>                # Competitors cited for the same prompts
+/seo creaitor health <url>                     # Health score only
+```
+
+**Mutations** (`geo:write`, confirmed before sending):
+```
+/seo creaitor prompts <url> --add "best crm for agencies" --topic <topic-id>
+/seo creaitor prompts <url> --edit <query-id>               # Edit a tracked prompt
+/seo creaitor recommendations <url> --set <id> completed    # Update recommendation status
+```
+
+**Runs** (`geo:execute`, consumes workspace quota, only on explicit invocation):
+```
+/seo creaitor audit <url> --run              # Run a fresh GEO audit, then read the result
+/seo creaitor prompts <url> --run <query-id> # Re-run a single tracked prompt
+/seo creaitor citations <url> --export       # Export citations (execute-tier API)
+/seo creaitor llms-txt <url>                 # Queue generation; retrieve result in Creaitor
+```
+
+Read commands never trigger a run: if stored data is empty or stale, the skill says so and offers the matching run command instead of spending quota. Every live figure is cited with its retrieval timestamp and the period/model filters used.
+
+---
+
 ## Quick Reference
 
 | Command | Use Case |
@@ -722,3 +759,4 @@ Multi-page Lighthouse audit via Unlighthouse (extension, MIT, no API quota). **P
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
+| `/seo creaitor [command] <url>` | GEO visibility, citations, audits, and recommendations via Creaitor (extension) |

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -61,6 +61,39 @@ Use `mcp-server-pagespeed` by [enemyrr](https://github.com/enemyrr/mcp-server-pa
 }
 ```
 
+### Creaitor (remote MCP)
+
+GEO visibility, LLM citations, cited sources, audits, and recommendations for
+domains configured in a [Creaitor](https://app.creaitor.ai) workspace. Unlike the
+other extensions, this is a **remote** MCP server: there is no local process, so
+the entry goes in `~/.claude.json` (the Claude user config, where remote MCP
+servers live) rather than `settings.json`.
+
+**Configuration** (written by `./extensions/creaitor/install.sh`):
+
+```json
+{
+  "mcpServers": {
+    "creaitor-geo": {
+      "type": "http",
+      "url": "https://app.creaitor.ai/api/v2/mcp",
+      "headers": {
+        "Authorization": "Bearer <creaitor-pat>",
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}
+```
+
+The token is a personal access token from
+https://app.creaitor.ai/user/api-tokens. Its abilities gate the tool surface:
+`geo:read` for every read tool, `geo:write` for prompt and recommendation
+mutations, `geo:execute` for execute-tier operations (`run_audit`, `run_query`,
+`generate_llms_txt`, `export_citations`). Set `CREAITOR_MCP_URL` before running the installer to
+point at a self-hosted or staging endpoint. Full walkthrough:
+[extensions/creaitor/docs/CREAITOR-SETUP.md](../extensions/creaitor/docs/CREAITOR-SETUP.md).
+
 ### Official SEO MCP Servers (2025-2026)
 
 The MCP ecosystem for SEO has matured significantly. These are production-ready integrations:
@@ -72,6 +105,7 @@ The MCP ecosystem for SEO has matured significantly. These are production-ready 
 | **Google Search Console** | `mcp-server-gsc` | Community | By ahonn. Search performance, URL inspection, sitemaps. |
 | **PageSpeed Insights** | `mcp-server-pagespeed` | Community | By enemyrr. Lighthouse audits, CWV metrics, performance scoring. |
 | **DataForSEO** | `dataforseo-mcp-server` | Official extension | 9 modules, 79 tools, 23 commands. Install: `./extensions/dataforseo/install.sh`. See [extension docs](../extensions/dataforseo/README.md). |
+| **Creaitor** | `https://app.creaitor.ai/api/v2/mcp` | Official extension (remote) | GEO visibility, LLM citations, sources, audits, recommendations. Install: `./extensions/creaitor/install.sh`. See [setup](../extensions/creaitor/docs/CREAITOR-SETUP.md). |
 | **kwrds.ai** | kwrds MCP server | Community | Keyword research, search volume, difficulty scoring. |
 | **SEO Review Tools** | SEO Review Tools MCP | Community | Site auditing and on-page analysis API. |
 

--- a/extensions/creaitor/docs/CREAITOR-SETUP.md
+++ b/extensions/creaitor/docs/CREAITOR-SETUP.md
@@ -1,0 +1,114 @@
+# Creaitor extension setup
+
+Registers Creaitor's remote MCP server (`https://app.creaitor.ai/api/v2/mcp`)
+with Claude Code as `creaitor-geo`, so the `seo-creaitor` skill can read live
+AI-search visibility, LLM citations, audits, and recommendations for the domains
+configured in your Creaitor workspace.
+
+## 1. Create a token
+
+At https://app.creaitor.ai/user/api-tokens, create a personal access token with
+the abilities you need:
+
+| Ability | Grants |
+|---|---|
+| `geo:read` | Every non-export read command: overview, visibility, citations, sources, prompts, audits, recommendations, competitors, health |
+| `geo:write` | Adding/editing tracked prompts, updating recommendation status |
+| `geo:execute` | `audit --run`, `prompts --run`, `llms-txt`, and citations `--export` (execute-tier API operations) |
+
+`geo:read` alone is enough for every default read command. Grant
+`geo:execute` only if you want Claude to trigger runs, generation, or exports.
+
+## 2. Install
+
+Quit all running Claude Code sessions first so they cannot overwrite
+`~/.claude.json` on exit. Then run:
+
+```bash
+./extensions/creaitor/install.sh        # macOS / Linux
+.\extensions\creaitor\install.ps1       # Windows PowerShell
+```
+
+The installer:
+
+1. Verifies Python 3 is on `PATH` and that the claude-seo base plugin is installed.
+2. Prompts for the token with the input hidden — it is never echoed, never
+   written to your shell history, and never printed back.
+3. Copies `skills/seo-creaitor/SKILL.md` into `~/.claude/skills/seo-creaitor/`.
+4. Merges this entry into `~/.claude.json` (the Claude user config, where remote
+   MCP servers live — not `settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "creaitor-geo": {
+      "type": "http",
+      "url": "https://app.creaitor.ai/api/v2/mcp",
+      "headers": {
+        "Authorization": "Bearer <your token>",
+        "Content-Type": "application/json"
+      }
+    }
+  }
+}
+```
+
+The merge is atomic (temp file + `os.replace`) and the result is `chmod 0600` on
+Unix, matching how claude-seo stores OAuth tokens. Everything else in
+`~/.claude.json` is preserved; if the file is not readable as a JSON object the
+installer aborts rather than replacing it.
+
+### Self-hosted / staging endpoint
+
+```bash
+CREAITOR_MCP_URL=https://staging.example.com/api/v2/mcp ./extensions/creaitor/install.sh
+```
+
+The same variable works for `install.ps1` (`$env:CREAITOR_MCP_URL`).
+
+## 3. Verify
+
+Open a **new** Claude Code session (MCP servers are read at startup) and run:
+
+```
+/seo creaitor domains
+```
+
+You should get the domains configured in your Creaitor workspace. Then:
+
+```
+/seo creaitor overview https://example.com
+```
+
+## Rotate the token
+
+Re-run the installer. It replaces only the `creaitor-geo` entry, leaving the
+rest of `~/.claude.json` intact. Revoke the old token in the Creaitor app.
+
+## Uninstall
+
+```bash
+./extensions/creaitor/uninstall.sh
+```
+
+Removes `~/.claude/skills/seo-creaitor/` and the `mcpServers.creaitor-geo` key.
+No other config is touched. Revoke the token in the Creaitor app afterwards.
+
+## Cost model
+
+Read commands (`geo:read`) return stored data and do not consume run quota.
+`audit --run`, `prompts --run`, and `llms-txt` execute quota-consuming work;
+citations `--export` is also execute-tier. The skill only calls these on the
+matching explicit command, never as a follow-up to a read command or as part of
+`/seo audit`. MCP can queue `llms-txt` generation but cannot poll its status;
+retrieve the completed content in Creaitor.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `/seo creaitor` says the extension is not installed | Session started before the config was written | Restart Claude Code; MCP servers are loaded at startup |
+| 401 from every command | Token revoked, expired, or mistyped | Mint a new token and re-run the installer |
+| 403 on one command only | Token lacks that ability | Re-mint with `geo:write` / `geo:execute` as needed |
+| "domain not configured in Creaitor" | The URL's host is not in the workspace | Add the domain in the Creaitor app; the skill never creates domains |
+| Installer aborts with "not valid JSON" | `~/.claude.json` is corrupted | Fix or restore the file; the installer will not overwrite it |

--- a/extensions/creaitor/install.ps1
+++ b/extensions/creaitor/install.ps1
@@ -1,0 +1,88 @@
+# Claude SEO — Creaitor (GEO visibility) extension installer (Windows / PowerShell).
+# Mirrors extensions/creaitor/install.sh.
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    throw "Python 3 is required."
+}
+
+$SkillDir = Join-Path $HOME ".claude/skills"
+# Remote MCP servers live in the Claude user config, not settings.json.
+$ClaudeJson = Join-Path $HOME ".claude.json"
+$McpUrl = if ($env:CREAITOR_MCP_URL) { $env:CREAITOR_MCP_URL } else { "https://app.creaitor.ai/api/v2/mcp" }
+
+if (-not (Test-Path (Join-Path $SkillDir "seo"))) {
+    throw "claude-seo base plugin not installed."
+}
+
+Write-Host "MCP endpoint: $McpUrl"
+Write-Host "Important: quit other Claude Code sessions first; they may rewrite ~/.claude.json on exit."
+$Secure = Read-Host "Creaitor API token (input hidden)" -AsSecureString
+$Token = [System.Net.NetworkCredential]::new("", $Secure).Password
+if (-not $Token) { throw "No token provided." }
+
+$SourceDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillTarget = Join-Path $SkillDir "seo-creaitor"
+New-Item -ItemType Directory -Path $SkillTarget -Force | Out-Null
+Copy-Item -Path (Join-Path $SourceDir "skills/seo-creaitor/SKILL.md") `
+          -Destination (Join-Path $SkillTarget "SKILL.md") -Force
+Write-Host "Installed skill: $SkillTarget"
+
+# The token travels in the environment, never in argv and never interpolated
+# into the Python source (this is a literal here-string: no $ expansion).
+$pyScript = @'
+import json, os, sys, tempfile
+path = sys.argv[1]
+token = os.environ["CREAITOR_TOKEN"]
+url = os.environ["CREAITOR_MCP_URL"]
+data = {}
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as fh:
+        raw = fh.read().strip()
+    if raw:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            sys.exit(f"{path} is not valid JSON - refusing to overwrite it.")
+    if not isinstance(data, dict):
+        sys.exit(f"{path} is not a JSON object - refusing to overwrite it.")
+servers = data.setdefault("mcpServers", {})
+if not isinstance(servers, dict):
+    sys.exit(f"mcpServers in {path} is not an object - refusing to overwrite it.")
+servers["creaitor-geo"] = {
+    "type": "http",
+    "url": url,
+    "headers": {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    },
+}
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(path)),
+                           prefix=".claude.", suffix=".json")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+print(f"Wrote mcpServers.creaitor-geo -> {url} in {path}")
+'@
+
+try {
+    $env:CREAITOR_TOKEN = $Token
+    $env:CREAITOR_MCP_URL = $McpUrl
+    $pyScript | python - $ClaudeJson
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to update $ClaudeJson (Python exit code $LASTEXITCODE)."
+    }
+} finally {
+    Remove-Item Env:CREAITOR_TOKEN -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "Done. Open a new Claude Code session and run /seo creaitor overview <url>."

--- a/extensions/creaitor/install.sh
+++ b/extensions/creaitor/install.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Claude SEO — Creaitor (GEO visibility) extension installer.
+#
+# Registers the Creaitor remote MCP server as `creaitor-geo` in the Claude
+# user config (~/.claude.json) and copies the seo-creaitor skill into
+# ~/.claude/skills/.
+#
+# Prereq: a Creaitor personal access token with the geo:read ability (plus
+# geo:write / geo:execute for mutations and runs). Create one at
+# https://app.creaitor.ai/user/api-tokens
+set -euo pipefail
+
+main() {
+    SKILL_DIR="${HOME}/.claude/skills"
+    # Remote MCP servers live in the Claude user config, not settings.json.
+    CLAUDE_JSON="${HOME}/.claude.json"
+    MCP_URL="${CREAITOR_MCP_URL:-https://app.creaitor.ai/api/v2/mcp}"
+
+    echo "════════════════════════════════════════"
+    echo "║   Claude SEO — Creaitor extension    ║"
+    echo "════════════════════════════════════════"
+
+    command -v python3 >/dev/null 2>&1 || { echo "✗ Python 3 required."; exit 1; }
+
+    if [ ! -d "${SKILL_DIR}/seo" ]; then
+        echo "✗ claude-seo base plugin not installed."
+        echo "  Install it first: curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/claude-seo/main/install.sh | bash"
+        exit 1
+    fi
+
+    # Locate this script's directory so the call works for both
+    # `./install.sh` and `curl | bash` invocations.
+    SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+
+    echo "→ MCP endpoint: ${MCP_URL}"
+    echo "! Quit other Claude Code sessions before continuing; they may rewrite ~/.claude.json on exit."
+    read -rsp "Creaitor API token (input hidden): " CREAITOR_TOKEN
+    echo
+    if [ -z "${CREAITOR_TOKEN}" ]; then
+        echo "✗ No token provided."; exit 1;
+    fi
+
+    mkdir -p "${SKILL_DIR}/seo-creaitor"
+    cp "${SOURCE_DIR}/skills/seo-creaitor/SKILL.md" "${SKILL_DIR}/seo-creaitor/SKILL.md"
+    echo "✓ Installed skill: ${SKILL_DIR}/seo-creaitor/SKILL.md"
+
+    # Merge the MCP entry into ~/.claude.json atomically. The token travels in
+    # the environment, never in argv (visible in `ps`) and never interpolated
+    # into the Python source below (the heredoc is quoted, so the shell does
+    # not expand anything inside it).
+    export CREAITOR_TOKEN CREAITOR_MCP_URL="${MCP_URL}"
+    python3 - "${CLAUDE_JSON}" <<'PY'
+import json
+import os
+import sys
+import tempfile
+
+path = sys.argv[1]
+token = os.environ["CREAITOR_TOKEN"]
+url = os.environ["CREAITOR_MCP_URL"]
+
+# ~/.claude.json holds the whole Claude Code user config. If it exists but is
+# unreadable as a JSON object, abort rather than replace it with our one key.
+data = {}
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as fh:
+        raw = fh.read().strip()
+    if raw:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            sys.exit(f"✗ {path} is not valid JSON — refusing to overwrite it.")
+    if not isinstance(data, dict):
+        sys.exit(f"✗ {path} is not a JSON object — refusing to overwrite it.")
+
+servers = data.setdefault("mcpServers", {})
+if not isinstance(servers, dict):
+    sys.exit(f"✗ mcpServers in {path} is not an object — refusing to overwrite it.")
+
+servers["creaitor-geo"] = {
+    "type": "http",
+    "url": url,
+    "headers": {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    },
+}
+
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(path)),
+                           prefix=".claude.", suffix=".json")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+print(f"✓ Wrote mcpServers.creaitor-geo -> {url} in {path}")
+PY
+    unset CREAITOR_TOKEN
+
+    echo
+    echo "Done. Open a new Claude Code session and run:"
+    echo "  /seo creaitor overview https://example.com"
+    echo
+    echo "Full docs: extensions/creaitor/docs/CREAITOR-SETUP.md"
+}
+
+main "$@"

--- a/extensions/creaitor/skills/seo-creaitor/SKILL.md
+++ b/extensions/creaitor/skills/seo-creaitor/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: seo-creaitor
+description: Creaitor GEO analyst (extension). Reads AI-search visibility, LLM citations, cited sources, tracked prompts, audits, recommendations, competitors, and health scores for a domain configured in Creaitor, via the Creaitor remote MCP server.
+metadata:
+  version: "2.2.5"
+  original_author: "Creaitor (creaitor.ai)"
+compatibility: "Requires the creaitor-geo remote MCP server in ~/.claude.json (run extensions/creaitor/install.sh or install.ps1) and a Creaitor personal access token. Read commands need the geo:read ability; mutations need geo:write; runs need geo:execute."
+---
+
+# seo-creaitor
+
+Creaitor tracks how a domain performs in AI answers: which prompts surface it,
+which LLMs cite it, which sources they cite instead, and what to fix. This skill
+reads that data live through the `creaitor-geo` remote MCP server
+(`https://app.creaitor.ai/api/v2/mcp`).
+
+Unlike `seo-geo`, which infers citability from the page itself, Creaitor reports
+observed citations for prompts you already track. Use both: `seo-geo` for why a
+page should be cited, `seo-creaitor` for whether it actually is.
+
+## Prerequisites
+
+- Run `extensions/creaitor/install.sh` (macOS/Linux) or `install.ps1` (Windows).
+- A Creaitor personal access token from https://app.creaitor.ai/user/api-tokens
+  with the abilities the command needs (`geo:read`, `geo:write`, `geo:execute`).
+- The domain must already exist in the Creaitor workspace the token belongs to.
+  This skill never creates domains.
+
+Before the first tool call in a session, confirm a Creaitor MCP tool (for
+example `list_domains`) is available. If none are, stop and tell the user the
+extension is not installed, with the install command above. Do not fall back to
+scraping app.creaitor.ai.
+
+## Domain resolution
+
+Every command except `/seo creaitor domains` takes a URL and must resolve it to
+a configured Creaitor domain before anything else:
+
+1. Call `list_domains` (read-only, free).
+2. Normalize the user's URL and every configured domain the same way: lowercase,
+   drop the scheme, drop a leading `www.`, drop the default port, drop any path,
+   query, and fragment, drop a trailing slash.
+3. Match on the normalized host. Reuse the resolved `domain_id` for the rest of
+   the session instead of calling `list_domains` again.
+4. **No match: stop.** Report the URL as given and list the domains returned.
+   The MCP tool returns at most the 25 newest domains, so do not claim the
+   domain is absent from the workspace. Ask the user to verify or add it in the
+   Creaitor app. Never guess the closest domain, substitute an apex for a
+   subdomain, or call an execute-tier command with an unresolved domain.
+5. Ambiguous match (several configured domains normalize to the same host): ask
+   which one, do not pick.
+
+Subdomains are distinct domains. `blog.example.com` matches a configured
+`blog.example.com`, not a configured `example.com`.
+
+## Routing
+
+| Command | Creaitor MCP tools | Ability |
+|---|---|---|
+| `/seo creaitor domains` | `list_domains` | `geo:read` |
+| `/seo creaitor overview <url>` | `get_health_score`, `get_analytics`, `list_recommendations` | `geo:read` |
+| `/seo creaitor visibility <url>` | `get_analytics`, `list_queries`, then `get_results` per query | `geo:read` |
+| `/seo creaitor citations <url>` | `get_citations` | `geo:read` |
+| `/seo creaitor citations <url> --export` | `export_citations` | `geo:execute` |
+| `/seo creaitor sources <url>` | `get_sources` | `geo:read` |
+| `/seo creaitor prompts <url>` | `list_queries` | `geo:read` |
+| `/seo creaitor prompts <url> --add "<prompt>" --topic <topic-id>` | `create_query` | `geo:write` |
+| `/seo creaitor prompts <url> --edit <query-id>` | `update_query` | `geo:write` |
+| `/seo creaitor prompts <url> --run <query-id>` | `run_query` | `geo:execute` |
+| `/seo creaitor audit <url>` | `list_audits`, `get_audit` | `geo:read` |
+| `/seo creaitor audit <url> --run` | `run_audit`, then `get_audit` | `geo:execute` |
+| `/seo creaitor recommendations <url>` | `list_recommendations` | `geo:read` |
+| `/seo creaitor recommendations <url> --set <id> <status>` | `update_recommendation` | `geo:write` |
+| `/seo creaitor competitors <url>` | `list_competitors` | `geo:read` |
+| `/seo creaitor health <url>` | `get_health_score` | `geo:read` |
+| `/seo creaitor llms-txt <url>` | `generate_llms_txt` (queues generation; retrieve content in Creaitor) | `geo:execute` |
+
+Bare `/seo creaitor <url>` (no command) runs `overview`.
+
+## Execution rules
+
+**Read commands never trigger a run.** `overview`, `visibility`, `citations`,
+`sources`, `prompts`, `recommendations`, `competitors`, `health`, and
+`audit` (without `--run`) call read tools only. If the stored data is empty or
+stale, say so and offer the matching execute command — do not run it to fill the
+gap.
+
+**Execute-tier tools run only when explicitly invoked.** `run_audit`,
+`run_query`, and `generate_llms_txt` consume workspace quota; `export_citations`
+is also gated by `geo:execute`. Call them only for the corresponding explicit
+`--run`, `llms-txt`, or `--export` command. Never call them as a follow-up to a
+read command, as part of `/seo audit`, or to refresh data autonomously.
+
+`create_query` requires a real `topic_id`. Require `--topic <topic-id>` and pass
+it unchanged. Existing query records may expose their topic ID; if none do,
+tell the user to create or select the topic in Creaitor first. Never invent an
+ID.
+
+`generate_llms_txt` returns only a queued generation ID over MCP. Report that
+honestly and direct the user to Creaitor for completion and content; do not poll
+a non-existent MCP status tool.
+
+**Writes are confirmed.** Before `create_query`, `update_query`, or
+`update_recommendation`, echo the exact change and get a yes.
+
+**Missing ability.** The MCP server returns JSON-RPC error `-32001` when the
+token lacks an ability. Report which ability is missing (`geo:read` /
+`geo:write` / `geo:execute`) and point at
+https://app.creaitor.ai/user/api-tokens to mint a replacement, then re-run the
+installer to store it.
+
+## Output conventions
+
+- Cite Creaitor on every live figure, with the retrieval time and the filters
+  that produced it: `Creaitor (live, 2026-09-01T14:03Z, domain=example.com,
+  period=last-30d, models=ChatGPT+Perplexity)`. State the timestamp in UTC.
+- Name the period and model/platform filter you used, including when you used
+  the API default — an unqualified "12% citation rate" is not reportable.
+- Report the audit's own `completed_at` (not the current time) when summarizing
+  a stored audit, and flag audits older than 30 days as stale.
+- Distinguish "0 citations observed" from "prompt not tracked" and from "no run
+  yet". They imply different fixes.
+- When Creaitor and another source disagree (`seo-dataforseo` AI mentions,
+  `seo-profound`, `seo-seranking`), report both with their timestamps rather
+  than averaging: they sample different prompt sets at different times.
+
+## Cross-skill delegation
+
+- Page-level citability, AI crawler access, and passage structure: `seo-geo`.
+- Fixing pages a recommendation points at: `seo-content` for E-E-A-T and
+  passage rewriting, `seo-schema` for markup gaps, `seo-technical` for crawl or
+  render blockers keeping a cited page out of AI answers.
+- Competitor domains that Creaitor reports as cited instead of yours: hand the
+  URLs to `seo-backlinks` or `seo-cluster` for gap analysis.
+- Broader LLM citation time-series across more platforms: `seo-profound` and
+  `seo-seranking`.
+
+## Docs
+
+Setup, token rotation, and troubleshooting:
+`extensions/creaitor/docs/CREAITOR-SETUP.md`.

--- a/extensions/creaitor/uninstall.sh
+++ b/extensions/creaitor/uninstall.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Claude SEO — Creaitor extension uninstaller.
+# Removes the seo-creaitor skill and the mcpServers.creaitor-geo entry.
+# Nothing else in ~/.claude.json is touched.
+set -euo pipefail
+
+SKILL_DIR="${HOME}/.claude/skills/seo-creaitor"
+CLAUDE_JSON="${HOME}/.claude.json"
+
+if [ -d "${SKILL_DIR}" ]; then
+    rm -rf "${SKILL_DIR}"
+    echo "✓ Removed ${SKILL_DIR}"
+fi
+
+if [ -f "${CLAUDE_JSON}" ]; then
+    python3 - "${CLAUDE_JSON}" <<'PY'
+import json
+import os
+import sys
+import tempfile
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except json.JSONDecodeError:
+    sys.exit(f"✗ {path} is not valid JSON — leaving it untouched.")
+
+servers = data.get("mcpServers")
+if not isinstance(servers, dict) or "creaitor-geo" not in servers:
+    print(f"  (no mcpServers.creaitor-geo entry to remove in {path})")
+    raise SystemExit(0)
+
+servers.pop("creaitor-geo")
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(path)),
+                           prefix=".claude.", suffix=".json")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+print(f"✓ Removed mcpServers.creaitor-geo from {path}")
+PY
+fi
+
+echo "Done. Revoke the token at https://app.creaitor.ai/user/api-tokens if it is no longer needed."

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -54,6 +54,11 @@ extension is also installable (see "Optional Extensions" below).
 | `/seo firecrawl [command] <url>` | Full-site crawling and site mapping (extension) |
 | `/seo dataforseo [command]` | Live SEO data via DataForSEO (extension) |
 | `/seo image-gen [use-case] <description>` | AI image generation for SEO assets (extension) |
+| `/seo ahrefs [command] <url>` | Backlinks, organic keywords, and content data via the official Ahrefs MCP (extension) |
+| `/seo seranking [command]` | AI Share-of-Voice across ChatGPT, Gemini, Perplexity, AI Overviews, AI Mode (extension) |
+| `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
+| `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
+| `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
 | `/seo flow [stage] [url\|topic]` | FLOW framework: evidence-led prompts for Find, Leverage, Optimize, Win, or Local stages |
 | `/seo setup` | Explicitly create or refresh the isolated Python runtime and Chromium |
 | `/seo doctor` | Check runtime readiness without changing the system |

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -59,6 +59,7 @@ extension is also installable (see "Optional Extensions" below).
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
+| `/seo creaitor [command] <url>` | GEO visibility, citations, audits, and recommendations via Creaitor (extension) |
 | `/seo flow [stage] [url\|topic]` | FLOW framework: evidence-led prompts for Find, Leverage, Optimize, Win, or Local stages |
 | `/seo setup` | Explicitly create or refresh the isolated Python runtime and Chromium |
 | `/seo doctor` | Check runtime readiness without changing the system |
@@ -251,7 +252,8 @@ installer to activate (see each extension's `install.sh`/`install.ps1`):
 
 All optional extensions are reachable through `/seo` subcommands once
 installed: firecrawl, dataforseo, and image-gen, plus `/seo ahrefs`,
-`/seo bing`, `/seo profound`, `/seo seranking`, and `/seo unlighthouse`.
+`/seo bing`, `/seo creaitor`, `/seo profound`, `/seo seranking`, and
+`/seo unlighthouse`.
 Each installs as its own sub-skill, so the model also auto-routes to their
 descriptions without the `/seo` prefix.
 

--- a/tests/test_extension_installer_injection.py
+++ b/tests/test_extension_installer_injection.py
@@ -6,11 +6,16 @@ source string, so a credential containing ``'''`` broke out of the string
 literal and executed arbitrary code at install time. The fix passes
 credentials as ``sys.argv`` via a quoted heredoc and writes the
 credential-bearing settings file atomically with ``0600`` perms.
+
+The Creaitor section at the bottom holds the same line for the one installer
+that writes the Claude user config (``~/.claude.json``) instead of
+``settings.json``, and additionally pins that the merge is non-destructive.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -66,3 +71,160 @@ def test_installer_credential_injection_is_inert(tmp_path: Path, rel: str, argc:
     blob = json.dumps(json.loads(settings.read_text(encoding="utf-8")))
     assert payload in blob, f"{rel}: credential not stored literally"
     assert (settings.stat().st_mode & 0o777) == 0o600, f"{rel}: settings not 0600"
+
+
+# ---------------------------------------------------------------------------
+# Creaitor: remote MCP server, so the entry lands in the Claude *user config*
+# (~/.claude.json) rather than settings.json. That file holds the whole Claude
+# Code user state, which raises the stakes on two fronts the tests below pin:
+# the merge must preserve unrelated keys, and the token must never reach the
+# Python source, argv, or stdout.
+# ---------------------------------------------------------------------------
+
+CREAITOR_INSTALL = "extensions/creaitor/install.sh"
+CREAITOR_UNINSTALL = "extensions/creaitor/uninstall.sh"
+CREAITOR_MCP_URL = "https://app.creaitor.ai/api/v2/mcp"
+
+
+def _creaitor_config(**extra: object) -> dict:
+    """A ~/.claude.json with unrelated state the installer must not disturb."""
+    config = {
+        "numStartups": 7,
+        "installMethod": "native",
+        "projects": {"/tmp/demo": {"allowedTools": ["Read"]}},
+        "mcpServers": {
+            "unrelated": {"command": "npx", "args": ["-y", "some-server"]},
+        },
+    }
+    config.update(extra)
+    return config
+
+
+def test_creaitor_installer_keeps_the_token_out_of_source_and_argv() -> None:
+    text = (ROOT / CREAITOR_INSTALL).read_text(encoding="utf-8")
+    writer = _extract_writer(text)
+
+    assert "'''${" not in text, "credential interpolated into Python source"
+    assert "<<'PY'" in text, "heredoc must be quoted so the shell expands nothing"
+    assert "${CREAITOR_TOKEN}" not in writer, "token interpolated into the writer"
+    assert 'os.environ["CREAITOR_TOKEN"]' in writer, "token must arrive via the environment"
+    # argv carries the config path only; a token in argv is world-readable via `ps`.
+    assert 'python3 - "${CLAUDE_JSON}" <<' in text, "token must not be passed in argv"
+    assert "read -rsp" in text, "token prompt must not echo"
+    assert "0o600" in writer, "config must be written 0600"
+    assert 'CLAUDE_JSON="${HOME}/.claude.json"' in text, (
+        "remote MCP servers are configured in ~/.claude.json, not settings.json"
+    )
+    assert "CREAITOR_MCP_URL:-https://app.creaitor.ai/api/v2/mcp" in text, (
+        "installer must default to the production endpoint and allow an override"
+    )
+
+
+def test_creaitor_windows_installer_checks_native_python_exit() -> None:
+    text = (ROOT / "extensions/creaitor/install.ps1").read_text(encoding="utf-8")
+    assert "$LASTEXITCODE -ne 0" in text
+    assert "throw \"Failed to update $ClaudeJson" in text
+
+
+def test_creaitor_config_writer_injection_is_inert_and_preserves_config(
+    tmp_path: Path,
+) -> None:
+    writer = _extract_writer((ROOT / CREAITOR_INSTALL).read_text(encoding="utf-8"))
+    script = tmp_path / "writer.py"
+    script.write_text(writer, encoding="utf-8")
+
+    config = tmp_path / ".claude.json"
+    existing = _creaitor_config()
+    config.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    marker = tmp_path / "PWNED"
+    payload = f"tok'''; open({str(marker)!r}, 'w').write('pwned'); x='''"
+
+    proc = subprocess.run(
+        [sys.executable, str(script), str(config)],
+        env={
+            **os.environ,
+            "CREAITOR_TOKEN": payload,
+            "CREAITOR_MCP_URL": CREAITOR_MCP_URL,
+        },
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert not marker.exists(), "token payload executed code"
+
+    data = json.loads(config.read_text(encoding="utf-8"))
+    for key in ("numStartups", "installMethod", "projects"):
+        assert data[key] == existing[key], f"installer clobbered unrelated key {key}"
+    assert data["mcpServers"]["unrelated"] == existing["mcpServers"]["unrelated"], (
+        "installer clobbered an unrelated MCP server"
+    )
+    assert data["mcpServers"]["creaitor-geo"] == {
+        "type": "http",
+        "url": CREAITOR_MCP_URL,
+        "headers": {
+            "Authorization": f"Bearer {payload}",
+            "Content-Type": "application/json",
+        },
+    }, "remote MCP entry is not the expected http/url/headers object"
+
+    assert (config.stat().st_mode & 0o777) == 0o600, "~/.claude.json not written 0600"
+    assert payload not in proc.stdout + proc.stderr, "token leaked to the terminal"
+
+
+def test_creaitor_installer_refuses_to_overwrite_unparseable_config(
+    tmp_path: Path,
+) -> None:
+    """A corrupt ~/.claude.json must abort, not get replaced by our single key."""
+    writer = _extract_writer((ROOT / CREAITOR_INSTALL).read_text(encoding="utf-8"))
+    script = tmp_path / "writer.py"
+    script.write_text(writer, encoding="utf-8")
+
+    config = tmp_path / ".claude.json"
+    config.write_text('{"projects": {', encoding="utf-8")  # truncated write
+
+    proc = subprocess.run(
+        [sys.executable, str(script), str(config)],
+        env={
+            **os.environ,
+            "CREAITOR_TOKEN": "tok",
+            "CREAITOR_MCP_URL": CREAITOR_MCP_URL,
+        },
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert config.read_text(encoding="utf-8") == '{"projects": {'
+
+
+def test_creaitor_uninstaller_removes_only_its_own_entry(tmp_path: Path) -> None:
+    writer = _extract_writer((ROOT / CREAITOR_UNINSTALL).read_text(encoding="utf-8"))
+    script = tmp_path / "remover.py"
+    script.write_text(writer, encoding="utf-8")
+
+    config = tmp_path / ".claude.json"
+    existing = _creaitor_config()
+    existing["mcpServers"]["creaitor-geo"] = {
+        "type": "http",
+        "url": CREAITOR_MCP_URL,
+        "headers": {"Authorization": "Bearer secret", "Content-Type": "application/json"},
+    }
+    config.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(script), str(config)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert "creaitor-geo" not in data["mcpServers"]
+    assert data["mcpServers"]["unrelated"] == _creaitor_config()["mcpServers"]["unrelated"]
+    assert data["projects"] == _creaitor_config()["projects"]
+    assert (config.stat().st_mode & 0o777) == 0o600
+    assert "secret" not in proc.stdout + proc.stderr

--- a/tests/test_orchestrator_command_table.py
+++ b/tests/test_orchestrator_command_table.py
@@ -36,9 +36,23 @@ def quick_reference_commands():
 
 
 def extension_commands():
-    """Command tokens for every optional extension that installs its own sub-skill."""
-    return {path.parent.name[len("seo-"):]
-            for path in REPO.glob("extensions/*/skills/seo-*/SKILL.md")}
+    """Commands whose extension skill name and own routing table agree."""
+    commands = set()
+    for path in REPO.glob("extensions/*/skills/seo-*/SKILL.md"):
+        command = path.parent.name.removeprefix("seo-")
+        declared = {
+            match.group(1)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.startswith("|")
+            for match in [COMMAND_CELL.search(line.split("|")[1])]
+            if match
+        }
+        assert command in declared, (
+            f"{path.relative_to(REPO)} names /seo {command} but its command table "
+            f"declares: {', '.join(sorted(declared)) or 'nothing'}"
+        )
+        commands.add(command)
+    return commands
 
 
 def test_quick_reference_table_parses():

--- a/tests/test_orchestrator_command_table.py
+++ b/tests/test_orchestrator_command_table.py
@@ -55,6 +55,22 @@ def extension_commands():
     return commands
 
 
+def test_extension_discovery_covers_the_shipped_extensions():
+    """Canary for the discovery glob itself.
+
+    ``extension_commands()`` derives the expected set from directory names, so a
+    layout slip (``extensions/creaitor/skills/creaitor/`` instead of
+    ``skills/seo-creaitor/``) would silently shrink that set and make the table
+    test below pass vacuously for the missing extension.
+    """
+    expected = {
+        "ahrefs", "bing", "creaitor", "dataforseo", "firecrawl",
+        "image-gen", "profound", "seranking", "unlighthouse",
+    }
+    missing = sorted(expected - extension_commands())
+    assert missing == [], f"extension sub-skills not discovered on disk: {missing}"
+
+
 def test_quick_reference_table_parses():
     commands = quick_reference_commands()
     assert {"audit", "page", "technical"} <= commands, (

--- a/tests/test_orchestrator_command_table.py
+++ b/tests/test_orchestrator_command_table.py
@@ -1,0 +1,70 @@
+"""Regression: the /seo orchestrator Quick Reference must list every extension command.
+
+Optional extensions ship in ``extensions/<name>/skills/seo-<token>/`` and are
+activated by a separate installer, so they are easy to document everywhere
+(README, CLAUDE.md, AGENTS.md, docs/COMMANDS.md) while being forgotten in the
+one table the model actually routes from. ``scripts/consistency_check.py``
+matches ``/seo <cmd>`` anywhere in the file, so a prose mention alone satisfies
+it; this test asserts the command has a row in the Quick Reference table itself.
+"""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+ORCHESTRATOR = REPO / "skills" / "seo" / "SKILL.md"
+
+COMMAND_CELL = re.compile(r"`/seo\s+([a-z][a-z0-9-]*)")
+
+
+def quick_reference_commands():
+    """Command tokens appearing in the first column of the Quick Reference table."""
+    lines = ORCHESTRATOR.read_text(encoding="utf-8").splitlines()
+    commands = set()
+    in_section = False
+    for line in lines:
+        if line.startswith("## "):
+            if in_section:
+                break
+            in_section = line.strip() == "## Quick Reference"
+            continue
+        if in_section and line.startswith("|"):
+            first_cell = line.split("|")[1]
+            match = COMMAND_CELL.search(first_cell)
+            if match:
+                commands.add(match.group(1))
+    return commands
+
+
+def extension_commands():
+    """Command tokens for every optional extension that installs its own sub-skill."""
+    return {path.parent.name[len("seo-"):]
+            for path in REPO.glob("extensions/*/skills/seo-*/SKILL.md")}
+
+
+def test_quick_reference_table_parses():
+    commands = quick_reference_commands()
+    assert {"audit", "page", "technical"} <= commands, (
+        "Quick Reference table not found or not parseable in skills/seo/SKILL.md"
+    )
+
+
+def test_every_extension_command_has_a_quick_reference_row():
+    expected = extension_commands()
+    assert expected, "no extension sub-skills discovered under extensions/*/skills/"
+    missing = sorted(expected - quick_reference_commands())
+    assert missing == [], (
+        "extension commands missing from the /seo Quick Reference table: "
+        + ", ".join(f"/seo {cmd}" for cmd in missing)
+    )
+
+
+def test_extension_rows_are_marked_as_extensions():
+    text = ORCHESTRATOR.read_text(encoding="utf-8")
+    unmarked = []
+    for cmd in sorted(extension_commands()):
+        row = re.search(rf"^\|\s*`/seo {re.escape(cmd)}\b.*$", text, re.MULTILINE)
+        if row and "(extension)" not in row.group(0):
+            unmarked.append(cmd)
+    assert unmarked == [], (
+        "extension rows must be labelled `(extension)`: " + ", ".join(unmarked)
+    )

--- a/tests/test_parasite_risk_and_extensions.py
+++ b/tests/test_parasite_risk_and_extensions.py
@@ -1,7 +1,7 @@
 """
 Tests for the v2 Checkpoint 5 deliverables:
     scripts/parasite_risk.py
-    extensions/<name>/  (structure check for all 5 new extensions)
+    extensions/<name>/  (structure check for each optional extension)
     skills/seo-geo/references/llmstxt-evidence.md  (evidence file exists)
 """
 
@@ -104,6 +104,7 @@ def test_audit_page_counts_pattern_hits() -> None:
         ("profound", "seo-profound"),
         ("bing-webmaster", "seo-bing"),
         ("unlighthouse", "seo-unlighthouse"),
+        ("creaitor", "seo-creaitor"),
     ],
 )
 def test_extension_has_install_skill_and_docs(name: str, skill_dir: str) -> None:
@@ -123,7 +124,8 @@ def test_extension_has_install_skill_and_docs(name: str, skill_dir: str) -> None
 
 
 @pytest.mark.parametrize(
-    "name", ["ahrefs", "seranking", "profound", "bing-webmaster", "unlighthouse"],
+    "name",
+    ["ahrefs", "seranking", "profound", "bing-webmaster", "unlighthouse", "creaitor"],
 )
 def test_extension_install_script_is_executable(name: str) -> None:
     install = _REPO_ROOT / "extensions" / name / "install.sh"
@@ -157,6 +159,7 @@ def test_every_extension_install_and_uninstall_is_executable() -> None:
         ("profound", "seo-profound"),
         ("bing-webmaster", "seo-bing"),
         ("unlighthouse", "seo-unlighthouse"),
+        ("creaitor", "seo-creaitor"),
     ],
 )
 def test_extension_skillmd_has_required_frontmatter(


### PR DESCRIPTION
## Summary

- adds a real optional Creaitor extension with the direct command `/seo creaitor [command] <url>`
- connects Claude Code to Creaitor’s official remote GEO MCP endpoint at `https://app.creaitor.ai/api/v2/mcp`
- exposes live GEO visibility, citations, sources, tracked prompts, stored audits, recommendations, competitors, and health scores
- includes guarded execute-tier commands for audits, query runs, citation exports, and `llms.txt` generation
- exposes all separately installed optional extensions in the main `/seo` Quick Reference

## Creaitor commands

Read-only examples:

- `/seo creaitor overview <url>`
- `/seo creaitor visibility <url>`
- `/seo creaitor citations <url>`
- `/seo creaitor sources <url>`
- `/seo creaitor prompts <url>`
- `/seo creaitor audit <url>`
- `/seo creaitor recommendations <url>`
- `/seo creaitor competitors <url>`
- `/seo creaitor health <url>`

Explicit write/execute examples:

- `/seo creaitor prompts <url> --add "<prompt>" --topic <topic-id>`
- `/seo creaitor audit <url> --run`
- `/seo creaitor prompts <url> --run <query-id>`
- `/seo creaitor citations <url> --export`
- `/seo creaitor llms-txt <url>`

## Installation and security

- Unix and PowerShell installers copy `seo-creaitor` and merge `mcpServers.creaitor-geo` into `~/.claude.json`
- token input is hidden and never printed or passed in process arguments
- config writes are atomic and preserve unrelated Claude/MCP configuration
- malformed config fails closed instead of being overwritten
- Unix config permissions are `0600`
- uninstaller removes only the Creaitor skill and MCP entry
- read commands never trigger quota-consuming operations

## Verification

- [x] Full suite: `453 passed`
- [x] Focused extension/security/consistency tests: `53 passed`
- [x] Ruff: passed
- [x] Portability lint: 34 skills, 0 errors/warnings
- [x] Real Unix installer/uninstaller smoke test in isolated HOME: passed, no token leak
- [x] Claude CLI-generated remote MCP config shape compared: exact match
- [x] Production MCP endpoint probe: HTTP 401 with structured `unauthenticated` envelope, confirming the live route
- [x] Independent review: PASS after correcting execute abilities, topic IDs, PowerShell error propagation, domain cap, JSON-RPC errors, and queue-only behavior
- [x] SKILL.md remains below 500 lines (141 lines)
- [x] CHANGELOG.md updated

## Notes

A Creaitor personal access token is created at `https://app.creaitor.ai/user/api-tokens`. `geo:read` covers the default read commands; `geo:write` covers mutations; `geo:execute` covers explicit execute-tier operations.
