### PR TITLE
fix(preload_check): exit 0 on a completed run, gate only with --fail-under

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `preload_check.py` exited 1 on every successful run that scored below a
+  hard-coded 75, so `set -e` scripts and CI steps aborted on healthy pages. A
+  completed analysis now exits 0; the gate is opt-in through `--fail-under N`.
+  Exit 2 for a URL refused by url_safety is unchanged. (#281)
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/scripts/preload_check.py
+++ b/scripts/preload_check.py
@@ -46,6 +46,12 @@ Result JSON::
       "score": 0..100,
       "recommendations": ["…"]
     }
+
+Exit status::
+
+    0  analysis completed (a low score is a finding, not a failed run)
+    1  score below ``--fail-under N`` (opt-in gate, off by default)
+    2  URL refused by url_safety
 """
 
 from __future__ import annotations
@@ -195,6 +201,14 @@ def main() -> int:
     )
     parser.add_argument("url")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--fail-under",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Exit 1 if the score is below N. Off by default: a successful "
+             "run exits 0 whatever the score.",
+    )
     args = parser.parse_args()
 
     try:
@@ -228,7 +242,9 @@ def main() -> int:
             for r in result["recommendations"]:
                 print(f"  - {r}")
 
-    return 0 if result["score"] >= 75 else 1
+    if args.fail_under is not None and result["score"] < args.fail_under:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_technical_depth.py
+++ b/tests/test_technical_depth.py
@@ -14,8 +14,10 @@ deferred to manual smoke tests.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 _SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
@@ -170,3 +172,41 @@ def test_unlighthouse_reports_missing_node(monkeypatch) -> None:
     result = unlighthouse_run.run("https://example.com/")
     assert result["ok"] is False
     assert "npx" in result["error"].lower() or "node" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# preload_check exit status (issue #281): success is 0, gating is opt-in
+# ---------------------------------------------------------------------------
+
+_PLAIN_HTML = "<html><head></head><body><p>nothing to preload</p></body></html>"
+
+
+def _run_preload_main(monkeypatch, capsys, *argv: str) -> tuple[int, str]:
+    response = SimpleNamespace(url="https://example.com/", text=_PLAIN_HTML, headers={})
+    monkeypatch.setattr(preload_check, "safe_requests_get", lambda *a, **k: response)
+    monkeypatch.setattr(sys, "argv", ["preload_check.py", "https://example.com/", *argv])
+    code = preload_check.main()
+    return code, capsys.readouterr().out
+
+
+def test_preload_main_exits_zero_on_a_low_score(monkeypatch, capsys) -> None:
+    score = preload_check.analyse(_PLAIN_HTML, {})["score"]
+    assert score < 75  # the old hard-coded gate would have exited 1 here
+    code, out = _run_preload_main(monkeypatch, capsys, "--json")
+    assert code == 0
+    assert json.loads(out)["score"] == score
+
+
+def test_preload_main_fail_under_gates_on_the_score(monkeypatch, capsys) -> None:
+    score = preload_check.analyse(_PLAIN_HTML, {})["score"]
+    assert _run_preload_main(monkeypatch, capsys, "--fail-under", str(score + 1))[0] == 1
+    assert _run_preload_main(monkeypatch, capsys, "--fail-under", str(score))[0] == 0
+
+
+def test_preload_main_still_exits_two_on_url_safety_error(monkeypatch, capsys) -> None:
+    def refuse(*a, **k):
+        raise preload_check.URLSafetyError("blocked")
+
+    monkeypatch.setattr(preload_check, "safe_requests_get", refuse)
+    monkeypatch.setattr(sys, "argv", ["preload_check.py", "http://127.0.0.1/"])
+    assert preload_check.main() == 2


### PR DESCRIPTION
## Summary

Fixes #281. `preload_check.py` encoded a quality threshold in its exit status: any page scoring below a hard-coded 75 made a successful run exit 1, so `set -e` scripts and CI steps aborted on healthy pages, and 1 was indistinguishable in meaning from the genuine error path (2 for a URL refused by url_safety). The threshold was undocumented and not configurable, unlike `content_quality.py`'s `--threshold`.

A completed analysis now exits 0. The gate stays available as an opt-in `--fail-under N`, and the module docstring documents the exit status (0 / 1 / 2).

```
$ python scripts/preload_check.py https://example.com/ --json >/dev/null; echo $?
1     # main (score 50)
0     # this branch
$ python scripts/preload_check.py https://example.com/ --json --fail-under 75 >/dev/null; echo $?
1     # opt-in gate, same behaviour as before
```

Verified in:
- Windows 11, Python 3.14, clean venv from `requirements.txt` + pytest — `test_technical_depth.py` 20 passed; full suite 427 passed, 17 failed — the same 17 that fail on `main` on Windows today (POSIX mode bits, cp1252 decode, CRLF lock), addressed by #292/#293; the three CLI runs above against the live `https://example.com/`
- Windows 11, Python 3.11.16, same setup — 426 passed, 18 failed — the same 18 that fail on `main` on Windows today (the 17 above plus `os.fchmod` absent before 3.13), addressed by #292/#293
- GitHub Actions `ubuntu-latest`, Python 3.10, full suite — 444 passed
- GitHub Actions `windows-latest` / `macos-latest`, Python 3.10, portability job — 15 passed each

Two of the three new tests fail without the change (the third pins that exit 2 is unchanged).

Note: this and #292–#295 each add an `[Unreleased]` section to `CHANGELOG.md`; whichever lands later needs a trivial rebase, which I am happy to do.

## Type of Change

- [x] Bug fix
- [ ] New feature / sub-skill
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe below)

## Checklist

- [x] Tested with a real URL before submitting
- [ ] SKILL.md files stay under 500 lines (if modified)
- [x] Python scripts output JSON (if modified)
- [ ] Reference files stay under 200 lines (if modified)
- [ ] `set -euo pipefail` used in any new shell scripts
- [x] CHANGELOG.md updated with the change

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
