### PR TITLE
ci: run the full suite on windows and macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
   portability:
     name: Portability (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      # Same reason as the test job: sync_flow.py talks to the GitHub API
+      # through gh, and anonymous requests hit the 60/hr per-IP limit.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       # Report both legs independently; a failure on one platform should not
       # hide the result on the other.
@@ -96,24 +100,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install pytest
-        # These three modules need nothing beyond pytest -- verified on a clean
-        # virtualenv. Keeping the install minimal keeps the job from failing for
-        # reasons that have nothing to do with portability.
-        run: pip install pytest
+      - name: Install runtime + test deps
+        run: pip install -r requirements.txt pytest
 
-      - name: Run the platform-sensitive suites
-        # Deliberately not `pytest tests/`. The full suite has 15 tests that
-        # assert POSIX semantics directly -- the executable bit via os.access
-        # X_OK in test_parasite_risk_and_extensions.py and
-        # test_runtime_installers.py, and chmod 0o600/0o644 token permissions in
-        # test_url_safety.py -- which cannot hold on Windows. The three modules
-        # below are the ones written to be platform-neutral, so they are the
-        # ones worth running here. Widening this list means teaching those 15
-        # tests to skip on non-POSIX first.
-        run: >
-          pytest
-          tests/test_portability.py
-          tests/test_cross_platform_hooks.py
-          tests/test_drift_portability.py
-          -v
+      - name: Run pytest
+        # The whole suite, not a hand-picked subset. The tests that assert
+        # POSIX mode bits (the executable bit, chmod 0o600/0o644) skip on
+        # Windows via os.name; everything else must hold on every platform.
+        run: pytest tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- CI now runs the full test suite on Windows and macOS, not just the three
+  platform-neutral modules. The tests that assert POSIX mode bits skip on
+  Windows instead of failing.
+
+### Fixed
+
+- The schema-hook policy tests decoded the hook's UTF-8 output with the locale
+  codec, which is cp1252 on Windows and cannot represent the emoji markers.
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/tests/test_extension_installer_injection.py
+++ b/tests/test_extension_installer_injection.py
@@ -11,6 +11,7 @@ credential-bearing settings file atomically with ``0600`` perms.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -47,6 +48,9 @@ def test_installer_uses_safe_credential_pattern(rel: str, argc: int) -> None:
     assert "0o600" in text, f"{rel} not writing settings with 0600 perms"
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts 0o600 mode bits, which Windows does not represent"
+)
 @pytest.mark.parametrize("rel,argc", INSTALLERS.items())
 def test_installer_credential_injection_is_inert(tmp_path: Path, rel: str, argc: int) -> None:
     writer = _extract_writer((ROOT / rel).read_text(encoding="utf-8"))

--- a/tests/test_parasite_risk_and_extensions.py
+++ b/tests/test_parasite_risk_and_extensions.py
@@ -7,6 +7,7 @@ Tests for the v2 Checkpoint 5 deliverables:
 
 from __future__ import annotations
 
+import os
 import stat
 import sys
 from pathlib import Path
@@ -122,6 +123,12 @@ def test_extension_has_install_skill_and_docs(name: str, skill_dir: str) -> None
     )
 
 
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix", reason="the executable bit is a POSIX mode bit; Windows has none"
+)
+
+
+@_POSIX_ONLY
 @pytest.mark.parametrize(
     "name", ["ahrefs", "seranking", "profound", "bing-webmaster", "unlighthouse"],
 )
@@ -131,6 +138,7 @@ def test_extension_install_script_is_executable(name: str) -> None:
     assert mode & stat.S_IXUSR, f"{name}/install.sh must be executable for chmod"
 
 
+@_POSIX_ONLY
 def test_every_extension_install_and_uninstall_is_executable() -> None:
     """All extensions ship executable install.sh + uninstall.sh — including v1 ones."""
     ext_root = _REPO_ROOT / "extensions"

--- a/tests/test_runtime_installers.py
+++ b/tests/test_runtime_installers.py
@@ -1,6 +1,9 @@
 """Static installer/runtime contract checks that do not mutate a real home."""
 
+import os
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -29,10 +32,15 @@ def test_windows_installer_delegates_to_runtime_without_path_mutation() -> None:
     assert "-Directory -Filter 'seo*'" not in text
 
 
-def test_launcher_is_executable_and_uses_safe_exec() -> None:
-    launcher = ROOT / "bin/claude-seo"
-    assert launcher.stat().st_mode & 0o100
-    text = launcher.read_text(encoding="utf-8")
+@pytest.mark.skipif(
+    os.name != "posix", reason="the executable bit is a POSIX mode bit; Windows has none"
+)
+def test_launcher_is_executable() -> None:
+    assert (ROOT / "bin/claude-seo").stat().st_mode & 0o100
+
+
+def test_launcher_uses_safe_exec() -> None:
+    text = (ROOT / "bin/claude-seo").read_text(encoding="utf-8")
     assert 'exec py -3 "${runtime}" "$@"' in text
     assert 'exec python3 "${runtime}" "$@"' in text
     assert 'exec python "${runtime}" "$@"' in text

--- a/tests/test_schema_hook_policy.py
+++ b/tests/test_schema_hook_policy.py
@@ -63,7 +63,10 @@ def test_graph_members_inherit_context_but_still_require_type(tmp_path: Path) ->
         "@context": "https://schema.org",
         "@graph": [{"name": "Missing type"}],
     }
-    result = _run_payload(tmp_path, payload, capture_output=True, text=True)
+    # The hook forces UTF-8 on its own stdout (_configure_utf8); decode with the
+    # same codec, not the locale default, which is cp1252 on Windows and cannot
+    # represent the emoji markers.
+    result = _run_payload(tmp_path, payload, capture_output=True, encoding="utf-8")
     assert result.returncode == 1
     assert "Missing @type" in result.stdout
     assert "Missing @context" not in result.stdout
@@ -82,7 +85,7 @@ def test_non_object_graph_members_are_reported_without_crashing(tmp_path: Path) 
         "@context": "https://schema.org",
         "@graph": ["not-a-node", 42],
     }
-    result = _run_payload(tmp_path, payload, capture_output=True, text=True)
+    result = _run_payload(tmp_path, payload, capture_output=True, encoding="utf-8")
     assert result.returncode == 1
     assert "@graph member 1 must be an object" in result.stdout
     assert "@graph member 2 must be an object" in result.stdout
@@ -93,7 +96,7 @@ def test_graph_must_be_a_list(tmp_path: Path) -> None:
         "@context": "https://schema.org",
         "@graph": {"@type": "Organization"},
     }
-    result = _run_payload(tmp_path, payload, capture_output=True, text=True)
+    result = _run_payload(tmp_path, payload, capture_output=True, encoding="utf-8")
     assert result.returncode == 1
     assert "@graph must be a list" in result.stdout
 

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -502,6 +502,9 @@ def test_route_handler_continues_when_both_ipv4_and_ipv6_public() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts POSIX mode bits, which Windows does not represent"
+)
 def test_save_oauth_token_writes_0o600(tmp_path, monkeypatch) -> None:
     """_save_oauth_token must produce a 0o600 file regardless of whether
     the path existed beforehand or what the umask is."""
@@ -519,6 +522,9 @@ def test_save_oauth_token_writes_0o600(tmp_path, monkeypatch) -> None:
         os.umask(old_umask)
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts POSIX mode bits, which Windows does not represent"
+)
 def test_save_oauth_token_remediates_legacy_0o644(tmp_path, monkeypatch) -> None:
     """A pre-existing 0o644 token (v1.9.x default) is locked down on save."""
     import google_auth  # noqa: WPS433
@@ -582,6 +588,9 @@ def test_save_oauth_token_ignores_fchmod_oserror(tmp_path, monkeypatch) -> None:
     }
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts POSIX mode bits, which Windows does not represent"
+)
 def test_load_oauth_token_remediates_legacy_0o644(tmp_path, monkeypatch) -> None:
     """_load_oauth_token chmods the file before reading, so the next read
     by any other process sees 0o600 even without a re-save."""

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -581,7 +581,9 @@ def test_save_oauth_token_ignores_fchmod_oserror(tmp_path, monkeypatch) -> None:
     def unsupported_fchmod(_fd, _mode):
         raise OSError("unsupported")
 
-    monkeypatch.setattr(google_auth.os, "fchmod", unsupported_fchmod)
+    # os.fchmod only exists on Windows from Python 3.13; install the stub
+    # either way so the OSError path is exercised on every platform.
+    monkeypatch.setattr(google_auth.os, "fchmod", unsupported_fchmod, raising=False)
     google_auth._save_oauth_token({"access_token": "portable"})
     assert json.loads(target.read_text(encoding="utf-8")) == {
         "access_token": "portable"


### PR DESCRIPTION
## Summary

Follow-up to #185. The portability job ran three hand-picked modules because 15 tests could not hold on Windows. This widens it to `pytest tests/` on both legs, with the same install and `GH_TOKEN` setup as the ubuntu job, after making the suite actually portable:

- 13 tests assert the executable bit or `chmod 0o600/0o644`; they now skip on `os.name != "posix"`. The launcher test is split so its text assertions still run everywhere.
- Three schema-hook tests decoded the hook's UTF-8 output with the locale codec (cp1252 on Windows), so `result.stdout` came back `None`.
- One test monkeypatched `os.fchmod`, which Windows only has from Python 3.13; `raising=False` installs the stub on the 3.10 leg too.

The remaining Windows failure is `test_no_consistency_errors`, which #292 fixes: the runner's git checks the FLOW prompts out with CRLF and the lock check rejects them. The windows leg of this PR stays red until #292 lands, so #292 should merge first.

Verified in:
- Windows 11, Python 3.14, clean venv from `requirements.txt` + pytest, with #292 applied — 431 passed, 13 skipped
- Windows 11, Python 3.11.16, same setup — 431 passed, 13 skipped
- GitHub Actions `windows-latest`, Python 3.10 — 1 failed (`test_no_consistency_errors`), 428 passed, 13 skipped on this branch alone; 431 passed, 13 skipped with #292 applied on top
- GitHub Actions `macos-latest`, Python 3.10 — 442 passed
- GitHub Actions `ubuntu-latest`, Python 3.10 (existing `test` job) — green

Note: this and #292 both add an `[Unreleased]` section to `CHANGELOG.md`; whichever lands second needs a trivial rebase, which I am happy to do.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [x] Other (describe below) — CI coverage

## Checklist

- [ ] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [ ] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
