### PR TITLE
fix(hooks): detect every ld+json block and stop flagging template expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The JSON-LD hook now validates every `application/ld+json` block regardless of
+  attribute order, CSP `nonce`, `id` or `data-*` attributes, tag case, or an
+  unquoted type value; such blocks were previously skipped without validation.
+- The JSON-LD hook no longer reports runtime template expressions (JSX, Vue,
+  Svelte, template literals in component files; PHP and EJS everywhere) as
+  invalid JSON, while a malformed literal in plain HTML is still reported.
+- The JSON-LD hook accepts the schema.org `@context` with a trailing slash, in
+  list form, and in `{"@vocab": ...}` object form.
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/hooks/validate-schema.py
+++ b/hooks/validate-schema.py
@@ -49,6 +49,45 @@ BRACKET_PLACEHOLDERS = (
 )
 BARE_PLACEHOLDER_RE = re.compile(r"\bREPLACE(?:_[A-Z]+)*\b")
 
+# Match every <script ...>...</script> pair, then filter on the type attribute.
+# The previous pattern required ``type`` to be the first and only attribute, so
+# blocks carrying a CSP ``nonce``, an ``id`` or ``data-*`` attributes, or an
+# unquoted type value were skipped without validation.
+SCRIPT_TAG_RE = re.compile(
+    r"<script\b([^>]*)>(.*?)</script\s*>", re.DOTALL | re.IGNORECASE
+)
+LD_JSON_TYPE_RE = re.compile(
+    r"""(?:^|\s)type\s*=\s*"""
+    r"""(?:"application/ld\+json"|'application/ld\+json'|application/ld\+json(?=\s|$))""",
+    re.IGNORECASE,
+)
+
+# Server- or client-side template expressions that render JSON-LD at runtime.
+# The hook runs on .jsx/.tsx/.vue/.svelte/.php/.ejs sources, where the script
+# body is frequently an expression rather than literal JSON. Those blocks cannot
+# be validated statically and must not be reported as invalid JSON.
+SERVER_TEMPLATE_RE = re.compile(
+    r"""^(?:
+        <\?(?:php\b|=)            # <?php ... ?> / <?= ... ?>
+      | <%                        # EJS / ERB
+    )""",
+    re.VERBOSE,
+)
+COMPONENT_EXPRESSION_RE = re.compile(
+    r"""^(?:
+        \{\{                      # Vue / Handlebars / Twig
+      | \{@html\b                 # Svelte
+      | \$\{                      # JS template literal
+      | \{\s*[A-Za-z_$][\w$.]*    # JSX expression: {schema} / {JSON.stringify(...)}
+    )""",
+    re.VERBOSE,
+)
+COMPONENT_EXTENSIONS = (".jsx", ".tsx", ".vue", ".svelte")
+
+SCHEMA_ORG_CONTEXTS = frozenset(
+    {"https://schema.org", "http://schema.org", "https://schema.org/", "http://schema.org/"}
+)
+
 
 def _configure_utf8() -> None:
     """Keep hook diagnostics printable on legacy Windows console encodings."""
@@ -58,17 +97,57 @@ def _configure_utf8() -> None:
             reconfigure(encoding="utf-8", errors="replace")
 
 
-def validate_jsonld(content: str) -> List[str]:
+def _extract_ld_json_blocks(content: str) -> List[str]:
+    """Return the bodies of every ``<script type="application/ld+json">`` block.
+
+    Attribute order, extra attributes (``nonce``, ``id``, ``data-*``), tag case
+    and unquoted type values are all accepted; only the type value is decisive.
+    """
+    blocks = []
+    for attributes, body in SCRIPT_TAG_RE.findall(content):
+        if LD_JSON_TYPE_RE.search(attributes):
+            blocks.append(body)
+    return blocks
+
+
+def _is_template_expression(block: str, filepath: str = "") -> bool:
+    """True when the script body is rendered at runtime rather than literal JSON.
+
+    Server-side markers (PHP, EJS) are never valid JSON and are skipped for
+    every file type. Component expressions (JSX, Vue, Svelte, template
+    literals) are only skipped in component sources, so a malformed object
+    literal in a plain ``.html`` file is still reported.
+    """
+    if SERVER_TEMPLATE_RE.match(block):
+        return True
+    if filepath.lower().endswith(COMPONENT_EXTENSIONS):
+        return bool(COMPONENT_EXPRESSION_RE.match(block))
+    return False
+
+
+def _is_schema_org_context(value: Any) -> bool:
+    """Accept the schema.org context in its string, list and object forms."""
+    if isinstance(value, str):
+        return value in SCHEMA_ORG_CONTEXTS
+    if isinstance(value, list):
+        return any(_is_schema_org_context(item) for item in value)
+    if isinstance(value, dict):
+        return _is_schema_org_context(value.get("@vocab"))
+    return False
+
+
+def validate_jsonld(content: str, filepath: str = "") -> List[str]:
     """Validate JSON-LD blocks in HTML content."""
     errors = []
-    pattern = r'<script\s+type=["\']application/ld\+json["\']\s*>(.*?)</script>'
-    blocks = re.findall(pattern, content, re.DOTALL | re.IGNORECASE)
+    blocks = _extract_ld_json_blocks(content)
 
     if not blocks:
         return []  # No schema found; not an error
 
     for i, block in enumerate(blocks, 1):
         block = block.strip()
+        if _is_template_expression(block, filepath):
+            continue  # Rendered at runtime; nothing to validate statically
         try:
             data = json.loads(block)
         except json.JSONDecodeError as e:
@@ -99,10 +178,7 @@ def _validate_schema_object(
     # Check @context
     if "@context" not in obj and not inherited_context:
         errors.append(f"{prefix}: Missing @context")
-    elif "@context" in obj and obj["@context"] not in (
-        "https://schema.org",
-        "http://schema.org",
-    ):
+    elif "@context" in obj and not _is_schema_org_context(obj["@context"]):
         errors.append(f"{prefix}: @context should be 'https://schema.org'")
 
     graph = obj.get("@graph")
@@ -214,7 +290,7 @@ def main():
     except (OSError, IOError):
         sys.exit(0)
 
-    errors = validate_jsonld(content)
+    errors = validate_jsonld(content, filepath)
 
     if not errors:
         sys.exit(0)

--- a/tests/test_schema_hook_detection.py
+++ b/tests/test_schema_hook_detection.py
@@ -1,0 +1,155 @@
+"""Block detection regressions for the JSON-LD validation hook.
+
+Two failure classes are covered:
+
+1. False negatives. The hook must find every ``application/ld+json`` block,
+   whatever the attribute order, the presence of a CSP ``nonce`` or ``id``,
+   the quoting of the type value or the case of the tag. A missed block means
+   a placeholder or a retired type reaches production unnoticed.
+2. False positives. Component and server templates render JSON-LD at runtime.
+   Their script bodies are expressions, not JSON, and must not be reported as
+   invalid on every edit. A malformed literal in plain HTML is still reported.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "hooks" / "validate-schema.py"
+
+RETIRED = '{"@context":"https://schema.org","@type":"ClaimReview"}'
+PLACEHOLDER = '{"@context":"https://schema.org","@type":"LocalBusiness","name":"[Business Name]"}'
+VALID = '{"@context":"https://schema.org","@type":"Organization","name":"Example"}'
+
+
+def _run(tmp_path: Path, filename: str, head: str) -> subprocess.CompletedProcess:
+    target = tmp_path / filename
+    target.write_text(f"<html><head>{head}</head><body></body></html>", encoding="utf-8")
+    return subprocess.run([sys.executable, str(HOOK), str(target)], capture_output=True, text=True)
+
+
+# --- false negatives -------------------------------------------------------
+
+
+def test_block_with_csp_nonce_is_validated(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path,
+        "page.html",
+        f'<script type="application/ld+json" nonce="r4nd0m">{PLACEHOLDER}</script>',
+    )
+    assert result.returncode == 2
+    assert "[Business Name]" in result.stdout
+
+
+def test_attribute_before_type_is_validated(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path, "page.html", f'<script id="schema" type="application/ld+json">{RETIRED}</script>'
+    )
+    assert result.returncode == 2
+    assert "ClaimReview" in result.stdout
+
+
+def test_unquoted_type_value_is_validated(tmp_path: Path) -> None:
+    result = _run(tmp_path, "page.html", f"<script type=application/ld+json>{RETIRED}</script>")
+    assert result.returncode == 2
+
+
+def test_uppercase_tag_and_attribute_are_validated(tmp_path: Path) -> None:
+    result = _run(tmp_path, "page.html", f'<SCRIPT TYPE="application/ld+json">{RETIRED}</SCRIPT>')
+    assert result.returncode == 2
+
+
+def test_other_script_types_are_ignored(tmp_path: Path) -> None:
+    head = f'<script type="module">{RETIRED}</script><script type="text/javascript">var x = {RETIRED};</script>'
+    assert _run(tmp_path, "page.html", head).returncode == 0
+
+
+def test_valid_block_with_extra_attributes_passes(tmp_path: Path) -> None:
+    head = f'<script data-testid="ld" type="application/ld+json" nonce="abc">{VALID}</script>'
+    assert _run(tmp_path, "page.html", head).returncode == 0
+
+
+# --- false positives on templates -------------------------------------------
+
+
+def test_jsx_expression_body_is_not_reported(tmp_path: Path) -> None:
+    head = '<script type="application/ld+json">{JSON.stringify(schema)}</script>'
+    result = _run(tmp_path, "page.tsx", head)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_jsx_identifier_body_is_not_reported(tmp_path: Path) -> None:
+    result = _run(tmp_path, "Page.jsx", '<script type="application/ld+json">{jsonLd}</script>')
+    assert result.returncode == 0
+
+
+def test_vue_mustache_body_is_not_reported(tmp_path: Path) -> None:
+    result = _run(tmp_path, "Page.vue", '<script type="application/ld+json">{{ jsonLd }}</script>')
+    assert result.returncode == 0
+
+
+def test_svelte_html_body_is_not_reported(tmp_path: Path) -> None:
+    head = '<script type="application/ld+json">{@html JSON.stringify(schema)}</script>'
+    assert _run(tmp_path, "Page.svelte", head).returncode == 0
+
+
+def test_php_echo_body_is_not_reported(tmp_path: Path) -> None:
+    head = '<script type="application/ld+json"><?php echo json_encode($schema); ?></script>'
+    assert _run(tmp_path, "page.php", head).returncode == 0
+
+
+def test_ejs_body_is_not_reported(tmp_path: Path) -> None:
+    head = '<script type="application/ld+json"><%- JSON.stringify(schema) %></script>'
+    assert _run(tmp_path, "page.ejs", head).returncode == 0
+
+
+def test_literal_json_in_component_file_is_still_validated(tmp_path: Path) -> None:
+    result = _run(tmp_path, "Page.tsx", f'<script type="application/ld+json">{RETIRED}</script>')
+    assert result.returncode == 2
+
+
+def test_malformed_object_literal_in_html_is_still_reported(tmp_path: Path) -> None:
+    result = _run(
+        tmp_path, "page.html", '<script type="application/ld+json">{name: "unquoted"}</script>'
+    )
+    assert result.returncode == 1
+    assert "Invalid JSON" in result.stdout
+
+
+# --- @context forms ---------------------------------------------------------
+
+
+def test_context_with_trailing_slash_is_accepted(tmp_path: Path) -> None:
+    head = '<script type="application/ld+json">{"@context":"https://schema.org/","@type":"Organization","name":"X"}</script>'
+    result = _run(tmp_path, "page.html", head)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_context_object_with_schema_vocab_is_accepted(tmp_path: Path) -> None:
+    head = (
+        '<script type="application/ld+json">'
+        '{"@context":{"@vocab":"https://schema.org/"},"@type":"Organization","name":"X"}'
+        "</script>"
+    )
+    assert _run(tmp_path, "page.html", head).returncode == 0
+
+
+def test_context_list_containing_schema_org_is_accepted(tmp_path: Path) -> None:
+    head = (
+        '<script type="application/ld+json">'
+        '{"@context":["https://schema.org",{"ex":"https://example.com/ns#"}],"@type":"Organization","name":"X"}'
+        "</script>"
+    )
+    assert _run(tmp_path, "page.html", head).returncode == 0
+
+
+def test_foreign_context_is_still_reported(tmp_path: Path) -> None:
+    head = '<script type="application/ld+json">{"@context":"https://example.com/ns","@type":"Organization"}</script>'
+    result = _run(tmp_path, "page.html", head)
+    assert result.returncode == 1
+    assert "@context should be" in result.stdout


### PR DESCRIPTION
## Summary

`hooks/validate-schema.py` only matched `<script type="application/ld+json">` when `type` was the first and only attribute, and it reported runtime template expressions in framework files as invalid JSON. This PR fixes both and widens the accepted `@context` forms.

Reproduced on `main` (a1480c7) by running the hook directly on fixture files.

**Silent skips (exit 0, nothing validated):**

| Fixture | Result on main |
|---|---|
| `<script type="application/ld+json" nonce="abc">` containing `[Business Name]` | exit 0, placeholder not caught |
| `<script id="ld" type="application/ld+json">` containing `ClaimReview` | exit 0, retired type not caught |
| `<script type=application/ld+json>` (unquoted) | exit 0 |

CSP nonces are standard on production sites, so the hook was skipping exactly the blocks it exists to check.

**Noise on every edit (exit 1 warning):**

| File | Body | Result on main |
|---|---|---|
| `.tsx` | `{JSON.stringify(schema)}` | Invalid JSON |
| `.vue` | `{{ jsonLd }}` | Invalid JSON |
| `.php` | `<?php echo json_encode($schema); ?>` | Invalid JSON |
| `.ejs` | `<%- JSON.stringify(schema) %>` | Invalid JSON |
| `.svelte` | `{@html ...}` | Invalid JSON |

The hook's own extension list targets these frameworks, and nothing the author does can make a runtime expression parse as JSON.

**Valid `@context` reported as wrong:** `"https://schema.org/"` (trailing slash), `["https://schema.org", {...}]`, `{"@vocab": "https://schema.org/"}`.

**Changes**

- Match every `<script ...>...</script>` pair and decide on the `type` attribute alone, so attribute order, extra attributes, tag case and unquoted values no longer matter. Other script types are still ignored.
- Skip server template markers (`<?php`, `<?=`, `<%`) in every file type. Skip component expressions (JSX, Vue, Svelte, template literals) only in `.jsx/.tsx/.vue/.svelte`, so a malformed object literal in a plain `.html` file is still reported.
- Accept the schema.org context as a string with or without trailing slash, as a list containing it, or as an object whose `@vocab` is it. Foreign contexts are still reported.

`validate_jsonld()` gains an optional `filepath` argument; `main()` passes the resolved path. No callers outside the hook.

**Tests**

`tests/test_schema_hook_detection.py`, 18 cases: 6 false negatives, 8 template cases including the two guards (literal JSON in a `.tsx` still validated, malformed literal in `.html` still reported), 4 `@context` forms.

```
pytest tests/test_schema_hook_detection.py tests/test_schema_hook_policy.py tests/test_cross_platform_hooks.py tests/test_schema_v2.py
51 passed
ruff check hooks/validate-schema.py tests/test_schema_hook_detection.py
All checks passed
```

Note for reviewers: the full suite does not collect on a machine without the Google client libraries because `scripts/gsc_query.py` calls `sys.exit(1)` at import and `tests/test_gsc_pagination.py` imports it at module level. Unrelated to this change; happy to open a separate PR that guards the import if useful.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting (hook exercised on fixture files covering every case above; the hook does not fetch URLs)
- [x] SKILL.md files stay under 500 lines (if modified) - not modified
- [x] Python scripts output JSON (if modified) - hook output format unchanged
- [x] Reference files stay under 200 lines (if modified) - not modified
- [x] `set -euo pipefail` used in any new shell scripts - no shell scripts
- [x] CHANGELOG.md updated with the change