### PR TITLE
fix(url_safety): refuse the RFC 6598 shared address space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `url_safety.is_safe_ip` accepted the RFC 6598 shared address space
+  (100.64.0.0/10), which Python's `ipaddress` does not count as private. Alibaba
+  Cloud serves instance metadata at 100.100.100.200, so a crafted URL or DNS
+  answer in that range slipped past the SSRF guard. The range is now refused,
+  and IPv4-mapped IPv6 literals are judged as their embedded IPv4 address.
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/scripts/url_safety.py
+++ b/scripts/url_safety.py
@@ -180,20 +180,30 @@ def _reject_authority_confusion(url: str, parsed) -> None:
         raise URLSafetyError("URL fragment/userinfo confusion refused")
 
 
+# RFC 6598 shared address space (carrier-grade NAT). Not in ``is_private``
+# on any supported Python, yet never publicly routable: Alibaba Cloud serves
+# its instance metadata at 100.100.100.200, and Tailscale/WireGuard meshes
+# hand out 100.64/10 addresses for internal services.
+_SHARED_ADDRESS_SPACE = ipaddress.ip_network("100.64.0.0/10")
+
+
 def is_safe_ip(ip_str: str) -> bool:
     """Return True iff ``ip_str`` is a public unicast address.
 
-    Handles IPv4-mapped IPv6 (``::ffff:127.0.0.1`` correctly returns False
-    because Python 3.9+'s ``ipaddress`` propagates ``is_loopback`` /
-    ``is_private`` through IPv4-mapped form). IPv6 unique-local
-    (``fc00::/7``) and link-local (``fe80::/10``) are also rejected.
+    IPv4-mapped IPv6 (``::ffff:127.0.0.1``) is unwrapped and judged as the
+    embedded IPv4 address, so every IPv4 rule below applies to it too.
+    IPv6 unique-local (``fc00::/7``) and link-local (``fe80::/10``) are
+    also rejected.
     """
     try:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
         return False
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
     return not (
         ip.is_private
+        or (ip.version == 4 and ip in _SHARED_ADDRESS_SPACE)
         or ip.is_loopback
         or ip.is_reserved
         or ip.is_link_local

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -133,6 +133,13 @@ def test_validate_url_blocks_authority_confusion(url: str) -> None:
         ("172.16.0.1", False),
         ("127.0.0.1", False),
         ("169.254.169.254", False),  # AWS/GCP/Azure metadata
+        ("100.100.100.200", False),  # Alibaba Cloud metadata (RFC 6598 shared space)
+        ("100.64.0.0", False),  # RFC 6598 lower bound
+        ("100.127.255.255", False),  # RFC 6598 upper bound
+        ("100.128.0.1", True),  # first address past the /10 is public
+        ("::ffff:100.100.100.200", False),  # IPv4-mapped form of the above
+        ("::ffff:127.0.0.1", False),
+        ("::ffff:8.8.8.8", True),
         ("0.0.0.0", False),
         ("::1", False),
         ("fe80::1", False),  # IPv6 link-local
@@ -204,6 +211,8 @@ def test_validate_url_strict_accepts_ip_literal_public() -> None:
         "https://10.0.0.1/",
         "https://192.168.1.1/",
         "https://169.254.169.254/",
+        "http://100.100.100.200/latest/meta-data/",
+        "http://[::ffff:100.100.100.200]/latest/meta-data/",
         "https://0.0.0.0/",
     ],
 )


### PR DESCRIPTION
## Summary

`is_safe_ip` decides what counts as public by `ipaddress.is_private` plus a few flags. That leaves the RFC 6598 shared address space (100.64.0.0/10) open: Python does not classify it as private on any supported version, but it is never publicly routable. Alibaba Cloud serves its instance metadata at 100.100.100.200, and mesh VPNs hand out 100.64/10 addresses for internal services, so a URL literal or a DNS answer in that range passed `validate_url_strict` and the pinned-resolver check.

Refuse the range explicitly. IPv4-mapped IPv6 literals are unwrapped first, so every IPv4 rule also covers `::ffff:a.b.c.d`.

```
>>> validate_url_strict("http://100.100.100.200/latest/meta-data/")
('http://100.100.100.200/latest/meta-data/', '100.100.100.200')   # before
URLSafetyError: Blocked IP literal: 100.100.100.200                # after
```

Verified in:
- Windows 11, Python 3.14, clean venv from `requirements.txt` + pytest — `test_url_safety.py` 99 passed; full suite 433 passed, 17 failed — the same 17 that fail on `main` on Windows today (POSIX mode bits, cp1252 decode, CRLF lock), addressed by #292/#293
- Windows 11, Python 3.11.16, same setup — 432 passed, 18 failed — the same 18 that fail on `main` on Windows today (POSIX mode bits, cp1252 decode, CRLF lock, `os.fchmod` absent before 3.13), addressed by #292/#293
- GitHub Actions `ubuntu-latest`, Python 3.10, full suite — 450 passed
- GitHub Actions `windows-latest` / `macos-latest`, Python 3.10, portability job — 15 passed each

The added `is_safe_ip` cases fail without the change (3 failed on `main`).

Note: this and #292/#293 each add an `[Unreleased]` section to `CHANGELOG.md`; whichever lands later needs a trivial rebase, which I am happy to do.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [ ] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
