### PR TITLE
fix(consistency): fold CRLF before hashing FLOW lock inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `consistency_check.py` reported every FLOW-locked prompt file as a hash
+  mismatch on a stock Windows clone: Git for Windows checks the files out with
+  CRLF (`core.autocrlf=true`) while the lock hashes LF content. The check now
+  folds CRLF before hashing, so the lock only fails on real content changes.
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/scripts/consistency_check.py
+++ b/scripts/consistency_check.py
@@ -230,6 +230,18 @@ def check_agent_refs(files, texts):
     return errors
 
 
+def _normalise_newlines(data):
+    """Hash lock inputs as LF text so a CRLF checkout matches the baseline.
+
+    The lock is written from LF content (sync_flow.py hashes the fetched text
+    directly). Git for Windows defaults to core.autocrlf=true, which checks the
+    same files out with CRLF, so a byte-for-byte hash flagged every locked file
+    as tampered on a stock Windows clone. Only CRLF is folded; any other change
+    still fails the check.
+    """
+    return data.replace(b"\r\n", b"\n")
+
+
 def check_flow_lock(files):
     errors = []
     locked = {}
@@ -246,7 +258,7 @@ def check_flow_lock(files):
             errors.append(f"flow lock: missing {rel}")
             continue
         with open(full, "rb") as fh:
-            got = hashlib.sha256(fh.read()).hexdigest()
+            got = hashlib.sha256(_normalise_newlines(fh.read())).hexdigest()
         if got != want:
             errors.append(f"flow lock: hash mismatch {rel}")
     extra = {f for f in files

--- a/tests/test_consistency_check.py
+++ b/tests/test_consistency_check.py
@@ -15,6 +15,11 @@ from pathlib import Path
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPT = os.path.join(REPO, "scripts", "consistency_check.py")
+_SCRIPTS = os.path.join(REPO, "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import consistency_check  # noqa: E402
 
 
 def run_checker():
@@ -44,3 +49,41 @@ def test_user_facing_markdown_has_no_raw_core_script_paths():
             for match in pattern.finditer(path.read_text(encoding="utf-8")):
                 offenders.append(f"{path.relative_to(root)}: scripts/{match.group(1)}")
     assert offenders == [], "raw bundled script paths:\n" + "\n".join(offenders)
+
+
+def _locked_paths() -> list:
+    lock = Path(REPO) / consistency_check.LOCK_PATH
+    return [line.split()[1] for line in lock.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.startswith("#")]
+
+
+def _copy_with_crlf(dst: Path, rels: list) -> None:
+    """Mirror ``rels`` under ``dst`` the way core.autocrlf=true checks them out."""
+    for rel in rels:
+        data = (Path(REPO) / rel).read_bytes().replace(b"\r\n", b"\n")
+        target = dst / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data.replace(b"\n", b"\r\n"))
+
+
+def test_flow_lock_accepts_crlf_checkout(tmp_path, monkeypatch):
+    """Git for Windows defaults to core.autocrlf=true, so the locked prompt
+    files check out with CRLF while the lock was written from LF content.
+    Hashing must fold CRLF, or a stock Windows clone reports every locked
+    file as tampered."""
+    locked = _locked_paths()
+    _copy_with_crlf(tmp_path, [consistency_check.LOCK_PATH, *locked])
+    monkeypatch.setattr(consistency_check, "REPO", str(tmp_path))
+    assert consistency_check.check_flow_lock(locked) == []
+
+
+def test_flow_lock_still_detects_content_change(tmp_path, monkeypatch):
+    """Folding CRLF must not weaken the lock: any other change is caught."""
+    locked = _locked_paths()
+    _copy_with_crlf(tmp_path, [consistency_check.LOCK_PATH, *locked])
+    with open(tmp_path / locked[0], "ab") as fh:
+        fh.write(b"tampered\r\n")
+    monkeypatch.setattr(consistency_check, "REPO", str(tmp_path))
+    assert consistency_check.check_flow_lock(locked) == [
+        f"flow lock: hash mismatch {locked[0]}"
+    ]


### PR DESCRIPTION
## Summary

`consistency_check.py` hashes the 44 FLOW-locked prompt files byte-for-byte against `flow-prompts.lock`. The lock was written from LF content (`sync_flow.py` hashes the fetched text), but Git for Windows defaults to `core.autocrlf=true`, so a stock clone checks those files out with CRLF. Every locked file then reads as tampered: `consistency_check.py` reports 44 errors and `test_consistency_check` fails on any Windows machine cloned the way the README describes it.

Fold CRLF to LF before hashing. LF content hashes unchanged, so the lock still fails on any real edit; the second new test pins that.

```
$ git config core.autocrlf   # true, Git for Windows default
$ python scripts/consistency_check.py --json | jq '.errors | length'
44                            # before
0                             # after
```

Verified in:
- Windows 11, Python 3.14, clean venv from `requirements.txt` + pytest, `core.autocrlf=true` — full suite 431 passed, 13 skipped (the 13 are POSIX mode-bit tests, skipped by the follow-up CI PR)
- Windows 11, Python 3.11.16, same setup — 431 passed, 13 skipped
- GitHub Actions `windows-latest`, Python 3.10, full suite with the portability job widened (follow-up PR) — `test_no_consistency_errors` fails on `main` with `flow lock: hash mismatch` and passes with this commit (the runner's git also ships `autocrlf=true`)
- GitHub Actions `macos-latest` and `ubuntu-latest`, Python 3.10 — green

Both new tests fail without the change to `consistency_check.py` (3 failed, 2 passed).

Note: this and the follow-up CI PR both add an `[Unreleased]` section to `CHANGELOG.md`; whichever lands second needs a trivial rebase, which I am happy to do.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
