### PR TITLE
release: v2.2.6 - security, hosted install, and reliability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "name": "AgriciDaniel"
   },
   "metadata": {
-    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse). v2.2.5 hardens installation, schema validation, rendered-page and accessibility analysis, runtime portability, and current Google Search guidance."
+    "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions (DataForSEO, Firecrawl, Banana, Ahrefs, SE Ranking, Profound, Bing Webmaster, Unlighthouse). v2.2.6 installs from the claude.ai-hosted marketplace, closes a cache-path traversal and a WHOIS referral SSRF, refuses the RFC 6598 range, raises dependency floors, and locks the cost ledgers."
   },
   "plugins": [
     {
       "name": "claude-seo",
       "source": "./",
-      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions. v2.2.5 hardens installation, schema validation, rendered-page and accessibility analysis, runtime portability, and current Google Search guidance.",
+      "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills and 18 sub-agents, plus 8 optional MCP extensions. v2.2.6 installs from the claude.ai-hosted marketplace, closes a cache-path traversal and a WHOIS referral SSRF, refuses the RFC 6598 range, raises dependency floors, and locks the cost ledgers.",
       "author": {
         "name": "AgriciDaniel",
         "url": "https://github.com/AgriciDaniel"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-seo",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Comprehensive SEO analysis plugin for Claude Code. 25 sub-skills (21 core + 1 orchestrator + 1 framework + 2 extension mirrors) and 18 sub-agents cover technical SEO, content quality, schema, sitemaps, Core Web Vitals, local SEO, backlinks, AI/GEO, ecommerce, hreflang, SXO, clustering, drift monitoring, and Google APIs. Includes optional MCP extensions, SPA-aware rendering, portability, and hardened SSRF/DNS-rebinding safe fetchers.",
   "author": {
     "name": "AgriciDaniel",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
   portability:
     name: Portability (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      # Same reason as the test job: sync_flow.py talks to the GitHub API
+      # through gh, and anonymous requests hit the 60/hr per-IP limit.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       # Report both legs independently; a failure on one platform should not
       # hide the result on the other.
@@ -96,24 +100,11 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Install pytest
-        # These three modules need nothing beyond pytest -- verified on a clean
-        # virtualenv. Keeping the install minimal keeps the job from failing for
-        # reasons that have nothing to do with portability.
-        run: pip install pytest
+      - name: Install runtime + test deps
+        run: pip install -r requirements.txt pytest
 
-      - name: Run the platform-sensitive suites
-        # Deliberately not `pytest tests/`. The full suite has 15 tests that
-        # assert POSIX semantics directly -- the executable bit via os.access
-        # X_OK in test_parasite_risk_and_extensions.py and
-        # test_runtime_installers.py, and chmod 0o600/0o644 token permissions in
-        # test_url_safety.py -- which cannot hold on Windows. The three modules
-        # below are the ones written to be platform-neutral, so they are the
-        # ones worth running here. Widening this list means teaching those 15
-        # tests to skip on non-POSIX first.
-        run: >
-          pytest
-          tests/test_portability.py
-          tests/test_cross_platform_hooks.py
-          tests/test_drift_portability.py
-          -v
+      - name: Run pytest
+        # The whole suite, not a hand-picked subset. The tests that assert
+        # POSIX mode bits (the executable bit, chmod 0o600/0o644) skip on
+        # Windows via os.name; everything else must hold on every platform.
+        run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
         run: pip install -r requirements.txt pytest
 
       - name: Run pytest
+        env:
+          CLAUDE_SEO_NETWORK_TESTS: "1"
+          GH_TOKEN: ${{ github.token }}
         run: pytest tests/ -v
 
   secret-scan:
@@ -107,4 +110,7 @@ jobs:
         # The whole suite, not a hand-picked subset. The tests that assert
         # POSIX mode bits (the executable bit, chmod 0o600/0o644) skip on
         # Windows via os.name; everything else must hold on every platform.
+        env:
+          CLAUDE_SEO_NETWORK_TESTS: "1"
+          GH_TOKEN: ${{ github.token }}
         run: pytest tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,28 @@ jobs:
           CLAUDE_SEO_NETWORK_TESTS: "1"
           GH_TOKEN: ${{ github.token }}
         run: pytest tests/ -v
+
+  dep-audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.10"
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Audit requirements.txt against the PyPI advisory database
+        # requirements.txt documents CVE floors per dependency in comments, but
+        # nothing verified them; this closes that loop. Because the pins are
+        # bounded ranges rather than exact versions, pip-audit resolves the
+        # newest allowed release, so a newly published advisory can turn this
+        # job red without a commit to the repo. That is the intended signal:
+        # it means a floor in requirements.txt needs raising. To land an
+        # unavoidable advisory in the meantime, add
+        # `--ignore-vuln GHSA-xxxx-xxxx-xxxx` with a comment naming the reason.
+        run: pip-audit -r requirements.txt --progress-spinner off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,6 @@ jobs:
   portability:
     name: Portability (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    env:
-      # Same reason as the test job: sync_flow.py talks to the GitHub API
-      # through gh, and anonymous requests hit the 60/hr per-IP limit.
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       # Report both legs independently; a failure on one platform should not
       # hide the result on the other.

--- a/.github/workflows/v2.yml
+++ b/.github/workflows/v2.yml
@@ -84,9 +84,14 @@ jobs:
           python-version: "3.10"
 
       - name: Install pytest + test deps
+        # Must not be tolerated with `|| true`: several test modules import
+        # scripts that call sys.exit(1) at module scope when a dependency is
+        # missing, so a swallowed install failure resurfaces later as an opaque
+        # pytest INTERNALERROR instead of the pip error that caused it. Matches
+        # ci.yml, which installs the same set without a fallback.
         run: |
           pip install pytest beautifulsoup4
-          pip install -r requirements.txt || true
+          pip install -r requirements.txt
 
       - name: Run pytest
         run: pytest tests/ -v

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -18,7 +18,7 @@ on:
       target_ref:
         description: "Released tag or main branch to install"
         required: true
-        default: "v2.2.5"
+        default: "v2.2.6"
         type: string
 
 permissions:
@@ -37,7 +37,7 @@ jobs:
       - id: ref
         name: Validate released source ref
         env:
-          TARGET_REF: ${{ inputs.target_ref || 'v2.2.5' }}
+          TARGET_REF: ${{ inputs.target_ref || 'v2.2.6' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/windows-smoke.yml"
       - "install.ps1"
       - "uninstall.ps1"
-      - "bin/claude-seo"
+      - "scripts/claude-seo"
       - "requirements.txt"
       - "scripts/runtime.py"
       - "scripts/seo_updates.py"

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -37,11 +37,15 @@ jobs:
       - id: ref
         name: Validate released source ref
         env:
-          TARGET_REF: ${{ inputs.target_ref || 'v2.2.6' }}
+          # Manual runs install a released tag or main. Pull requests from this
+          # repository install their own head branch, so the installer under
+          # test is the one in the PR rather than the previous release.
+          TARGET_REF: ${{ inputs.target_ref || github.head_ref || 'v2.2.6' }}
+          EVENT_NAME: ${{ github.event_name }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ ! "$TARGET_REF" =~ ^(main|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && ! "$TARGET_REF" =~ ^(main|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             echo "::error::target_ref must be main or a stable vX.Y.Z tag."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Every skill in `skills/*/SKILL.md` is authored to a portable subset of the
 Claude Code skill spec. Validate compatibility with your harness via:
 
 ```bash
-./bin/claude-seo run portability_check.py
+./scripts/claude-seo run portability_check.py
 ```
 
 The check confirms each `SKILL.md` has the minimum frontmatter every harness
@@ -106,19 +106,19 @@ provide execution capabilities.
 **Running scripts directly** (Cursor doesn't have MCP):
 ```bash
 # Page fetching with SSRF protection
-./bin/claude-seo run fetch_page.py https://example.com
+./scripts/claude-seo run fetch_page.py https://example.com
 
 # HTML parsing for SEO elements
-./bin/claude-seo run parse_html.py https://example.com
+./scripts/claude-seo run parse_html.py https://example.com
 
 # PageSpeed Insights
-./bin/claude-seo run pagespeed_check.py https://example.com --json
+./scripts/claude-seo run pagespeed_check.py https://example.com --json
 
 # Drift baseline
-./bin/claude-seo run drift_baseline.py https://example.com
+./scripts/claude-seo run drift_baseline.py https://example.com
 
 # DataForSEO (requires credentials)
-DATAFORSEO_USERNAME=user DATAFORSEO_PASSWORD=pass ./bin/claude-seo run dataforseo_merchant.py search "keyword"
+DATAFORSEO_USERNAME=user DATAFORSEO_PASSWORD=pass ./scripts/claude-seo run dataforseo_merchant.py search "keyword"
 ```
 
 **Cursor Cloud gotchas:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `url_safety.is_safe_ip` accepted the RFC 6598 shared address space
+  (100.64.0.0/10), which Python's `ipaddress` does not count as private. Alibaba
+  Cloud serves instance metadata at 100.100.100.200, so a crafted URL or DNS
+  answer in that range slipped past the SSRF guard. The range is now refused,
+  and IPv4-mapped IPv6 literals are judged as their embedded IPv4 address.
+  Note: 100.64.0.0/10 is also the Tailscale range, so audits of a staging site
+  reached over Tailscale lose access; see SECURITY.md.
 - `commoncrawl_graph.py` no longer writes outside its cache directory. The
   `--release` value was interpolated raw into the cache filename, so
   `--release ../../../../tmp/x` escaped the cache dir and `_save_cache`'s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CI now runs the full test suite on Windows and macOS, not just the three
+  platform-neutral modules. The tests that assert POSIX mode bits skip on
+  Windows instead of failing.
+
+### Fixed
+- The schema-hook policy tests decoded the hook's UTF-8 output with the locale
+  codec, which is cp1252 on Windows and cannot represent the emoji markers.
 - `consistency_check.py` reported every FLOW-locked prompt file as a hash
   mismatch on a stock Windows clone: Git for Windows checks the files out with
   CRLF (`core.autocrlf=true`) while the lock hashes LF content. The check now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `preload_check.py` exited 1 on every successful run that scored below a
+  hard-coded 75, so `set -e` scripts and CI steps aborted on healthy pages. A
+  completed analysis now exits 0; the gate is opt-in through `--fail-under N`.
+  Exit 2 for a URL refused by url_safety is unchanged. (#281)
 - CI now runs the full test suite on Windows and macOS, not just the three
   platform-neutral modules. The tests that assert POSIX mode bits skip on
   Windows instead of failing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The plugin now installs from the claude.ai-hosted marketplace. Hosted sync
+  rejects any plugin that ships a top-level `bin/` directory with
+  `marketplace_sync_bin_directory_not_allowed`, which is exactly what the
+  launcher lived in, so the listing could never sync. `bin/claude-seo` moved to
+  `scripts/claude-seo`, where it resolves `runtime.py` as a sibling, and every
+  skill, agent, and doc now calls it through the documented plugin-relative
+  form `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>` instead of
+  relying on undocumented `bin/` PATH injection. Manual installs are unchanged
+  in behaviour: `install.sh` and `install.ps1` copy the launcher to
+  `~/.claude/skills/seo/scripts/claude-seo` and rewrite that canonical token to
+  the absolute path in the Markdown they install. Fixes #298; supersedes #199.
 - `seo-technical` no longer treats dynamic rendering as a valid setup to verify. Google
   documents it as a workaround rather than a recommended solution, so the audit step now
   flags it as technical debt. Adds a rendering-strategy table (SSR / SSG / CSR) and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Spend ledger lost concurrent writes (`dataforseo_costs.py`).** The ledger took its
+  file lock twice, once to read and once to write, and released it in between, so two
+  concurrent `log` calls both read the same ledger and the second silently overwrote the
+  first. Measured 3 entries lost out of 20 concurrent writes, with 1 to 3 lost on every
+  repeat run. This is not platform-specific. It matters because `seo-audit` fans out to
+  up to 15 parallel specialists, three of which call DataForSEO and each of which logs
+  after every call, so the ledger under-reported most during the runs that spend the
+  most. One exclusive lock now spans the entire read-modify-write in both `log` and
+  `reset`.
+- **No file locking at all on Windows.** The module set `fcntl = None` when the import
+  failed and then took every unlocked code path, so Windows ran the ledger with no
+  locking whatsoever. Locking now falls back to `msvcrt`, and when neither primitive is
+  available the operation fails loudly rather than proceeding unlocked.
+- **A corrupt ledger silently reset the budget to zero.** The non-atomic
+  `open(..., "w")` write could leave a truncated file if the process died mid-write, and
+  the reader caught `JSONDecodeError` and returned an empty ledger, which the next write
+  then persisted, discarding the whole spend history. Ledger writes are now atomic
+  (tempfile plus `os.replace`, matching the idiom already used in `google_auth.py`), and
+  an unparseable ledger fails closed with the file left in place for inspection.
+- **`CLAUDE_SEO_CONFIG_DIR`** now overrides the config and ledger location, so the new
+  `tests/test_dataforseo_costs.py` concurrency and durability tests run against an
+  isolated ledger instead of the operator's real spend history.
 - The Common-Crawl-only no-score rule is now enforced instead of merely stated. The
   `seo-backlinks` skill said not to produce a numeric health score when only Common Crawl
   data is available, while `skills/seo/references/free-backlink-sources.md` told the agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `consistency_check.py` reported every FLOW-locked prompt file as a hash
+  mismatch on a stock Windows clone: Git for Windows checks the files out with
+  CRLF (`core.autocrlf=true`) while the lock hashes LF content. The check now
+  folds CRLF before hashing, so the lock only fails on real content changes.
 - `url_safety.is_safe_ip` accepted the RFC 6598 shared address space
   (100.64.0.0/10), which Python's `ipaddress` does not count as private. Alibaba
   Cloud serves instance metadata at 100.100.100.200, so a crafted URL or DNS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `seo-technical` no longer treats dynamic rendering as a valid setup to verify. Google
+  documents it as a workaround rather than a recommended solution, so the audit step now
+  flags it as technical debt. Adds a rendering-strategy table (SSR / SSG / CSR) and a
+  preferred-framework list so the skill recommends a target state rather than only naming
+  the anti-pattern. Detection logic in `fetch_page.py` is unchanged: identifying dynamic
+  rendering is still useful, it is only the recommendation that was stale.
 - **The Banana cost ledger had the same defect, with no locking at all.**
   `extensions/banana/scripts/cost_tracker.py` read and wrote `~/.banana/costs.json` with
   no file locking on any platform and a non-atomic write. Measured 4 entries lost out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Banana cost ledger had the same defect, with no locking at all.**
+  `extensions/banana/scripts/cost_tracker.py` read and wrote `~/.banana/costs.json` with
+  no file locking on any platform and a non-atomic write. Measured 4 entries lost out of
+  20 concurrent `log` calls, and 3 of those processes crashed outright with
+  `JSONDecodeError` after reading a half-written file. It is also harder to notice than
+  the DataForSEO case: this ledger carries running aggregates (`total_cost`,
+  `total_images`, `daily`) incremented in the same write as the entry, so a lost write
+  drops both together and the file still looks internally consistent. Given the same
+  treatment: one exclusive lock across the whole read-modify-write in `log`, atomic
+  writes, `msvcrt` fallback with a hard failure when no locking primitive exists, and a
+  corrupt ledger that fails closed instead of raising a bare traceback. `reset` takes the
+  lock but deliberately does not read first, so it still works as the recovery path for a
+  corrupt ledger. `BANANA_HOME` overrides the ledger and pricing paths for the new
+  `tests/test_banana_cost_tracker.py`.
 - **Spend ledger lost concurrent writes (`dataforseo_costs.py`).** The ledger took its
   file lock twice, once to read and once to write, and released it in between, so two
   concurrent `log` calls both read the same ledger and the second silently overwrote the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,110 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.6] - 2026-09-10
+
+### Security
+
+- `commoncrawl_graph.py` no longer writes outside its cache directory: the `--release`
+  value was interpolated raw into the cache filename, so `--release ../../../../tmp/x`
+  escaped the cache directory and `_save_cache` wrote there. Malformed releases are now
+  rejected at the CLI and path containment is asserted.
+- `domain_history.py` no longer follows an unvalidated WHOIS referral. The IANA
+  `refer:` host is resolved and validated through `url_safety` and dialled at the
+  pinned address; an unusable referral degrades to IANA's own answer.
+- `url_safety.is_safe_ip` now refuses the RFC 6598 shared address space
+  (100.64.0.0/10), where Alibaba Cloud serves instance metadata, and judges
+  IPv4-mapped IPv6 literals by their embedded address. This also refuses Tailscale
+  addresses; see SECURITY.md.
+- WeasyPrint floor raised to 70.0 (PYSEC-2026-3940); requests, google-auth, courlan,
+  playwright, and numpy floors raised to current releases. `pip-audit` passes.
+- SECURITY.md describes only reporting channels that exist: private vulnerability
+  reporting is enabled and the unreachable email fallback is gone.
+
 ### Added
+
+- The plugin installs from the claude.ai-hosted marketplace. Hosted sync rejects any
+  plugin with a top-level `bin/` directory, so the launcher moved to
+  `scripts/claude-seo` and every skill, agent, and doc calls it as
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>`. Manual installs copy the
+  launcher to `~/.claude/skills/seo/scripts/claude-seo` and rewrite that token to the
+  absolute path. A layout test keeps `bin/` from coming back. Fixes #298 and #199.
+- CI runs the full suite on Windows and macOS, audits `requirements.txt` with
+  `pip-audit`, and no longer swallows a failed dependency install in the v2 audit.
+- `CLAUDE_SEO_CONFIG_DIR` overrides the config and ledger location, so the ledger tests
+  run against an isolated file. `BANANA_HOME` does the same for the Banana ledger.
+- `preload_check.py --fail-under N` turns the score into an opt-in gate.
+- Regression coverage for the backlink report validator, the schema-hook UTF-8 output,
+  CRLF checkouts, PSI null category scores, ledger concurrency, the hosted plugin layout,
+  and every ledger kind accepted by `seo_updates.py`.
 
 ### Changed
 
-### Fixed
-
-- The plugin now installs from the claude.ai-hosted marketplace. Hosted sync
-  rejects any plugin that ships a top-level `bin/` directory with
-  `marketplace_sync_bin_directory_not_allowed`, which is exactly what the
-  launcher lived in, so the listing could never sync. `bin/claude-seo` moved to
-  `scripts/claude-seo`, where it resolves `runtime.py` as a sibling, and every
-  skill, agent, and doc now calls it through the documented plugin-relative
-  form `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>` instead of
-  relying on undocumented `bin/` PATH injection. Manual installs are unchanged
-  in behaviour: `install.sh` and `install.ps1` copy the launcher to
-  `~/.claude/skills/seo/scripts/claude-seo` and rewrite that canonical token to
-  the absolute path in the Markdown they install. Fixes #298; supersedes #199.
-- `seo-technical` no longer treats dynamic rendering as a valid setup to verify. Google
-  documents it as a workaround rather than a recommended solution, so the audit step now
-  flags it as technical debt. Adds a rendering-strategy table (SSR / SSG / CSR) and a
-  preferred-framework list so the skill recommends a target state rather than only naming
-  the anti-pattern. Detection logic in `fetch_page.py` is unchanged: identifying dynamic
-  rendering is still useful, it is only the recommendation that was stale.
-- **The Banana cost ledger had the same defect, with no locking at all.**
-  `extensions/banana/scripts/cost_tracker.py` read and wrote `~/.banana/costs.json` with
-  no file locking on any platform and a non-atomic write. Measured 4 entries lost out of
-  20 concurrent `log` calls, and 3 of those processes crashed outright with
-  `JSONDecodeError` after reading a half-written file. It is also harder to notice than
-  the DataForSEO case: this ledger carries running aggregates (`total_cost`,
-  `total_images`, `daily`) incremented in the same write as the entry, so a lost write
-  drops both together and the file still looks internally consistent. Given the same
-  treatment: one exclusive lock across the whole read-modify-write in `log`, atomic
-  writes, `msvcrt` fallback with a hard failure when no locking primitive exists, and a
-  corrupt ledger that fails closed instead of raising a bare traceback. `reset` takes the
-  lock but deliberately does not read first, so it still works as the recovery path for a
-  corrupt ledger. `BANANA_HOME` overrides the ledger and pricing paths for the new
-  `tests/test_banana_cost_tracker.py`.
-- **Spend ledger lost concurrent writes (`dataforseo_costs.py`).** The ledger took its
-  file lock twice, once to read and once to write, and released it in between, so two
-  concurrent `log` calls both read the same ledger and the second silently overwrote the
-  first. Measured 3 entries lost out of 20 concurrent writes, with 1 to 3 lost on every
-  repeat run. This is not platform-specific. It matters because `seo-audit` fans out to
-  up to 15 parallel specialists, three of which call DataForSEO and each of which logs
-  after every call, so the ledger under-reported most during the runs that spend the
-  most. One exclusive lock now spans the entire read-modify-write in both `log` and
-  `reset`.
-- **No file locking at all on Windows.** The module set `fcntl = None` when the import
-  failed and then took every unlocked code path, so Windows ran the ledger with no
-  locking whatsoever. Locking now falls back to `msvcrt`, and when neither primitive is
-  available the operation fails loudly rather than proceeding unlocked.
-- **A corrupt ledger silently reset the budget to zero.** The non-atomic
-  `open(..., "w")` write could leave a truncated file if the process died mid-write, and
-  the reader caught `JSONDecodeError` and returned an empty ledger, which the next write
-  then persisted, discarding the whole spend history. Ledger writes are now atomic
-  (tempfile plus `os.replace`, matching the idiom already used in `google_auth.py`), and
-  an unparseable ledger fails closed with the file left in place for inspection.
-- **`CLAUDE_SEO_CONFIG_DIR`** now overrides the config and ledger location, so the new
-  `tests/test_dataforseo_costs.py` concurrency and durability tests run against an
-  isolated ledger instead of the operator's real spend history.
-- The Common-Crawl-only no-score rule is now enforced instead of merely stated. The
-  `seo-backlinks` skill said not to produce a numeric health score when only Common Crawl
-  data is available, while `skills/seo/references/free-backlink-sources.md` told the agent
-  to "cap the maximum health score at 70/100" in the same case. The reference gave the more
-  actionable of two contradictory instructions, which is the likely reason the rule was
-  violated in practice. The guidance now agrees across both files, and
-  `validate_backlink_report.py` gains a `source_score_consistency` check that fails a
-  report carrying a number with no scoreable source (Moz, Bing, or DataForSEO), or a
-  `source: not-assessed` finding carrying a score.
-- `preload_check.py` exited 1 on every successful run that scored below a
-  hard-coded 75, so `set -e` scripts and CI steps aborted on healthy pages. A
-  completed analysis now exits 0; the gate is opt-in through `--fail-under N`.
-  Exit 2 for a URL refused by url_safety is unchanged. (#281)
-- CI now runs the full test suite on Windows and macOS, not just the three
-  platform-neutral modules. The tests that assert POSIX mode bits skip on
-  Windows instead of failing.
+- `seo-technical` treats dynamic rendering as a workaround to flag, not a target state,
+  and recommends SSR, SSG, or CSR with a preferred-framework list.
+- The `seo-backlinks` skill and `free-backlink-sources.md` no longer contradict each
+  other on Common-Crawl-only reports: no numeric score is produced, and
+  `validate_backlink_report.py` fails a report that carries one.
+- The Repository Topology section of CLAUDE.md describes the two single-remote
+  checkouts and the cherry-pick promotion flow actually in use.
+- The three `test_sync_flow.py` tests that call the live GitHub API run only when
+  `CLAUDE_SEO_NETWORK_TESTS=1`; both CI test jobs set it with `GH_TOKEN`.
 
 ### Fixed
-- The schema-hook policy tests decoded the hook's UTF-8 output with the locale
-  codec, which is cp1252 on Windows and cannot represent the emoji markers.
-- `consistency_check.py` reported every FLOW-locked prompt file as a hash
-  mismatch on a stock Windows clone: Git for Windows checks the files out with
-  CRLF (`core.autocrlf=true`) while the lock hashes LF content. The check now
-  folds CRLF before hashing, so the lock only fails on real content changes.
-- `url_safety.is_safe_ip` accepted the RFC 6598 shared address space
-  (100.64.0.0/10), which Python's `ipaddress` does not count as private. Alibaba
-  Cloud serves instance metadata at 100.100.100.200, so a crafted URL or DNS
-  answer in that range slipped past the SSRF guard. The range is now refused,
-  and IPv4-mapped IPv6 literals are judged as their embedded IPv4 address.
-  Note: 100.64.0.0/10 is also the Tailscale range, so audits of a staging site
-  reached over Tailscale lose access; see SECURITY.md.
-- `commoncrawl_graph.py` no longer writes outside its cache directory. The
-  `--release` value was interpolated raw into the cache filename, so
-  `--release ../../../../tmp/x` escaped the cache dir and `_save_cache`'s
-  `open(..., "w")` followed it. The value also reaches a download URL, so a
-  malformed release is now rejected at the CLI rather than silently rewritten
-  (which would leave the cache key disagreeing with what was fetched); path
-  components are sanitised and containment asserted as defence in depth.
-- `domain_history.py` no longer follows an unvalidated WHOIS referral. It asks
-  IANA for the authoritative server and dialled whatever host came back, over
-  plaintext port 43: so anyone able to tamper with that response could point
-  it at an internal address and use it to probe the operator's private network.
-  The referral is now resolved and validated through `url_safety` and the
-  connection is made to the pinned address; an unusable referral degrades to
-  IANA's own answer rather than blanking the lookup.
+
+- The DataForSEO and Banana cost ledgers lost concurrent writes and could reset spend
+  history after a truncated write. One exclusive lock now spans each read-modify-write,
+  writes are atomic, Windows falls back to `msvcrt`, and a corrupt ledger fails closed.
+- `pagespeed_check.py` raised `TypeError` when a Lighthouse category returned a null
+  score; the category is now skipped and the page is kept.
+- `preload_check.py` exited 1 on every successful run that scored below 75. A completed
+  analysis exits 0. (#281)
+- `consistency_check.py` reported every FLOW-locked prompt as a hash mismatch on CRLF
+  checkouts; it folds CRLF before hashing.
+- `seo_updates.py --kind documentation` was rejected by argparse while the ledger used
+  that kind; the CLI and the schema now share one list.
+- Optional Google, Bing, and rendering dependencies missing at import time no longer
+  abort the whole pytest session (`pytest.importorskip` in the affected modules).
+- The schema-hook tests decode the hook's UTF-8 output explicitly instead of through the
+  locale codec, which is cp1252 on Windows.
 
 ## [2.2.5] - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Common-Crawl-only no-score rule is now enforced instead of merely stated. The
+  `seo-backlinks` skill said not to produce a numeric health score when only Common Crawl
+  data is available, while `skills/seo/references/free-backlink-sources.md` told the agent
+  to "cap the maximum health score at 70/100" in the same case. The reference gave the more
+  actionable of two contradictory instructions, which is the likely reason the rule was
+  violated in practice. The guidance now agrees across both files, and
+  `validate_backlink_report.py` gains a `source_score_consistency` check that fails a
+  report carrying a number with no scoreable source (Moz, Bing, or DataForSEO), or a
+  `source: not-assessed` finding carrying a score.
 - `preload_check.py` exited 1 on every successful run that scored below a
   hard-coded 75, so `set -e` scripts and CI steps aborted on healthy pages. A
   completed analysis now exits 0; the gate is opt-in through `--fail-under N`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `commoncrawl_graph.py` no longer writes outside its cache directory. The
+  `--release` value was interpolated raw into the cache filename, so
+  `--release ../../../../tmp/x` escaped the cache dir and `_save_cache`'s
+  `open(..., "w")` followed it. The value also reaches a download URL, so a
+  malformed release is now rejected at the CLI rather than silently rewritten
+  (which would leave the cache key disagreeing with what was fetched); path
+  components are sanitised and containment asserted as defence in depth.
+- `domain_history.py` no longer follows an unvalidated WHOIS referral. It asks
+  IANA for the authoritative server and dialled whatever host came back, over
+  plaintext port 43: so anyone able to tamper with that response could point
+  it at an internal address and use it to probe the operator's private network.
+  The referral is now resolved and validated through `url_safety` and the
+  connection is made to the pinned address; an unusable referral degrades to
+  IANA's own answer rather than blanking the lookup.
+
 ## [2.2.5] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (100.64.0.0/10), where Alibaba Cloud serves instance metadata, and judges
   IPv4-mapped IPv6 literals by their embedded address. This also refuses Tailscale
   addresses; see SECURITY.md.
-- WeasyPrint floor raised to 70.0 (PYSEC-2026-3940); requests, google-auth, courlan,
-  playwright, and numpy floors raised to current releases. `pip-audit` passes.
+- WeasyPrint floor raised to 70.0 (PYSEC-2026-3940) and requests to 2.34.2
+  (CVE-2026-25645). `pip-audit` passes.
 - SECURITY.md describes only reporting channels that exist: private vulnerability
   reporting is enabled and the unreachable email fallback is gone.
 
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dependency floors raised by Dependabot: google-auth 2.56.2, courlan 1.4.0,
+  playwright 1.62.0, numpy 2.2.6 (a major bump from 1.26; matplotlib moves to 3.9.0,
+  the first line that supports numpy 2).
 - `seo-technical` treats dynamic rendering as a workaround to flag, not a target state,
   and recommends SSR, SSG, or CSR with a preferred-framework list.
 - The `seo-backlinks` skill and `free-backlink-sources.md` no longer contradict each

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
 repository-code: 'https://github.com/AgriciDaniel/claude-seo'
 url: 'https://github.com/AgriciDaniel/claude-seo'
 license: MIT
-version: 2.2.5
-date-released: '2026-08-25'
+version: 2.2.6
+date-released: '2026-09-10'
 keywords:
   - seo
   - claude-code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,9 +237,10 @@ Part of the Claude Code skill family:
 
 ## Repository Topology (public + private)
 
-This project is mirrored across two GitHub remotes that share git history.
-Both originate from the same local checkout; neither is a GitHub fork of
-the other (different orgs, no parent/child relationship in the GitHub UI).
+This project is mirrored across two GitHub remotes with shared historical
+ancestry. Reviewed back-ports, private-only research, and marketplace branding
+mean their release commits can have different SHAs. Neither repository is a
+GitHub fork of the other.
 
 | Remote | URL | Visibility | Role |
 |---|---|---|---|
@@ -253,17 +254,15 @@ Daily development:
 - `git push aimh <branch>` to publish work-in-progress to the private repo
   (Dependabot, Actions, and CI run there).
 
-Promoting to public on release:
-1. Merge `v2` into local `main` when ready to release (fast-forward).
-2. Tag the release locally (`git tag -a vX.Y.Z`).
-3. Push the tag and main to **both** remotes in this order:
-   - First: `git push aimh main && git push aimh vX.Y.Z`
-   - Then: `git push origin vX.Y.Z && git push origin main`
-   - The "tag before merge" sequence (see `feedback_push_caution` memory)
-     applies on `origin` to avoid the `curl|bash` outage window where
-     users pull a tag that doesn't yet point at code on `main`.
-4. `gh release create vX.Y.Z --repo AgriciDaniel/claude-seo` (public-only).
-5. `/release-blog` to publish the release post.
+Promoting reviewed release changes:
+1. Use an isolated clean worktree from the target repository branch.
+2. Fast-forward only when ancestry proves it is safe. Otherwise cherry-pick
+   the exact reviewed commits with `-x` and resolve only documented divergence.
+3. Run the full validation suite and compare the private/public release trees.
+4. Create an annotated repository-specific tag after validation.
+5. Push private changes first. Push public changes only with explicit release
+   authorization, with the public tag available before the installer moves.
+6. Create the GitHub Release and release post on the public repository only.
 
 ### Safety rules
 
@@ -271,12 +270,10 @@ Promoting to public on release:
   pushes are user-authorized per-release.
 - **`aimh` accepts day-to-day pushes.** No release-gate ceremony required
   for the private remote.
-- **Tags push to private first.** Historical pre-release illustration: v2.0.0
-  once lived on `aimh` before `origin`. Before the authorized v2.2.5 release,
-  released tags through v2.2.4 are on both remotes. Verify v2.2.5 on both
-  remotes after publication.
-- **History stays shared.** Never rewrite history on either remote with
-  force-push unless explicitly authorized for that specific operation.
+- **v2.2.5 is tagged on both repositories.** Each tag points to that
+  repository's reviewed release commit.
+- **Never force-sync the histories.** Preserve reviewed divergence and never
+  rewrite either remote without explicit per-operation authorization.
 
 ### Verifying the topology
 
@@ -284,9 +281,10 @@ Promoting to public on release:
 # Both remotes configured
 git remote -v        # expects: origin (public) + aimh (private)
 
-# Both share main HEAD
+# Compare heads and then audit the documented divergence. Equal SHAs are not
+# expected after repository-specific back-ports.
 git ls-remote --heads aimh main
-git ls-remote --heads origin main   # origin = aimh/main + 1 public-branding commit (intentional; see docs/WORKFLOW-public-private.md)
+git ls-remote --heads origin main
 ```
 
 Full workflow reference: `docs/WORKFLOW-public-private.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ claude-seo/
 ## Report Generation Rules
 
 - **All SEO reports must use `scripts/google_report.py`** as the canonical report generator
-- **Dependencies**: `matplotlib>=3.8.0` (charts) + `weasyprint>=61.0` (HTML-to-PDF), both in `requirements.txt`
+- **Dependencies**: `matplotlib>=3.8.0` (charts) + `weasyprint>=70.0` (HTML-to-PDF), both in `requirements.txt`
 - **Format**: A4 PDF via WeasyPrint + matplotlib charts at 200 DPI
 - **Style**: Clean white title page with navy (#1e3a5f) accent, Times New Roman body font
 - **Color palette**: Navy #1e3a5f (headers), dark gold #b8860b (accents), forest green #2d6a4f (pass), warm amber #d4740e (warnings), deep red #c53030 (fail), warm cream #faf9f7 (backgrounds)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ claude-seo/
   CONTRIBUTORS.md                    # Community credits (Pro Hub Challenge)
   AGENTS.md                          # Multi-platform agent instructions (Cursor, Antigravity)
   .claude-plugin/
-    plugin.json                    # Plugin manifest (v2.2.5)
+    plugin.json                    # Plugin manifest (v2.2.6)
     marketplace.json               # Marketplace catalog for distribution
   skills/                            # 25 sub-skills (auto-discovered)
     seo/                           # Main orchestrator skill

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ claude-seo/
 - Scripts must have docstrings, CLI interface, and JSON output
 - Follow kebab-case naming for all skill directories
 - Agents invoked via Agent tool, never via Bash
-- Bundled tools run through `claude-seo run`; plugin state uses `CLAUDE_PLUGIN_DATA`
+- Bundled tools run through `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run`; plugin state uses `CLAUDE_PLUGIN_DATA`
 - Manual Python dependencies install into `~/.claude/skills/seo/.venv/`
 - Test with `python3 -m pytest tests/` after changes (if applicable)
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Test coverage grew from 39 (v1.9.9) to 410 across the v2 line; the url_safety su
 - **v2.2.3 (July 2026): prompt-hygiene alignment.** Normalized emphasis and punctuation across the prompt surface without changing behavior, routing, or output contracts.
 - **v2.2.4 (July 2026): community maintenance.** Added the managed cross-platform runtime and safe sitemap discovery, repaired GSC pagination and totals, replaced removed Bing endpoints, fixed extension and Windows portability gaps, and reconciled every open issue and pull request.
 - **v2.2.5 (August 2026): reliability and Google-currency hardening.** Fixed manual-install data packaging and lxml runtime imports, hardened JSON-LD graphs and rendered-page accessibility analysis, enforced managed-runtime command references, and refreshed Google Search and Lighthouse guidance through August 25.
+- **v2.2.6 (September 2026): security and hosted-install patch.** Closed a cache-path traversal and a WHOIS referral SSRF, refused the RFC 6598 range, moved the launcher to `scripts/` so the claude.ai-hosted marketplace accepts the plugin, raised dependency floors past PYSEC-2026-3940, locked the cost ledgers, and added Windows, macOS, and pip-audit CI.
 
 ## Limitations
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,8 @@ claude-seo is a research and audit toolkit that runs on a user's workstation. It
 - **IPv6-only audit targets.** The strict validator queries `family=AF_INET` for the initial resolution. Hosts with AAAA records only will surface as "DNS resolution failed". This is **fail-closed** by design — we'd rather refuse than connect to an unvalidated IPv6 endpoint. Tracked for a future patch (full dual-stack pinning, similar to the Playwright handler which already uses `AF_UNSPEC`).
 - **Windows file permissions.** `os.fchmod(fd, 0o600)` is a no-op on Windows for non-ACL filesystems. Users on Windows should rely on per-user directory ACLs instead of POSIX mode bits.
 
+- **RFC 6598 (100.64.0.0/10) is refused.** Cloud providers serve instance metadata in this range, so `url_safety` treats it like RFC 1918. Tailscale also allocates from it: a staging site reached over Tailscale cannot be audited with the default policy. There is no escape hatch yet; an explicit local-target allowlist is planned.
+
 ## Security-relevant code paths
 
 If you are auditing, these are the high-leverage files:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 If you discover a security vulnerability, please report it responsibly. Do **not** open a public issue.
 
-1. Open a private [GitHub Security Advisory](https://github.com/AgriciDaniel/claude-seo/security/advisories/new) on this repository (preferred channel).
-2. As a fallback, email the maintainer at the address listed in [`CITATION.cff`](CITATION.cff).
-3. Encrypt sensitive disclosures if you can. Request the maintainer's PGP key in the advisory or email — the key fingerprint is published in advisory threads on first request and is rotated yearly.
+1. Open a private [GitHub Security Advisory](https://github.com/AgriciDaniel/claude-seo/security/advisories/new) on this repository. Private vulnerability reporting is enabled, so the "Report a vulnerability" button on the Security tab opens the same form.
+2. If the advisory form is unavailable to you, open a public issue titled "Security contact request" with no technical detail. The maintainer will reply with a private channel.
+3. Encrypt sensitive disclosures if you can. Request the maintainer's PGP key in the advisory thread; the fingerprint is shared there on first request and rotated yearly.
 
 When reporting, please include:
 

--- a/agents/seo-backlinks.md
+++ b/agents/seo-backlinks.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Write, Glob, Grep
 
 You are a backlink profile analyst. When delegated tasks during an SEO audit:
 
-1. Check credentials: `claude-seo run backlinks_auth.py --check --json`
+1. Check credentials: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check --json`
 2. Determine tier (0 = CC+verify, 1 = +Moz, 2 = +Bing, 3 = +DataForSEO)
 3. Run all available sources for the target domain
 4. Merge results with confidence weighting
@@ -17,28 +17,28 @@ You are a backlink profile analyst. When delegated tasks during an SEO audit:
 ## Tier-Based Workflow
 
 ### Tier 0 (Always Available, No Config Needed)
-- Common Crawl domain metrics: `claude-seo run commoncrawl_graph.py <domain> --json`
+- Common Crawl domain metrics: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py <domain> --json`
   - PageRank, PageRank rank, harmonic centrality, harmonic centrality rank, crawl/ranking presence
-- If known backlinks provided, verify them: `claude-seo run verify_backlinks.py --target <url> --links <file> --json`
+- If known backlinks provided, verify them: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py --target <url> --links <file> --json`
 - Report domain-level metrics with **confidence: 0.50** note
 - At Tier 0, fewer than 4 scoring factors have data, report **INSUFFICIENT DATA**, not a numeric score
 - Never produce a misleading numeric score when most factors lack data sources
 
 ### Tier 1 (+ Moz API)
 - All Tier 0 checks
-- Moz URL metrics: `claude-seo run moz_api.py metrics <url> --json`
+- Moz URL metrics: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json`
   - DA, PA, Spam Score, link counts, referring domains
-- Moz referring domains: `claude-seo run moz_api.py domains <url> --json`
-- Moz anchor text: `claude-seo run moz_api.py anchors <url> --json`
-- Moz top pages: `claude-seo run moz_api.py pages <domain> --json`
+- Moz referring domains: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py domains <url> --json`
+- Moz anchor text: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py anchors <url> --json`
+- Moz top pages: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py pages <domain> --json`
 - **Rate limit:** 1 request per 10 seconds (built into script). Plan calls carefully.
 - Report metrics with **confidence: 0.85** note
 
 ### Tier 2 (+ Bing Webmaster)
 - All Tier 1 checks
-- Bing inbound links: `claude-seo run bing_webmaster.py links <url> --json`
+- Bing inbound links: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py links <url> --json`
 - For comparison between two properties registered to the same Bing account:
-  `claude-seo run bing_webmaster.py compare <url1> <url2> --json`
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py compare <url1> <url2> --json`
 - Report with **confidence: 0.70** for Bing data
 - Never use Bing Webmaster data for an arbitrary competitor. Use Moz,
   DataForSEO, or Common Crawl when the second property is not registered.
@@ -89,7 +89,7 @@ Before returning results, run the automated validator AND manual checks.
 ### Step 1: Automated validation
 Save all collected data to a JSON file and run:
 ```bash
-claude-seo run validate_backlink_report.py --report report_data.json --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run validate_backlink_report.py --report report_data.json --json
 ```
 The validator checks: schema claims, JS false negatives, H1 accuracy, reciprocal links,
 CC interpretation, and health score sufficiency. If status is "FAIL", fix errors before proceeding.
@@ -112,7 +112,7 @@ If any check fails, fix the report before returning it.
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes full `raw_content`, `content`, `extracted_text`, `is_spa`, and `publication_date`; use `--max-text` only when explicit bounded output is needed. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes full `raw_content`, `content`, `extracted_text`, `is_spa`, and `publication_date`; use `--max-text` only when explicit bounded output is needed. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 Backlink verification (`/seo backlinks verify`) primarily reads outbound `<a>` tags, which are reliably present in raw HTML. `--mode never` is the right choice for speed on bulk verification jobs.
 

--- a/agents/seo-content.md
+++ b/agents/seo-content.md
@@ -67,7 +67,7 @@ Provide:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `is_spa`, complete `extracted_text`, and `publication_date`; use `--output rendered.html` for the full HTML. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `is_spa`, complete `extracted_text`, and `publication_date`; use `--output rendered.html` for the full HTML. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 ## Persistence Contract
 

--- a/agents/seo-drift.md
+++ b/agents/seo-drift.md
@@ -17,10 +17,10 @@ elements by comparing current page state against stored baselines.
 ## Tools
 
 All page fetching goes through the project's existing scripts with SSRF protection:
-- `claude-seo run drift_baseline.py <url>` -- capture a new baseline
-- `claude-seo run drift_compare.py <url>` -- compare current state to baseline
-- `claude-seo run drift_history.py <url>` -- show change history
-- `claude-seo run drift_report.py <file> --output report.html` -- generate HTML report
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_baseline.py <url>` -- capture a new baseline
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url>` -- compare current state to baseline
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>` -- show change history
+- `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_report.py <file> --output report.html` -- generate HTML report
 
 Never use curl, wget, or raw HTTP requests. All fetching is handled by
 the bundled `fetch_page.py` module internally, which validates URLs against private/loopback

--- a/agents/seo-ecommerce.md
+++ b/agents/seo-ecommerce.md
@@ -18,16 +18,16 @@ When delegated tasks during an SEO audit or analysis:
 
 1. Detect e-commerce signals: product schema, price elements, add-to-cart buttons,
    shopping cart, product grids, Shopify/WooCommerce/Magento markers
-2. Analyze product pages with `claude-seo run render_page.py <URL> --mode auto` and `claude-seo run parse_html.py <URL>`
+2. Analyze product pages with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto` and `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py <URL>`
 3. Validate Product schema against Google's required and recommended fields
 4. If DataForSEO credentials available, fetch marketplace data via
-   `claude-seo run dataforseo_merchant.py`
+   `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py`
 
 ## Cost Guardrails
 
 Before ANY DataForSEO Merchant API call:
 ```bash
-claude-seo run dataforseo_costs.py check <endpoint>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint>
 ```
 
 Only proceed if `"status": "approved"`. If `"needs_approval"`, surface the cost
@@ -36,7 +36,7 @@ the limitation.
 
 After each API call, log the cost:
 ```bash
-claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <actual_cost>
 ```
 
 ## Analysis Priorities
@@ -65,7 +65,7 @@ Match existing claude-seo patterns:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 E-commerce sites overwhelmingly inject product schema client-side (Shopify, Magento PWA, headless commerce on Next.js). Prefer `--mode always` for product page audits and compare `raw_content` vs `content` to confirm whether the JSON-LD is server-rendered.
 

--- a/agents/seo-geo.md
+++ b/agents/seo-geo.md
@@ -65,7 +65,7 @@ Provide a structured report with:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes full `raw_content`, `content`, `extracted_text`, `is_spa`, and `publication_date`; use `--max-text` only when explicit bounded output is needed. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes full `raw_content`, `content`, `extracted_text`, `is_spa`, and `publication_date`; use `--max-text` only when explicit bounded output is needed. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 AI citation analysis benefits from the `extracted_text` field, passage-level scoring should run against trafilatura's boilerplate-stripped output, not the full HTML, so navigation chrome and footers don't dilute the signal.
 

--- a/agents/seo-google.md
+++ b/agents/seo-google.md
@@ -8,7 +8,7 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 
 You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 
-1. Check credentials: `claude-seo run google_auth.py --check --json`
+1. Check credentials: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check --json`
 2. Determine tier (0 = API key, 1 = + service account, 2 = + GA4)
 3. Execute tier-appropriate analysis
 4. Format output to match claude-seo conventions
@@ -16,22 +16,22 @@ You are a Google SEO API data analyst. When delegated tasks during an SEO audit:
 ## Tier-Based Workflow
 
 ### Tier 0 (API Key Only)
-- Run PSI + CrUX on homepage: `claude-seo run pagespeed_check.py <url> --json`
-- Run CrUX History for origin: `claude-seo run crux_history.py <origin> --origin --json`
+- Run PSI + CrUX on homepage: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json`
+- Run CrUX History for origin: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py <origin> --origin --json`
 - Report CWV field data with traffic-light ratings
 
 ### Tier 1 (+ Service Account)
 - All Tier 0 checks
-- GSC top queries/pages (28 days): `claude-seo run gsc_query.py --property <prop> --json`
+- GSC top queries/pages (28 days): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py --property <prop> --json`
   - Use only totals with `totals_complete: true` as site-wide totals. Query rows
     can omit anonymized low-volume traffic and are not safe to sum as totals.
-- URL Inspection on homepage + key pages: `claude-seo run gsc_inspect.py <url> --json`
-- GSC sitemap status: `claude-seo run gsc_query.py sitemaps --property <prop> --json`
+- URL Inspection on homepage + key pages: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py <url> --json`
+- GSC sitemap status: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py sitemaps --property <prop> --json`
 
 ### Tier 2 (Full)
 - All Tier 1 checks
-- GA4 organic traffic (28 days): `claude-seo run ga4_report.py --property <id> --json`
-- Top organic landing pages: `claude-seo run ga4_report.py --property <id> --report top-pages --json`
+- GA4 organic traffic (28 days): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --json`
+- Top organic landing pages: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --report top-pages --json`
 
 ## Core Web Vitals Thresholds
 
@@ -58,7 +58,7 @@ After completing data collection at any tier, offer to generate a PDF report.
 The report uses the enterprise template: white cover, navy accents, Times New Roman, charts at 85% width, Google logo on title page. No page-break-inside: avoid (causes white gaps).
 
 ```bash
-claude-seo run google_report.py --type full --data data.json --domain DOMAIN --format pdf --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type full --data data.json --domain DOMAIN --format pdf --json
 ```
 Report types: `cwv-audit`, `gsc-performance`, `indexation`, `full`.
 Before presenting: verify `"review": {"status": "PASS"}` in the JSON output.
@@ -68,7 +68,7 @@ Before presenting: verify `"review": {"status": "PASS"}` in the JSON output.
 If `output_dir` is provided by the audit orchestrator, write:
 - `output_dir/findings/google.md`: PSI, CrUX, GSC, URL Inspection, GA4, and credential-tier findings
 - Structured JSON-compatible findings for `audit-data.json` under the Google SEO Data category
-- Generated PDF/HTML/XLSX reports under `output_dir/` with `claude-seo run google_report.py --output-dir "$output_dir"`
+- Generated PDF/HTML/XLSX reports under `output_dir/` with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --output-dir "$output_dir"`
 
 ## Error Handling
 

--- a/agents/seo-local.md
+++ b/agents/seo-local.md
@@ -79,7 +79,7 @@ Provide a structured report with:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes full `raw_content`, `content`, `extracted_text`, `is_spa`, and `publication_date`; use `--max-text` only when explicit bounded output is needed. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes full `raw_content`, `content`, `extracted_text`, `is_spa`, and `publication_date`; use `--max-text` only when explicit bounded output is needed. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 Map embeds, GBP widgets, and review carousels are commonly injected client-side. When auditing local pages on JS-heavy sites prefer `--mode always` so the audit reflects what users (and Google's crawler) actually see post-render.
 

--- a/agents/seo-performance.md
+++ b/agents/seo-performance.md
@@ -25,7 +25,7 @@ Google evaluates the **75th percentile** of page visits, 75% of visits must meet
 ## When Analyzing Performance
 
 1. Use PageSpeed Insights API if available
-2. Use `claude-seo run render_page.py <URL> --mode auto --json` before HTML/source inspection so SPA content is visible when needed
+2. Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` before HTML/source inspection so SPA content is visible when needed
 3. Provide specific, actionable optimization recommendations
 4. Prioritize by expected impact
 
@@ -67,10 +67,10 @@ Google evaluates the **75th percentile** of page visits, 75% of visits must meet
 
 ```bash
 # PageSpeed Insights API (uses header-based API key handling)
-claude-seo run pagespeed_check.py URL --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py URL --json
 
 # SPA-aware HTML/render inspection
-claude-seo run render_page.py URL --mode auto --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py URL --mode auto --json
 
 # Lighthouse CLI
 npx lighthouse URL --output json
@@ -80,8 +80,8 @@ npx lighthouse URL --output json
 
 If Google API credentials are configured, prefer CrUX field data over Lighthouse lab data for CWV assessment:
 ```bash
-claude-seo run pagespeed_check.py URL --json
-claude-seo run crux_history.py URL --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py URL --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py URL --json
 ```
 Field data (28-day Chrome user average) is more representative than lab data (single Lighthouse run). Use lab data as fallback when CrUX returns 404 (insufficient traffic).
 

--- a/agents/seo-schema.md
+++ b/agents/seo-schema.md
@@ -68,7 +68,7 @@ Provide:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `is_spa`, complete `extracted_text`, and `publication_date`; use `--output rendered.html` for the full HTML. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `is_spa`, complete `extracted_text`, and `publication_date`; use `--output rendered.html` for the full HTML. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 Use the JSON response's `structured_data` summary for routine JSON-LD detection. It is extracted from the full HTML before the HTML fields are truncated, but emits only bounded validity, size, and type metadata. When full blocks are necessary for validation, pass `--json-ld-output <path>` and read the bounded UTF-8 JSON artifact. Never copy unbounded page markup into an agent prompt.
 

--- a/agents/seo-sitemap.md
+++ b/agents/seo-sitemap.md
@@ -10,7 +10,7 @@ You are a Sitemap Architecture specialist.
 
 When working with sitemaps:
 
-1. Discover candidates with `claude-seo run sitemap_discovery.py <url> --json`.
+1. Discover candidates with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <url> --json`.
    Use only validated `found` entries and retain declared failures as findings.
 2. Validate XML format and URL status codes
 3. Check for deprecated tags (priority, changefreq: both ignored by Google)

--- a/agents/seo-sxo.md
+++ b/agents/seo-sxo.md
@@ -19,8 +19,8 @@ then comparing that against the target page.
 
 ### 1. Fetch and Parse Target Page
 
-- Fetch the target URL using `claude-seo run render_page.py "<url>" --mode auto --json` (SPA-aware SSRF-protected renderer)
-- Parse with `claude-seo run parse_html.py --url "<url>"` to extract SEO elements
+- Fetch the target URL using `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py "<url>" --mode auto --json` (SPA-aware SSRF-protected renderer)
+- Parse with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py --url "<url>"` to extract SEO elements
 - Identify: page type, title, H1, meta description, headings, word count, schema, CTAs, media
 - If no keyword was provided, derive primary keyword from title + H1 overlap
 
@@ -85,7 +85,7 @@ Score the target page across 7 dimensions (100 points total):
 ## Pre-Delivery Checklist
 
 Before presenting results, verify:
-- [ ] URL was fetched via `claude-seo run render_page.py --mode auto` (not raw curl)
+- [ ] URL was fetched via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py --mode auto` (not raw curl)
 - [ ] At least 5 SERP results were analyzed
 - [ ] Page type classification uses the taxonomy reference
 - [ ] User stories cite specific SERP signals
@@ -95,7 +95,7 @@ Before presenting results, verify:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `raw_content` (pre-JS), `content` (post-JS), `is_spa`, `extracted_text` (boilerplate-stripped via trafilatura), and `publication_date` (htmldate). SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 Search experience scoring needs the *rendered* DOM because users see what JS produces. Prefer `--mode always` so above-the-fold analysis matches what the persona actually encounters.
 

--- a/agents/seo-technical.md
+++ b/agents/seo-technical.md
@@ -9,7 +9,7 @@ tools: Read, Bash, Write, Glob, Grep  # Write needed for report/data file output
 You are a Technical SEO specialist. When given a URL or set of URLs:
 
 1. Fetch the page(s) and analyze HTML source
-2. Check sitemap availability with `claude-seo run sitemap_discovery.py <URL> --json`.
+2. Check sitemap availability with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <URL> --json`.
    A robots.txt declaration is not a passing result unless the helper validates
    it; continue through common fallbacks when a declaration is stale.
 3. Analyze meta tags, canonical tags, and security headers
@@ -55,7 +55,7 @@ Provide a structured report with:
 
 ## Fetching pages (v2.0.0)
 
-Use `claude-seo run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `is_spa`, complete `extracted_text`, and `publication_date`; use `--output rendered.html` for the full HTML. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --json` for page HTML. `auto` does a raw fetch and only spins up Playwright when an SPA shell is detected; use `--mode always` to force a render or `--mode never` to skip Playwright entirely. The JSON exposes `is_spa`, complete `extracted_text`, and `publication_date`; use `--output rendered.html` for the full HTML. SSRF and DNS-rebinding protection live in the bundled `url_safety.py` module, never call `requests.get` directly on user-supplied URLs.
 
 ## Persistence Contract
 

--- a/agents/seo-visual.md
+++ b/agents/seo-visual.md
@@ -29,8 +29,8 @@ pip install playwright && playwright install chromium
 Use the managed screenshot and renderer commands for browser automation:
 
 ```bash
-claude-seo run capture_screenshot.py URL --all --output screenshots/
-claude-seo run render_page.py URL --mode auto --a11y-tree --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run capture_screenshot.py URL --all --output screenshots/
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py URL --mode auto --a11y-tree --json
 ```
 
 ## Viewports to Test

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -224,10 +224,22 @@ User Request (e.g., /seo page)
 
 ### Managed Python runtime
 
-Bundled tools are dispatched through `bin/claude-seo` and
+Bundled tools are dispatched through `scripts/claude-seo` and
 `scripts/runtime.py`, never through a working-directory-relative Python command.
 The launcher resolves Python 3.10 or newer, while the standard-library runtime
 provides three operations: `run`, `setup`, and read-only `doctor`.
+
+The launcher lives in `scripts/` beside `runtime.py`, which it resolves as a
+sibling. A top-level `bin/` directory is not allowed: the claude.ai-hosted
+marketplace rejects such a plugin with `marketplace_sync_bin_directory_not_allowed`.
+Skills and agents therefore call the launcher by its plugin-relative path,
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>`, which Claude Code
+expands in skill body content, in `allowed-tools` Bash rules, and as an
+environment variable for hook processes. The quoting keeps the command correct
+when the plugin root contains spaces. Manual installers (`install.sh`,
+`install.ps1`) copy the launcher to `~/.claude/skills/seo/scripts/claude-seo`
+and rewrite that canonical token to the absolute path in every Markdown file
+they install, because a manual install has no plugin root.
 
 Plugin environments live under persistent `CLAUDE_PLUGIN_DATA`. Manual installs
 keep the compatible `~/.claude/skills/seo/.venv` location. A state marker records

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -72,7 +72,7 @@ used by every skill. It creates `~/.claude/skills/seo/.venv/` and never falls
 back to global or user package installation.
 
 ```bash
-~/.claude/skills/seo/bin/claude-seo doctor
+~/.claude/skills/seo/scripts/claude-seo doctor
 ```
 
 If core setup failed, rerun the inspected installer. If only Chromium failed,
@@ -87,7 +87,7 @@ The installer copies files to:
 | Main skill | `~/.claude/skills/seo/` |
 | Sub-skills | `~/.claude/skills/seo-*/` |
 | Subagents | `~/.claude/agents/seo-*.md` |
-| Runtime launcher | `~/.claude/skills/seo/bin/claude-seo` |
+| Runtime launcher | `~/.claude/skills/seo/scripts/claude-seo` |
 | Isolated Python | `~/.claude/skills/seo/.venv/` |
 
 ## Verify Installation
@@ -155,7 +155,7 @@ If the file doesn't exist, re-run the installer.
 Run the managed setup again:
 
 ```bash
-~/.claude/skills/seo/bin/claude-seo setup
+~/.claude/skills/seo/scripts/claude-seo setup
 ```
 
 ### Playwright screenshot errors
@@ -163,8 +163,8 @@ Run the managed setup again:
 Run the managed setup again and inspect the result:
 
 ```bash
-~/.claude/skills/seo/bin/claude-seo setup
-~/.claude/skills/seo/bin/claude-seo doctor
+~/.claude/skills/seo/scripts/claude-seo setup
+~/.claude/skills/seo/scripts/claude-seo doctor
 ```
 
 ### Permission errors on Unix

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -58,8 +58,8 @@ Dependencies belong in the managed runtime. For a plugin install, run:
 
 For a manual install, run:
 ```bash
-~/.claude/skills/seo/bin/claude-seo doctor
-~/.claude/skills/seo/bin/claude-seo setup
+~/.claude/skills/seo/scripts/claude-seo doctor
+~/.claude/skills/seo/scripts/claude-seo setup
 ```
 
 Do not install individual packages, use `pip --user`, or create a PATH shim.

--- a/extensions/ahrefs/docs/AHREFS-SETUP.md
+++ b/extensions/ahrefs/docs/AHREFS-SETUP.md
@@ -53,7 +53,7 @@ The Python merge script is idempotent — re-running only replaces the
 
 Ahrefs charges per "unit". A unit covers most read endpoints (domain
 metrics, backlink data) at 1 unit each; bulk endpoints cost more. The
-`claude-seo run dataforseo_costs.py` cost tracker shipped with claude-seo
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py` cost tracker shipped with claude-seo
 generalises across vendors — see the DataForSEO extension's
 `references/cost-tiers.md` for the budget-preset pattern to mirror when
 wiring Ahrefs accounting.

--- a/extensions/ahrefs/skills/seo-ahrefs/SKILL.md
+++ b/extensions/ahrefs/skills/seo-ahrefs/SKILL.md
@@ -2,7 +2,7 @@
 name: seo-ahrefs
 description: Ahrefs API analyst (extension). Reads referring domains, backlinks, organic keywords, and content explorer data via the tested @ahrefs/mcp@0.0.11 server. Pairs with seo-backlinks for multi-source confidence weighting.
 metadata:
-  version: "2.2.5"
+  version: "2.2.6"
 compatibility: "Tested with @ahrefs/mcp@0.0.11 (installed by extensions/ahrefs/install.sh)."
 ---
 

--- a/extensions/ahrefs/skills/seo-ahrefs/SKILL.md
+++ b/extensions/ahrefs/skills/seo-ahrefs/SKILL.md
@@ -46,7 +46,7 @@ provide the install command above.
 
 Ahrefs API usage is metered per unit. Before running a batch (>= 50 URLs):
 
-1. Estimate cost with `claude-seo run dataforseo_costs.py` (the cost-tracker module is generic and supports Ahrefs unit accounting).
+1. Estimate cost with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py` (the cost-tracker module is generic and supports Ahrefs unit accounting).
 2. Surface the estimate to the orchestrator.
 3. Log actual cost after each call.
 

--- a/extensions/banana/README.md
+++ b/extensions/banana/README.md
@@ -39,7 +39,7 @@ The installer will:
 
 CSV batch planning helper:
 ```bash
-claude-seo run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"
 ```
 
 ## Use Case Defaults

--- a/extensions/banana/docs/BANANA-SETUP.md
+++ b/extensions/banana/docs/BANANA-SETUP.md
@@ -31,14 +31,14 @@ add to `~/.claude/settings.json`:
 
 Scripted setup helper:
 ```bash
-claude-seo run --extension banana setup_mcp.py --key YOUR_KEY
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana setup_mcp.py --key YOUR_KEY
 ```
 
 ## Verifying Installation
 
 Run the validation script:
 ```bash
-claude-seo run --extension banana validate_setup.py
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana validate_setup.py
 ```
 
 Or check manually:

--- a/extensions/banana/install.sh
+++ b/extensions/banana/install.sh
@@ -154,14 +154,15 @@ PY
     cp "${SOURCE_DIR}/scripts/"*.py "${SKILL_DIR}/scripts/"
     cp "${SOURCE_DIR}/references/"*.md "${SKILL_DIR}/references/"
 
-    # Rewrite only files copied by this extension install. Manual installs do
-    # not receive plugin bin/ PATH injection.
+    # Rewrite only files copied by this extension install. Manual installs have
+    # no ${CLAUDE_PLUGIN_ROOT}, so the canonical launcher token becomes the
+    # absolute installed path. The substitution is idempotent.
     for installed_doc in "${SKILL_DIR}/SKILL.md" "${SKILL_DIR}/references/"*.md "${AGENT_DIR}/seo-image-gen.md"; do
         [ -f "${installed_doc}" ] || continue
         temp_doc="${installed_doc}.claude-seo-tmp"
-        sed -e 's#claude-seo run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
-            -e 's#claude-seo setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
-            -e 's#claude-seo doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
+        sed -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run#"$HOME/.claude/skills/seo/scripts/claude-seo" run#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup#"$HOME/.claude/skills/seo/scripts/claude-seo" setup#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor#"$HOME/.claude/skills/seo/scripts/claude-seo" doctor#g' \
             "${installed_doc}" > "${temp_doc}"
         mv "${temp_doc}" "${installed_doc}"
     done

--- a/extensions/banana/references/gemini-models.md
+++ b/extensions/banana/references/gemini-models.md
@@ -121,7 +121,7 @@ Verify current rate limits in Google-owned docs before planning batch work.
 
 Do not use hard-coded pricing assumptions. Verify current pricing at
 https://ai.google.dev/gemini-api/docs/pricing and store dated values in
-`~/.banana/pricing.json` via `claude-seo run --extension banana cost_tracker.py`.
+`~/.banana/pricing.json` via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana cost_tracker.py`.
 
 ## Image Output Specs
 

--- a/extensions/banana/references/seo-image-presets.md
+++ b/extensions/banana/references/seo-image-presets.md
@@ -123,7 +123,7 @@ preset format (see `references/presets.md` for schema details).
 
 Users can create their own presets:
 ```bash
-claude-seo run --extension banana presets.py create my-brand
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana presets.py create my-brand
 ```
 
 This creates `~/.banana/presets/my-brand.json` with the full schema.

--- a/extensions/banana/scripts/cost_tracker.py
+++ b/extensions/banana/scripts/cost_tracker.py
@@ -13,31 +13,148 @@ Usage:
 
 import argparse
 import json
+import os
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-LEDGER_PATH = Path.home() / ".banana" / "costs.json"
-PRICING_PATH = Path.home() / ".banana" / "pricing.json"
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
+
+# BANANA_HOME lets tests (and anyone running an isolated budget) point the
+# ledger and pricing config somewhere other than the real ones. Resolved at
+# import.
+BANANA_DIR = Path(os.environ.get("BANANA_HOME") or Path.home() / ".banana")
+LEDGER_PATH = BANANA_DIR / "costs.json"
+LOCK_PATH = BANANA_DIR / "costs.lock"
+PRICING_PATH = BANANA_DIR / "pricing.json"
 PRICING_SOURCE = "https://ai.google.dev/gemini-api/docs/pricing"
+
+
+def _empty_ledger():
+    return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
+
 
 # Batch API gets 50% discount
 BATCH_DISCOUNT = 0.5
 
 
-def _load_ledger():
-    """Load the cost ledger from disk."""
+class LedgerError(RuntimeError):
+    """The cost ledger could not be read or written safely."""
+
+
+def _lock(handle, exclusive):
+    """Take an advisory lock on an open handle, blocking until acquired.
+
+    Never degrades to running unlocked: a cost ledger that silently drops
+    entries is worse than one that refuses to run.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    elif msvcrt is not None:
+        # msvcrt has no shared mode, so readers take an exclusive lock too.
+        # LK_LOCK retries 10 times at 1s intervals, then raises OSError.
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        raise LedgerError(
+            "No file-locking primitive available (neither fcntl nor msvcrt). "
+            "Refusing to touch the cost ledger unlocked."
+        )
+
+
+def _unlock(handle):
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _read_ledger():
+    """Read the ledger. Caller must hold the lock."""
     if not LEDGER_PATH.exists():
-        return {"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}}
-    with open(LEDGER_PATH, "r") as f:
-        return json.load(f)
+        return _empty_ledger()
+    try:
+        with open(LEDGER_PATH, "r") as f:
+            ledger = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(
+            f"Cost ledger {LEDGER_PATH} is not valid JSON ({exc}). Refusing to "
+            "continue from a zero balance, which would under-report spend. "
+            "Inspect the file, then repair or remove it."
+        ) from exc
+    if not isinstance(ledger, dict) or not isinstance(ledger.get("entries"), list):
+        raise LedgerError(
+            f"Cost ledger {LEDGER_PATH} has an unexpected shape (no 'entries' "
+            "list). Inspect the file, then repair or remove it."
+        )
+    # Tolerate ledgers written before a field existed.
+    ledger.setdefault("total_cost", 0.0)
+    ledger.setdefault("total_images", 0)
+    ledger.setdefault("daily", {})
+    return ledger
 
 
-def _save_ledger(ledger):
-    """Save the cost ledger to disk."""
-    LEDGER_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(LEDGER_PATH, "w") as f:
-        json.dump(ledger, f, indent=2)
+def _write_ledger(ledger):
+    """Write the ledger atomically. Caller must hold the exclusive lock.
+
+    tempfile + os.replace so a crash mid-write can never leave a truncated,
+    unparseable ledger behind.
+    """
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(BANANA_DIR), prefix=".costs.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(ledger, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, LEDGER_PATH)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+@contextmanager
+def _locked_ledger(write=False):
+    """Yield the ledger under ONE lock held across the whole read-modify-write.
+
+    Reading under one lock, dropping it, then re-taking it to write loses
+    entries: two concurrent `log` calls both read the same ledger and the
+    second overwrites the first. This ledger also carries running aggregates
+    (total_cost, total_images, daily), so a lost write drops the entry and its
+    aggregate increment together and the file still looks self-consistent.
+
+    The lock lives in a separate .lock file on purpose. The atomic write
+    replaces the ledger's inode, so a lock held on the ledger itself would not
+    protect the replacement.
+    """
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_PATH, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=write)
+        try:
+            ledger = _read_ledger()
+            yield ledger
+            if write:
+                _write_ledger(ledger)
+        finally:
+            _unlock(lock_handle)
+
+
+def _ledger_snapshot():
+    """Read the ledger under a shared lock. For read-only commands."""
+    with _locked_ledger() as ledger:
+        return ledger
 
 
 def _load_pricing_config():
@@ -85,7 +202,6 @@ def _lookup_cost(model, resolution, batch=False):
 
 def cmd_log(args):
     """Log a generation to the ledger."""
-    ledger = _load_ledger()
     cost, checked_date = _lookup_cost(args.model, args.resolution, getattr(args, "batch", False))
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -100,24 +216,29 @@ def cmd_log(args):
         "prompt": args.prompt[:100],
     }
 
-    ledger["entries"].append(entry)
-    ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
-    ledger["total_images"] += 1
+    # Read and write inside one lock, so a concurrent log cannot overwrite this
+    # entry (and its aggregate increments) with a ledger it read beforehand.
+    with _locked_ledger(write=True) as ledger:
+        ledger["entries"].append(entry)
+        ledger["total_cost"] = round(ledger["total_cost"] + cost, 4)
+        ledger["total_images"] += 1
 
-    if today not in ledger["daily"]:
-        ledger["daily"][today] = {"count": 0, "cost": 0.0}
-    ledger["daily"][today]["count"] += 1
-    ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
+        if today not in ledger["daily"]:
+            ledger["daily"][today] = {"count": 0, "cost": 0.0}
+        ledger["daily"][today]["count"] += 1
+        ledger["daily"][today]["cost"] = round(ledger["daily"][today]["cost"] + cost, 4)
 
-    _save_ledger(ledger)
-    print(json.dumps({"logged": True, "cost": cost, "total_cost": ledger["total_cost"],
-                       "total_images": ledger["total_images"], "approximate": True,
+        total_cost = ledger["total_cost"]
+        total_images = ledger["total_images"]
+
+    print(json.dumps({"logged": True, "cost": cost, "total_cost": total_cost,
+                       "total_images": total_images, "approximate": True,
                        "pricing_checked_date": checked_date}))
 
 
 def cmd_summary(args):
     """Show cost summary."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     print(f"Total images: {ledger['total_images']}")
     print(f"Total cost:   approx ${ledger['total_cost']:.3f}")
     print()
@@ -136,7 +257,7 @@ def cmd_summary(args):
 
 def cmd_today(args):
     """Show today's usage."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     daily = ledger.get("daily", {}).get(today, {"count": 0, "cost": 0.0})
     print(f"Today ({today}): {daily['count']} images, approx ${daily['cost']:.3f}")
@@ -162,7 +283,16 @@ def cmd_reset(args):
     if not args.confirm:
         print("Error: Pass --confirm to reset the cost ledger.", file=sys.stderr)
         sys.exit(1)
-    _save_ledger({"total_cost": 0.0, "total_images": 0, "entries": [], "daily": {}})
+    # Takes the same exclusive lock as `log`, but deliberately does NOT read
+    # first: reset is the recovery path for a corrupt ledger, so it must not
+    # depend on the existing file parsing.
+    BANANA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_PATH, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=True)
+        try:
+            _write_ledger(_empty_ledger())
+        finally:
+            _unlock(lock_handle)
     print("Cost ledger reset.")
 
 
@@ -197,7 +327,12 @@ def main():
     args = parser.parse_args()
     cmds = {"log": cmd_log, "summary": cmd_summary, "today": cmd_today,
             "estimate": cmd_estimate, "reset": cmd_reset}
-    cmds[args.command](args)
+    try:
+        cmds[args.command](args)
+    except LedgerError as exc:
+        # Fail closed and loudly rather than under-reporting spend.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/extensions/banana/skills/seo-image-gen/SKILL.md
+++ b/extensions/banana/skills/seo-image-gen/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Requires nanobanana MCP server"
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/extensions/banana/skills/seo-image-gen/SKILL.md
+++ b/extensions/banana/skills/seo-image-gen/SKILL.md
@@ -83,7 +83,7 @@ For every generation request:
 
 If the user mentions a brand or has SEO presets configured:
 ```bash
-claude-seo run --extension banana presets.py list
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana presets.py list
 ```
 Load matching preset and apply as defaults. Also check `${CLAUDE_SKILL_DIR}/references/seo-image-presets.md`
 for SEO-specific preset templates.
@@ -121,7 +121,7 @@ After every successful generation, guide the user on:
 
 Image generation costs money. Be transparent:
 - Show estimated cost before generating (especially for batch)
-- Log every generation: `claude-seo run --extension banana cost_tracker.py log --model MODEL --resolution RES --prompt "brief"`
+- Log every generation: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana cost_tracker.py log --model MODEL --resolution RES --prompt "brief"`
 - Run `cost_tracker.py summary` if user asks about usage
 
 Pricing is not hard-coded. Check current Google pricing at
@@ -141,12 +141,12 @@ https://ai.google.dev/gemini-api/docs/pricing, store dated values in
 
 | Error | Resolution |
 |-------|-----------|
-| MCP not configured | Run `./extensions/banana/install.sh` or `claude-seo run --extension banana setup_mcp.py --key YOUR_KEY` |
+| MCP not configured | Run `./extensions/banana/install.sh` or `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana setup_mcp.py --key YOUR_KEY` |
 | API key invalid | New key at https://aistudio.google.com/apikey |
 | Rate limited (429) | Wait 60s, retry. Check current free-tier limits before batch operations |
 | `IMAGE_SAFETY` | Rephrase prompt - see `references/prompt-engineering.md` Safety section |
-| MCP unavailable | Fall back: `claude-seo run --extension banana generate.py --prompt "..." --aspect-ratio "16:9" --model "$NANOBANANA_MODEL"` |
-| CSV batch input | Plan first: `claude-seo run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"` |
+| MCP unavailable | Fall back: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana generate.py --prompt "..." --aspect-ratio "16:9" --model "$NANOBANANA_MODEL"` |
+| CSV batch input | Plan first: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run --extension banana batch.py --csv requests.csv --model "$NANOBANANA_MODEL"` |
 | Extension not installed | Show install instructions: `./extensions/banana/install.sh` |
 
 ## Cross-Skill Integration

--- a/extensions/bing-webmaster/docs/BING-WEBMASTER-SETUP.md
+++ b/extensions/bing-webmaster/docs/BING-WEBMASTER-SETUP.md
@@ -4,9 +4,9 @@
 
 1. **Bing Webmaster Tools API**: inbound links, crawl stats, search
    keywords, and competitor link comparison via
-   `claude-seo run bing_webmaster.py` (already shipped with claude-seo).
+   `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py` (already shipped with claude-seo).
 2. **IndexNow URL submission** for Amazon, Bing, Naver, Seznam.cz,
-   Yandex, and Yep via `claude-seo run indexnow_submit.py`.
+   Yandex, and Yep via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py`.
 3. A unified `seo-bing` skill that routes the right command at the
    right script.
 

--- a/extensions/bing-webmaster/install.sh
+++ b/extensions/bing-webmaster/install.sh
@@ -53,7 +53,7 @@ PY
 
     echo
     echo "Done. Verify your IndexNow key is published:"
-    echo "  claude-seo run indexnow_submit.py --host example.com \\"
+    echo "  \"\$HOME/.claude/skills/seo/scripts/claude-seo\" run indexnow_submit.py --host example.com \\"
     echo "    --key \$INDEXNOW_KEY --key-location \$INDEXNOW_KEY_LOCATION --verify-only"
 }
 main "$@"

--- a/extensions/bing-webmaster/install.sh
+++ b/extensions/bing-webmaster/install.sh
@@ -52,7 +52,8 @@ print(f"✓ Wrote Bing + IndexNow env to {path}")
 PY
 
     echo
-    echo "Done. Verify your IndexNow key is published:"
+    echo "Done. Verify your IndexNow key is published (manual install path shown;"
+    echo "plugin installs use \"\${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo\" instead):"
     echo "  \"\$HOME/.claude/skills/seo/scripts/claude-seo\" run indexnow_submit.py --host example.com \\"
     echo "    --key \$INDEXNOW_KEY --key-location \$INDEXNOW_KEY_LOCATION --verify-only"
 }

--- a/extensions/bing-webmaster/skills/seo-bing/SKILL.md
+++ b/extensions/bing-webmaster/skills/seo-bing/SKILL.md
@@ -2,7 +2,7 @@
 name: seo-bing
 description: Bing Webmaster Tools + IndexNow extension. Microsoft Copilot citations are fed by the Bing index; this skill makes Bing visibility, link data, and IndexNow URL submission first-class.
 metadata:
-  version: "2.2.5"
+  version: "2.2.6"
 compatibility: "Requires BING_WEBMASTER_API_KEY and (optionally) INDEXNOW_KEY in ~/.claude/settings.json env. Run extensions/bing-webmaster/install.sh to configure."
 ---
 

--- a/extensions/bing-webmaster/skills/seo-bing/SKILL.md
+++ b/extensions/bing-webmaster/skills/seo-bing/SKILL.md
@@ -24,11 +24,11 @@ specifically for **Amazon/Bing/Naver/Seznam.cz/Yandex/Yep indexing** and
 
 | Command | Underlying script |
 |---|---|
-| `/seo bing links <url>` | `claude-seo run bing_webmaster.py links <url>` |
-| `/seo bing compare <urlA> <urlB>` | `claude-seo run bing_webmaster.py compare <urlA> <urlB>`; both properties must be registered to the API account |
-| `/seo bing submit <url>` (single URL) | `claude-seo run indexnow_submit.py --host ... --urls <url>` |
-| `/seo bing submit-batch <file>` | `claude-seo run indexnow_submit.py --host ... --urls-file <file>` |
-| `/seo bing verify-indexnow` | `claude-seo run indexnow_submit.py --host ... --verify-only` |
+| `/seo bing links <url>` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py links <url>` |
+| `/seo bing compare <urlA> <urlB>` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py compare <urlA> <urlB>`; both properties must be registered to the API account |
+| `/seo bing submit <url>` (single URL) | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host ... --urls <url>` |
+| `/seo bing submit-batch <file>` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host ... --urls-file <file>` |
+| `/seo bing verify-indexnow` | `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexnow_submit.py --host ... --verify-only` |
 
 ## When this skill applies
 

--- a/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
+++ b/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
@@ -48,7 +48,7 @@ DataForSEO charges per API call. Be efficient:
 
 **Before every DataForSEO MCP call**, run cost estimation:
 ```
-claude-seo run dataforseo_costs.py check <endpoint> [--count N]
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]
 ```
 
 - If `"status": "approved"` → proceed with the API call
@@ -57,7 +57,7 @@ claude-seo run dataforseo_costs.py check <endpoint> [--count N]
 
 **After each API call completes**, log the cost:
 ```
-claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <actual_cost>
 ```
 
 **User commands for cost management:**

--- a/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
+++ b/extensions/dataforseo/skills/seo-dataforseo/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 compatibility: "Requires DataForSEO MCP server"
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/extensions/dataforseo/skills/seo-dataforseo/references/cost-tiers.md
+++ b/extensions/dataforseo/skills/seo-dataforseo/references/cost-tiers.md
@@ -31,7 +31,7 @@
 | **Aggressive** | $50.00 | $2.00 | threshold | Agency bulk work |
 | **Unlimited** | $999.00 | -- | none | Trusted pipelines |
 
-Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
+Configure with: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
 
 ## Cost Reduction Tips
 
@@ -44,11 +44,11 @@ Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --th
 ## Approval Flow
 
 Before any DataForSEO MCP call:
-1. Run `claude-seo run dataforseo_costs.py check <endpoint> [--count N]`
+1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]`
 2. If `status: "approved"` → proceed
 3. If `status: "needs_approval"` → show cost to user, ask to confirm
 4. If `status: "blocked"` → inform user daily limit would be exceeded
-5. After call completes, log: `claude-seo run dataforseo_costs.py log <endpoint> <cost>`
+5. After call completes, log: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <cost>`
 
 ## Warn Endpoints
 

--- a/extensions/firecrawl/skills/seo-firecrawl/SKILL.md
+++ b/extensions/firecrawl/skills/seo-firecrawl/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 compatibility: "Requires Firecrawl MCP server"
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/extensions/profound/skills/seo-profound/SKILL.md
+++ b/extensions/profound/skills/seo-profound/SKILL.md
@@ -2,7 +2,7 @@
 name: seo-profound
 description: Profound LLM citation tracker (extension). Time-series brand citation rates across ChatGPT, Perplexity, and other LLMs. Pairs with seo-seranking for triangulated AI visibility coverage.
 metadata:
-  version: "2.2.5"
+  version: "2.2.6"
 compatibility: "Requires a Profound API key (set PROFOUND_API_KEY by running extensions/profound/install.sh)."
 ---
 

--- a/extensions/seranking/skills/seo-seranking/SKILL.md
+++ b/extensions/seranking/skills/seo-seranking/SKILL.md
@@ -2,7 +2,7 @@
 name: seo-seranking
 description: SE Ranking AI visibility analyst (extension). Tracks AI Share-of-Voice across ChatGPT, Gemini, Perplexity, AI Overviews, and AI Mode in a single query.
 metadata:
-  version: "2.2.5"
+  version: "2.2.6"
 compatibility: "Requires an SE Ranking API key (set SERANKING_API_KEY by running extensions/seranking/install.sh)."
 ---
 

--- a/extensions/seranking/skills/seo-seranking/SKILL.md
+++ b/extensions/seranking/skills/seo-seranking/SKILL.md
@@ -42,7 +42,7 @@ Report each as a percentage with a confidence note based on sample size.
 ## Cost guardrails
 
 SE Ranking API uses unit accounting. Single AI visibility query is
-~5 units (1 per platform). Use `claude-seo run dataforseo_costs.py` to log
+~5 units (1 per platform). Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py` to log
 spend across vendors.
 
 ## Cross-skill delegation

--- a/extensions/unlighthouse/skills/seo-unlighthouse/SKILL.md
+++ b/extensions/unlighthouse/skills/seo-unlighthouse/SKILL.md
@@ -2,7 +2,7 @@
 name: seo-unlighthouse
 description: Multi-page Lighthouse audit via the MIT-licensed Unlighthouse CLI. Free-tier alternative to running PageSpeed against every URL on a site, no API quota burn, runs locally.
 metadata:
-  version: "2.2.5"
+  version: "2.2.6"
 compatibility: "Requires Node 18+ and the unlighthouse npm package. Run extensions/unlighthouse/install.sh to pre-warm."
 ---
 

--- a/extensions/unlighthouse/skills/seo-unlighthouse/SKILL.md
+++ b/extensions/unlighthouse/skills/seo-unlighthouse/SKILL.md
@@ -28,7 +28,7 @@ and aggregate the results. Useful when:
 | `/seo unlighthouse <url> --device desktop` | Desktop form factor |
 | `/seo unlighthouse <url> --max-routes 50 --output-dir ./reports` | Cap + persist |
 
-All flags forward through `claude-seo run unlighthouse_run.py`, which handles
+All flags forward through `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run unlighthouse_run.py`, which handles
 url_safety pre-flight and subprocess timeout management.
 
 ## Output handling
@@ -44,4 +44,4 @@ returns it parsed. Aggregate fields:
 
 - For single-URL field data (CrUX), use `seo-google psi` / `seo-google crux`.
 - For LCP subpart decomposition on slow pages, use the
-  `claude-seo run lcp_subparts.py` workflow (Phase C).
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run lcp_subparts.py` workflow (Phase C).

--- a/install.ps1
+++ b/install.ps1
@@ -118,7 +118,7 @@ $RepoUrl = "https://github.com/AgriciDaniel/claude-seo"
 # This default MUST be bumped on every release. CI guard
 # (tests/test_manifest_consistency.py) enforces this matches plugin.json.
 # Override: $env:CLAUDE_SEO_TAG = 'main'; .\install.ps1
-$RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v2.2.5' }
+$RepoTag = if ($env:CLAUDE_SEO_TAG) { $env:CLAUDE_SEO_TAG } else { 'v2.2.6' }
 
 # Create directories
 New-Item -ItemType Directory -Force -Path $SkillDir | Out-Null

--- a/install.ps1
+++ b/install.ps1
@@ -197,12 +197,14 @@ try {
         Copy-Item -Recurse -Force "$ScriptsPath\*" $SkillScripts
     }
 
-    # Copy the stable launcher used by skill and agent instructions.
-    $BinPath = Join-Path $TempDir 'bin'
-    $SkillBin = Join-Path $SkillDir 'bin'
-    if (Test-Path (Join-Path $BinPath 'claude-seo')) {
-        New-Item -ItemType Directory -Force -Path $SkillBin | Out-Null
-        Copy-Item -Force (Join-Path $BinPath 'claude-seo') (Join-Path $SkillBin 'claude-seo')
+    # Copy the stable launcher used by skill and agent instructions. It ships in
+    # scripts/ (never a top-level bin/, which hosted marketplaces reject) and
+    # resolves runtime.py as a sibling, so it lands beside the copied scripts.
+    $LauncherSource = Join-Path $ScriptsPath 'claude-seo'
+    $SkillLauncherDir = Join-Path $SkillDir 'scripts'
+    if (Test-Path $LauncherSource) {
+        New-Item -ItemType Directory -Force -Path $SkillLauncherDir | Out-Null
+        Copy-Item -Force $LauncherSource (Join-Path $SkillLauncherDir 'claude-seo')
     }
 
     # Copy hooks
@@ -263,10 +265,12 @@ try {
         Copy-Item -Force $pluginManifest (Join-Path $SkillDir 'runtime-plugin.json')
     }
 
-    # Manual installs do not receive plugin bin/ PATH injection. Rewrite only
-    # the canonical runtime token in installed Markdown. Claude Code's Bash tool
-    # expands $HOME on Windows as well as Unix.
-    $manualRunner = '"$HOME/.claude/skills/seo/bin/claude-seo" run'
+    # Manual installs have no ${CLAUDE_PLUGIN_ROOT}. Rewrite the canonical
+    # launcher token in installed Markdown to the absolute installed path.
+    # Claude Code's Bash tool expands $HOME on Windows as well as Unix. The
+    # replacement consumes the plugin-root token, so a second pass is a no-op.
+    $pluginRunner = '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run'
+    $manualRunner = '"$HOME/.claude/skills/seo/scripts/claude-seo" run'
     $installedDocs = @()
     Get-ChildItem -Path $SkillsPath -Directory | ForEach-Object {
         $sourceRoot = $_.FullName
@@ -306,11 +310,13 @@ try {
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     $installedDocs | ForEach-Object {
         $text = [System.IO.File]::ReadAllText($_.FullName)
-        $manualSetup = '"$HOME/.claude/skills/seo/bin/claude-seo" setup'
-        $manualDoctor = '"$HOME/.claude/skills/seo/bin/claude-seo" doctor'
-        $updated = $text.Replace('claude-seo run', $manualRunner)
-        $updated = $updated.Replace('claude-seo setup', $manualSetup)
-        $updated = $updated.Replace('claude-seo doctor', $manualDoctor)
+        $pluginSetup = '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup'
+        $pluginDoctor = '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor'
+        $manualSetup = '"$HOME/.claude/skills/seo/scripts/claude-seo" setup'
+        $manualDoctor = '"$HOME/.claude/skills/seo/scripts/claude-seo" doctor'
+        $updated = $text.Replace($pluginRunner, $manualRunner)
+        $updated = $updated.Replace($pluginSetup, $manualSetup)
+        $updated = $updated.Replace($pluginDoctor, $manualDoctor)
         if ($updated -ne $text) {
             [System.IO.File]::WriteAllText($_.FullName, $updated, $utf8NoBom)
         }

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ main() {
     # This default MUST be bumped on every release. CI guard
     # (tests/test_manifest_consistency.py) enforces this matches plugin.json.
     # Override: CLAUDE_SEO_TAG=main bash install.sh
-    REPO_TAG="${CLAUDE_SEO_TAG:-v2.2.5}"
+    REPO_TAG="${CLAUDE_SEO_TAG:-v2.2.6}"
 
     echo "════════════════════════════════════════"
     echo "║   Claude SEO - Installer             ║"

--- a/install.sh
+++ b/install.sh
@@ -79,12 +79,13 @@ main() {
         cp -r "${TEMP_DIR}/claude-seo/scripts/"* "${SKILL_DIR}/scripts/"
     fi
 
-    # Copy the stable runtime launcher. Manual installs use its explicit path;
-    # plugin installs expose the repository bin/ directory automatically.
-    if [ -f "${TEMP_DIR}/claude-seo/bin/claude-seo" ]; then
-        mkdir -p "${SKILL_DIR}/bin"
-        cp "${TEMP_DIR}/claude-seo/bin/claude-seo" "${SKILL_DIR}/bin/claude-seo"
-        chmod +x "${SKILL_DIR}/bin/claude-seo"
+    # Copy the stable runtime launcher. It ships in scripts/ (never a top-level
+    # bin/, which hosted marketplaces reject) and resolves runtime.py as a
+    # sibling, so the manual layout below already matches the repository layout.
+    if [ -f "${TEMP_DIR}/claude-seo/scripts/claude-seo" ]; then
+        mkdir -p "${SKILL_DIR}/scripts"
+        cp "${TEMP_DIR}/claude-seo/scripts/claude-seo" "${SKILL_DIR}/scripts/claude-seo"
+        chmod +x "${SKILL_DIR}/scripts/claude-seo"
     fi
 
     # Copy hooks
@@ -134,14 +135,18 @@ main() {
     cp "${TEMP_DIR}/claude-seo/requirements.txt" "${SKILL_DIR}/requirements.txt" 2>/dev/null || true
     cp "${TEMP_DIR}/claude-seo/.claude-plugin/plugin.json" "${SKILL_DIR}/runtime-plugin.json" 2>/dev/null || true
 
-    # Manual installs cannot rely on plugin bin/ PATH injection. Rewrite only
-    # exact files copied from this checkout during this install.
+    # Manual installs have no ${CLAUDE_PLUGIN_ROOT}, so rewrite the canonical
+    # launcher token to the absolute installed path. Rewrite only exact files
+    # copied from this checkout during this install. The substitution is
+    # idempotent: it consumes the plugin-root token, so a second pass matches
+    # nothing. In a POSIX basic regular expression "$" is literal unless it ends
+    # the expression, so ${CLAUDE_PLUGIN_ROOT} needs no escaping here.
     rewrite_doc() {
         local doc="$1" temp_doc
         temp_doc="${doc}.claude-seo-tmp"
-        sed -e 's#claude-seo run#"$HOME/.claude/skills/seo/bin/claude-seo" run#g' \
-            -e 's#claude-seo setup#"$HOME/.claude/skills/seo/bin/claude-seo" setup#g' \
-            -e 's#claude-seo doctor#"$HOME/.claude/skills/seo/bin/claude-seo" doctor#g' \
+        sed -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run#"$HOME/.claude/skills/seo/scripts/claude-seo" run#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup#"$HOME/.claude/skills/seo/scripts/claude-seo" setup#g' \
+            -e 's#"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor#"$HOME/.claude/skills/seo/scripts/claude-seo" doctor#g' \
             "${doc}" > "${temp_doc}"
         mv "${temp_doc}" "${doc}"
     }
@@ -180,7 +185,7 @@ main() {
 
     echo "→ Creating isolated Python runtime..."
     set +e
-    "${SKILL_DIR}/bin/claude-seo" setup
+    "${SKILL_DIR}/scripts/claude-seo" setup
     runtime_status=$?
     set -e
     if [ "${runtime_status}" -ne 0 ] && [ "${runtime_status}" -ne 10 ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-seo"
-version = "2.2.5"
+version = "2.2.6"
 description = "Comprehensive SEO analysis skill for Claude Code"
 requires-python = ">=3.10"
 license = "MIT"

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ openpyxl>=3.1.5,<4.0.0                # No known CVEs (Excel export)
 
 # Google API dependencies (for seo-google skill)
 google-api-python-client>=2.196.0,<3.0.0   # No known CVEs
-google-auth>=2.20.0,<3.0.0                  # No known CVEs
+google-auth>=2.56.2,<3.0.0                  # No known CVEs
 google-auth-httplib2>=0.4.0,<1.0.0           # Compatibility floor for current google-auth stack
 google-analytics-data>=0.18.0,<1.0.0         # No known CVEs
 google-ads>=25.0.0,<40.0.0                   # Direct import in keyword_planner.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ urllib3>=2.7.0,<3.0.0             # High-severity urllib3 advisories GHSA-mf9v-m
 # v2.0.0 Phase A: headless rendering across all agents
 trafilatura>=2.0.0,<3.0.0         # Boilerplate-free content extraction (SPA-safe)
 htmldate>=1.9.0,<2.0.0            # Publication-date extraction for freshness signals
-courlan>=1.3.0,<2.0.0             # trafilatura URL helper; explicit pin avoids transitive drift
+courlan>=1.4.0,<2.0.0             # trafilatura URL helper; explicit pin avoids transitive drift
 
 # Report generation (for seo-google PDF/Excel reports)
 matplotlib>=3.8.0,<4.0.0              # No known CVEs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Last updated: August 25, 2026 (v2.2.5)
 
 beautifulsoup4>=4.12.0,<5.0.0     # No known CVEs
-requests>=2.32.4,<3.0.0           # CVE-2024-47081, CVE-2024-35195 fixes
+requests>=2.34.2,<3.0.0           # CVE-2024-47081, CVE-2024-35195 fixes
 lxml>=6.1.1,<7.0.0                # CVE-2025-24928 + additional libxml2 security patches
 lxml_html_clean>=0.4.3,<1.0.0     # lxml 6 removed html.clean into this standalone package
 playwright>=1.59.0,<2.0.0         # CVE-2025-59288 fix (macOS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ courlan>=1.4.0,<2.0.0             # trafilatura URL helper; explicit pin avoids 
 
 # Report generation (for seo-google PDF/Excel reports)
 matplotlib>=3.8.0,<4.0.0              # No known CVEs
-numpy>=1.26.0,<3.0.0                  # Direct import in google_report.py
+numpy>=2.2.6,<3.0.0                  # Direct import in google_report.py
 weasyprint>=70.0,<71.0                # PYSEC-2026-3940 fixed in 70.0
 openpyxl>=3.1.5,<4.0.0                # No known CVEs (Excel export)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ beautifulsoup4>=4.12.0,<5.0.0     # No known CVEs
 requests>=2.34.2,<3.0.0           # CVE-2024-47081, CVE-2024-35195 fixes
 lxml>=6.1.1,<7.0.0                # CVE-2025-24928 + additional libxml2 security patches
 lxml_html_clean>=0.4.3,<1.0.0     # lxml 6 removed html.clean into this standalone package
-playwright>=1.59.0,<2.0.0         # CVE-2025-59288 fix (macOS)
+playwright>=1.62.0,<2.0.0         # CVE-2025-59288 fix (macOS)
 urllib3>=2.7.0,<3.0.0             # High-severity urllib3 advisories GHSA-mf9v-mfxr-j63j, GHSA-qccp-gfcp-xxvc
 
 # v2.0.0 Phase A: headless rendering across all agents

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ htmldate>=1.9.0,<2.0.0            # Publication-date extraction for freshness si
 courlan>=1.4.0,<2.0.0             # trafilatura URL helper; explicit pin avoids transitive drift
 
 # Report generation (for seo-google PDF/Excel reports)
-matplotlib>=3.8.0,<4.0.0              # No known CVEs
-numpy>=2.2.6,<3.0.0                  # Direct import in google_report.py
+matplotlib>=3.9.0,<4.0.0              # No known CVEs
+numpy>=2.2.6,<3.0.0                   # Direct import in google_report.py; matplotlib>=3.9 is the first numpy 2 release line
 weasyprint>=70.0,<71.0                # PYSEC-2026-3940 fixed in 70.0
 openpyxl>=3.1.5,<4.0.0                # No known CVEs (Excel export)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ courlan>=1.3.0,<2.0.0             # trafilatura URL helper; explicit pin avoids 
 # Report generation (for seo-google PDF/Excel reports)
 matplotlib>=3.8.0,<4.0.0              # No known CVEs
 numpy>=1.26.0,<3.0.0                  # Direct import in google_report.py
-weasyprint>=68.1,<70.0                # No known CVEs
+weasyprint>=70.0,<71.0                # PYSEC-2026-3940 fixed in 70.0
 openpyxl>=3.1.5,<4.0.0                # No known CVEs (Excel export)
 
 # Google API dependencies (for seo-google skill)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Claude SEO - Python Dependencies
 # Bounded version pinning with security-conscious minimums
-# Last updated: August 25, 2026 (v2.2.5)
+# Last updated: September 10, 2026 (v2.2.6)
 
 beautifulsoup4>=4.12.0,<5.0.0     # No known CVEs
 requests>=2.34.2,<3.0.0           # CVE-2024-47081, CVE-2024-35195 fixes

--- a/scripts/bing_webmaster.py
+++ b/scripts/bing_webmaster.py
@@ -550,7 +550,7 @@ def main():
         result = {
             "status": "error",
             "data": None,
-            "error": "No Bing Webmaster API key configured. Run: claude-seo run backlinks_auth.py --setup",
+            "error": "No Bing Webmaster API key configured. Run backlinks_auth.py --setup through the claude-seo launcher.",
             "metadata": {"source": "bing_webmaster"},
         }
         if args.json:

--- a/scripts/claude-seo
+++ b/scripts/claude-seo
@@ -3,8 +3,12 @@ set -euo pipefail
 
 # Stable entry point for bundled Python tools. The launcher uses only shell
 # built-ins until a usable Python 3 interpreter has been identified.
+#
+# It lives in scripts/ rather than bin/ because hosted marketplaces reject any
+# plugin that ships a top-level bin/ directory. Skills, agents, and hooks call
+# it as "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo"; runtime.py is a sibling.
 launcher_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-runtime="${launcher_dir}/../scripts/runtime.py"
+runtime="${launcher_dir}/runtime.py"
 
 if [[ ! -f "${runtime}" ]]; then
     echo "Claude SEO runtime is missing. Reinstall Claude SEO." >&2

--- a/scripts/commoncrawl_graph.py
+++ b/scripts/commoncrawl_graph.py
@@ -21,6 +21,7 @@ import gzip
 import io
 import json
 import os
+import re
 import sys
 import time
 from typing import Optional
@@ -95,11 +96,47 @@ def _get_latest_release() -> Optional[str]:
     return None
 
 
+_CACHE_COMPONENT_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+# A Common Crawl release id, e.g. cc-main-2026-jan-feb-mar. Anchored, and no
+# '..' anywhere, because this value lands in a filesystem path and a URL path.
+_RELEASE_RE = re.compile(r"^(?!.*\.\.)[A-Za-z0-9._-]+$")
+
+
+def _safe_cache_component(value: str) -> str:
+    """Reduce one path component to a conservative charset.
+
+    Everything outside [A-Za-z0-9._-] becomes '_', then any run of dots is
+    collapsed so '..' can never survive. Both halves matter: stripping
+    separators alone still lets '..' through on a caller that joins
+    differently, and collapsing dots alone still lets a separator through.
+    """
+    cleaned = _CACHE_COMPONENT_RE.sub("_", value)
+    while ".." in cleaned:
+        cleaned = cleaned.replace("..", "_")
+    return cleaned.strip("._") or "_"
+
+
 def _get_cache_path(domain: str, release: str, data_type: str) -> str:
-    """Get the cache file path for a domain's data."""
+    """Get the cache file path for a domain's data.
+
+    Both `domain` and `release` reach this from the CLI. `release` used to be
+    interpolated raw, so `--release ../../../../tmp/x` escaped the cache
+    directory and `_save_cache`'s open(..., "w") wrote outside it. Every
+    component is now sanitised, and the joined result is asserted to stay
+    inside the cache directory as defence in depth.
+    """
     cache_dir = get_cache_dir()
-    safe_domain = domain.replace("/", "_").replace(":", "_")
-    return os.path.join(cache_dir, f"{safe_domain}-{release}-{data_type}.json")
+    safe_domain = _safe_cache_component(domain)
+    safe_release = _safe_cache_component(release)
+    safe_type = _safe_cache_component(data_type)
+    path = os.path.join(cache_dir, f"{safe_domain}-{safe_release}-{safe_type}.json")
+
+    resolved = os.path.realpath(path)
+    root = os.path.realpath(cache_dir)
+    if not (resolved == root or resolved.startswith(root + os.sep)):
+        raise ValueError(f"refusing to build a cache path outside {root}")
+    return path
 
 
 def _is_cached(domain: str, release: str) -> Optional[dict]:
@@ -429,6 +466,19 @@ def main():
 
     if not args.domain:
         print("Error: domain argument required (or use --info)", file=sys.stderr)
+        sys.exit(1)
+
+    # Reject a malformed release rather than silently sanitising it. The value
+    # is interpolated into both a cache filename and a download URL
+    # (_graph_file_url), so quietly rewriting it for one and not the other
+    # would make the cache key disagree with what was actually fetched.
+    if args.release is not None and not _RELEASE_RE.match(args.release):
+        print(
+            f"Error: invalid --release {args.release!r}. Expected a release id "
+            "such as cc-main-2026-jan-feb-mar (letters, digits, dot, dash, "
+            "underscore only).",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     result = get_domain_metrics(

--- a/scripts/consistency_check.py
+++ b/scripts/consistency_check.py
@@ -230,6 +230,18 @@ def check_agent_refs(files, texts):
     return errors
 
 
+def _normalise_newlines(data):
+    """Hash lock inputs as LF text so a CRLF checkout matches the baseline.
+
+    The lock is written from LF content (sync_flow.py hashes the fetched text
+    directly). Git for Windows defaults to core.autocrlf=true, which checks the
+    same files out with CRLF, so a byte-for-byte hash flagged every locked file
+    as tampered on a stock Windows clone. Only CRLF is folded; any other change
+    still fails the check.
+    """
+    return data.replace(b"\r\n", b"\n")
+
+
 def check_flow_lock(files):
     errors = []
     locked = {}
@@ -246,7 +258,7 @@ def check_flow_lock(files):
             errors.append(f"flow lock: missing {rel}")
             continue
         with open(full, "rb") as fh:
-            got = hashlib.sha256(fh.read()).hexdigest()
+            got = hashlib.sha256(_normalise_newlines(fh.read())).hexdigest()
         if got != want:
             errors.append(f"flow lock: hash mismatch {rel}")
     extra = {f for f in files

--- a/scripts/consistency_check.py
+++ b/scripts/consistency_check.py
@@ -177,7 +177,11 @@ def check_runtime_invocations(texts):
         r"\b(?:python3|python|py\s+-3)\s+[^\n`]*?scripts/[A-Za-z0-9_./-]+\.py"
     )
     raw_path = re.compile(r"(?<![\w/])scripts/([A-Za-z0-9_]+\.py)\b")
-    runtime = re.compile(r"\bclaude-seo\s+run(?:\s+--extension\s+[a-z0-9-]+)?\s+([A-Za-z0-9_-]+\.py)")
+    # The canonical form is "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script>,
+    # so the closing quote may sit between the launcher name and the subcommand.
+    runtime = re.compile(
+        r"claude-seo[\"']?\s+run(?:\s+--extension\s+[a-z0-9-]+)?\s+([A-Za-z0-9_-]+\.py)"
+    )
     for f in carriers:
         content = read(f)
         for match in bare.finditer(content):
@@ -185,7 +189,7 @@ def check_runtime_invocations(texts):
         for script in sorted(set(raw_path.findall(content))):
             errors.append(
                 f"{f}: unsupported raw script path scripts/{script}; "
-                f"use claude-seo run {script}"
+                f'use "${{CLAUDE_PLUGIN_ROOT}}/scripts/claude-seo" run {script}'
             )
         for script in sorted(set(runtime.findall(content))):
             if not os.path.isfile(os.path.join(REPO, "scripts", script)) and not any(

--- a/scripts/dataforseo_costs.py
+++ b/scripts/dataforseo_costs.py
@@ -10,6 +10,7 @@ Provides cost-aware guardrails for DataForSEO API usage:
 
 Config: ~/.config/claude-seo/dataforseo-costs.json
 Ledger: ~/.config/claude-seo/dataforseo-ledger.json
+Set CLAUDE_SEO_CONFIG_DIR to point both somewhere else (used by the tests).
 
 Usage:
     python dataforseo_costs.py estimate <endpoint> [--count N]
@@ -27,18 +28,30 @@ Security fixes: config path corrected to ~/.config/claude-seo/
 import argparse
 import json
 import sys
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 
 try:
     import fcntl
 except ImportError:
-    fcntl = None  # Windows fallback: no locking
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 # ----- paths -----
-CONFIG_DIR = Path.home() / ".config" / "claude-seo"
+# CLAUDE_SEO_CONFIG_DIR lets tests (and anyone running an isolated budget) point
+# the ledger somewhere other than the real one. Resolved at import.
+CONFIG_DIR = Path(
+    os.environ.get("CLAUDE_SEO_CONFIG_DIR") or Path.home() / ".config" / "claude-seo"
+)
 CONFIG_FILE = CONFIG_DIR / "dataforseo-costs.json"
 LEDGER_FILE = CONFIG_DIR / "dataforseo-ledger.json"
+LOCK_FILE = CONFIG_DIR / "dataforseo-ledger.lock"
 
 # ----- cost table (USD per call, standard queue) -----
 # Source: https://dataforseo.com/pricing
@@ -140,41 +153,108 @@ def _save_config(cfg):
         json.dump(cfg, f, indent=2)
 
 
-def _load_ledger():
-    """Load spending ledger with file locking."""
+class LedgerError(RuntimeError):
+    """The ledger could not be read or written safely."""
+
+
+def _lock(handle, exclusive):
+    """Take an advisory lock on an open handle, blocking until acquired.
+
+    Never degrades to running unlocked: a spend ledger that silently drops
+    entries is worse than one that refuses to run.
+    """
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+    elif msvcrt is not None:
+        # msvcrt has no shared mode, so readers take an exclusive lock too.
+        # LK_LOCK retries 10 times at 1s intervals, then raises OSError.
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        raise LedgerError(
+            "No file-locking primitive available (neither fcntl nor msvcrt). "
+            "Refusing to touch the spend ledger unlocked."
+        )
+
+
+def _unlock(handle):
+    if fcntl is not None:
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    elif msvcrt is not None:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _read_ledger():
+    """Read the ledger. Caller must hold the lock."""
     if not LEDGER_FILE.exists():
         return {"entries": []}
-    if fcntl:
-        lock_path = LEDGER_FILE.with_suffix(".lock")
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_SH)
-            try:
-                with open(LEDGER_FILE) as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, IOError):
-                return {"entries": []}
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-    else:
+    try:
         with open(LEDGER_FILE) as f:
-            return json.load(f)
+            ledger = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise LedgerError(
+            f"Spend ledger {LEDGER_FILE} is not valid JSON ({exc}). Refusing to "
+            "continue from a zero balance, which would under-report spend. "
+            "Inspect the file, then repair or remove it."
+        ) from exc
+    if not isinstance(ledger, dict) or not isinstance(ledger.get("entries"), list):
+        raise LedgerError(
+            f"Spend ledger {LEDGER_FILE} has an unexpected shape (no 'entries' "
+            "list). Inspect the file, then repair or remove it."
+        )
+    return ledger
 
 
-def _save_ledger(ledger):
-    """Save spending ledger with file locking."""
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    if fcntl:
-        lock_path = LEDGER_FILE.with_suffix(".lock")
-        with open(lock_path, "w") as lock_file:
-            fcntl.flock(lock_file, fcntl.LOCK_EX)
-            try:
-                with open(LEDGER_FILE, "w") as f:
-                    json.dump(ledger, f, indent=2)
-            finally:
-                fcntl.flock(lock_file, fcntl.LOCK_UN)
-    else:
-        with open(LEDGER_FILE, "w") as f:
+def _write_ledger(ledger):
+    """Write the ledger atomically. Caller must hold the exclusive lock.
+
+    tempfile + os.replace so a crash mid-write can never leave a truncated,
+    unparseable ledger behind (same idiom as scripts/google_auth.py).
+    """
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(CONFIG_DIR), prefix=".dataforseo-ledger.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
             json.dump(ledger, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, LEDGER_FILE)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+@contextmanager
+def _locked_ledger(write=False):
+    """Yield the ledger under ONE lock held across the whole read-modify-write.
+
+    Taking the lock to read, dropping it, then re-taking it to write loses
+    entries: two concurrent writers both read the same ledger and the second
+    overwrites the first. The lock has to span both halves.
+
+    The lock lives in a separate .lock file on purpose. The atomic write
+    replaces the ledger's inode, so a lock held on the ledger itself would not
+    protect the replacement.
+    """
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(LOCK_FILE, "a+") as lock_handle:
+        _lock(lock_handle, exclusive=write)
+        try:
+            ledger = _read_ledger()
+            yield ledger
+            if write:
+                _write_ledger(ledger)
+        finally:
+            _unlock(lock_handle)
+
+
+def _ledger_snapshot():
+    """Read the ledger under a shared lock. For read-only commands."""
+    with _locked_ledger() as ledger:
+        return ledger
 
 
 def _today_str():
@@ -229,7 +309,7 @@ def cmd_estimate(args):
 def cmd_check(args):
     """Check if an API call should proceed (cost + approval logic)."""
     cfg = _load_config()
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     endpoint = args.endpoint
     count = args.count or 1
     unit_cost = COST_TABLE.get(endpoint)
@@ -298,7 +378,6 @@ def cmd_check(args):
 
 def cmd_log(args):
     """Log a completed API call cost."""
-    ledger = _load_ledger()
     entry = {
         "timestamp": datetime.now().isoformat(),
         "endpoint": args.endpoint,
@@ -306,8 +385,10 @@ def cmd_log(args):
     }
     if args.note:
         entry["note"] = args.note
-    ledger["entries"].append(entry)
-    _save_ledger(ledger)
+    # Read and write inside one lock, so a concurrent log cannot overwrite this
+    # entry with a ledger it read before this one was appended.
+    with _locked_ledger(write=True) as ledger:
+        ledger["entries"].append(entry)
 
     result = {
         "status": "logged",
@@ -319,7 +400,7 @@ def cmd_log(args):
 
 def cmd_summary(args):
     """Show spending summary for recent days."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     days = args.days or 7
     cutoff = (datetime.now() - timedelta(days=days)).isoformat()
 
@@ -350,7 +431,7 @@ def cmd_summary(args):
 
 def cmd_today(args):
     """Show today's spending."""
-    ledger = _load_ledger()
+    ledger = _ledger_snapshot()
     cfg = _load_config()
     today = _today_str()
     today_entries = [e for e in ledger["entries"] if e["timestamp"].startswith(today)]
@@ -416,23 +497,23 @@ def cmd_reset(args):
         json.dump(result, sys.stdout, indent=2)
         return
 
-    ledger = _load_ledger()
     today = _today_str()
-    today_entries = [e for e in ledger["entries"] if e["timestamp"].startswith(today)]
-    removed_total = sum(e["cost"] for e in today_entries)
-    removed_count = len(today_entries)
+    # One lock across the whole read-modify-write, so a concurrent log is either
+    # cleared by this reset or survives it, never silently discarded.
+    with _locked_ledger(write=True) as ledger:
+        today_entries = [e for e in ledger["entries"] if e["timestamp"].startswith(today)]
+        removed_total = sum(e["cost"] for e in today_entries)
+        removed_count = len(today_entries)
 
-    ledger["entries"] = [e for e in ledger["entries"] if not e["timestamp"].startswith(today)]
+        ledger["entries"] = [e for e in ledger["entries"] if not e["timestamp"].startswith(today)]
 
-    # Immutable audit entry for the reset itself
-    ledger["entries"].append({
-        "timestamp": datetime.now().isoformat(),
-        "endpoint": "_audit_reset",
-        "cost": 0,
-        "note": f"Reset cleared {removed_count} entries totaling ${removed_total:.4f}",
-    })
-
-    _save_ledger(ledger)
+        # Immutable audit entry for the reset itself
+        ledger["entries"].append({
+            "timestamp": datetime.now().isoformat(),
+            "endpoint": "_audit_reset",
+            "cost": 0,
+            "note": f"Reset cleared {removed_count} entries totaling ${removed_total:.4f}",
+        })
 
     result = {
         "status": "reset",
@@ -492,7 +573,13 @@ def main():
         "config": cmd_config,
         "reset": cmd_reset,
     }
-    dispatch[args.command](args)
+    try:
+        dispatch[args.command](args)
+    except LedgerError as exc:
+        # Fail closed and loudly. Callers parse stdout as JSON, so keep the
+        # contract even on the error path.
+        json.dump({"status": "error", "message": str(exc)}, sys.stdout, indent=2)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/dataforseo_costs.py
+++ b/scripts/dataforseo_costs.py
@@ -27,6 +27,7 @@ Security fixes: config path corrected to ~/.config/claude-seo/
 
 import argparse
 import json
+import os
 import sys
 import tempfile
 from contextlib import contextmanager

--- a/scripts/domain_history.py
+++ b/scripts/domain_history.py
@@ -68,7 +68,6 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 from url_safety import URLSafetyError, validate_url_strict  # noqa: E402
 
-
 _DATE_LABELS = {
     "created": (
         "creation date", "created on", "registered on", "registered",

--- a/scripts/domain_history.py
+++ b/scripts/domain_history.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import socket
@@ -61,6 +62,12 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from typing import Optional
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+from url_safety import URLSafetyError, validate_url_strict  # noqa: E402
+
 
 _DATE_LABELS = {
     "created": (
@@ -124,8 +131,23 @@ def _socket_whois(domain: str) -> Optional[str]:
         return iana_text
 
     referral = m.group(1).strip()
+
+    # The referral host is attacker-influenceable: WHOIS runs unencrypted on
+    # port 43, so anyone able to tamper with the IANA response can inject a
+    # `refer:` line pointing at an internal address, turning this fallback into
+    # a port-43 probe of the operator's private network. Resolve and validate
+    # it through the same guard every other outbound call uses, then connect to
+    # the pinned address so the answer cannot be re-pointed after the check.
+    # WHOIS is plaintext with no SNI, so dialling the IP directly is lossless.
     try:
-        with socket.create_connection((referral, 43), timeout=10) as sock:
+        _, pinned_ip = validate_url_strict(f"https://{referral}/")
+    except URLSafetyError:
+        # A referral we cannot vouch for is not worth following. IANA's own
+        # answer is still useful, so return that rather than nothing.
+        return iana_text
+
+    try:
+        with socket.create_connection((pinned_ip, 43), timeout=10) as sock:
             sock.sendall(f"{domain}\r\n".encode("ascii"))
             buf = b""
             while True:

--- a/scripts/pagespeed_check.py
+++ b/scripts/pagespeed_check.py
@@ -155,7 +155,12 @@ def run_pagespeed(
     # Lighthouse scores
     lr = data.get("lighthouseResult", {})
     for cat_key, cat_data in lr.get("categories", {}).items():
-        result["lighthouse_scores"][cat_key] = round(cat_data.get("score", 0) * 100)
+        # Lighthouse emits score: null for categories it could not evaluate
+        # (scoreDisplayMode "error"/"notApplicable"). Skip them rather than
+        # multiplying None, and rather than reporting a misleading 0/100.
+        cat_score = cat_data.get("score")
+        if cat_score is not None:
+            result["lighthouse_scores"][cat_key] = round(cat_score * 100)
 
     # Lab metrics from Lighthouse audits
     audits = lr.get("audits", {})

--- a/scripts/preload_check.py
+++ b/scripts/preload_check.py
@@ -46,6 +46,12 @@ Result JSON::
       "score": 0..100,
       "recommendations": ["…"]
     }
+
+Exit status::
+
+    0  analysis completed (a low score is a finding, not a failed run)
+    1  score below ``--fail-under N`` (opt-in gate, off by default)
+    2  URL refused by url_safety
 """
 
 from __future__ import annotations
@@ -195,6 +201,14 @@ def main() -> int:
     )
     parser.add_argument("url")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--fail-under",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Exit 1 if the score is below N. Off by default: a successful "
+             "run exits 0 whatever the score.",
+    )
     args = parser.parse_args()
 
     try:
@@ -228,7 +242,9 @@ def main() -> int:
             for r in result["recommendations"]:
                 print(f"  - {r}")
 
-    return 0 if result["score"] >= 75 else 1
+    if args.fail_under is not None and result["score"] < args.fail_under:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/runtime.py
+++ b/scripts/runtime.py
@@ -2,8 +2,11 @@
 """Cross-platform runtime for Claude SEO's bundled Python scripts.
 
 This module deliberately uses only the Python standard library. It is launched
-by ``bin/claude-seo`` under a base Python, then dispatches work through the
-managed virtual environment created by ``setup``.
+by the sibling ``scripts/claude-seo`` launcher under a base Python, then
+dispatches work through the managed virtual environment created by ``setup``.
+Skills, agents, and hooks invoke that launcher as
+``"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo"``; the repository keeps no
+top-level ``bin/`` directory because hosted marketplaces reject one.
 """
 
 from __future__ import annotations

--- a/scripts/seo_updates.py
+++ b/scripts/seo_updates.py
@@ -31,6 +31,14 @@ from typing import Iterable
 _DATA_FILE = Path(__file__).resolve().parents[1] / "data" / "google-updates.json"
 
 
+# Every kind the ledger schema accepts. tests/test_content_quality.py asserts the
+# ledger only uses these, and the CLI --kind filter accepts exactly the same set.
+KNOWN_KINDS = (
+    "core", "spam", "core+spam", "policy", "qrg", "product", "schema", "cwv",
+    "discover", "documentation",
+)
+
+
 def _load() -> dict:
     with _DATA_FILE.open() as fh:
         return json.load(fh)
@@ -70,7 +78,7 @@ def main() -> int:
     parser.add_argument(
         "--kind",
         action="append",
-        choices=("core", "spam", "core+spam", "policy", "qrg", "product", "schema", "cwv", "discover"),
+        choices=KNOWN_KINDS,
         help="Filter to one or more kinds (repeatable).",
     )
     parser.add_argument(

--- a/scripts/url_safety.py
+++ b/scripts/url_safety.py
@@ -180,20 +180,30 @@ def _reject_authority_confusion(url: str, parsed) -> None:
         raise URLSafetyError("URL fragment/userinfo confusion refused")
 
 
+# RFC 6598 shared address space (carrier-grade NAT). Not in ``is_private``
+# on any supported Python, yet never publicly routable: Alibaba Cloud serves
+# its instance metadata at 100.100.100.200, and Tailscale/WireGuard meshes
+# hand out 100.64/10 addresses for internal services.
+_SHARED_ADDRESS_SPACE = ipaddress.ip_network("100.64.0.0/10")
+
+
 def is_safe_ip(ip_str: str) -> bool:
     """Return True iff ``ip_str`` is a public unicast address.
 
-    Handles IPv4-mapped IPv6 (``::ffff:127.0.0.1`` correctly returns False
-    because Python 3.9+'s ``ipaddress`` propagates ``is_loopback`` /
-    ``is_private`` through IPv4-mapped form). IPv6 unique-local
-    (``fc00::/7``) and link-local (``fe80::/10``) are also rejected.
+    IPv4-mapped IPv6 (``::ffff:127.0.0.1``) is unwrapped and judged as the
+    embedded IPv4 address, so every IPv4 rule below applies to it too.
+    IPv6 unique-local (``fc00::/7``) and link-local (``fe80::/10``) are
+    also rejected.
     """
     try:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
         return False
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
     return not (
         ip.is_private
+        or (ip.version == 4 and ip in _SHARED_ADDRESS_SPACE)
         or ip.is_loopback
         or ip.is_reserved
         or ip.is_link_local

--- a/scripts/validate_backlink_report.py
+++ b/scripts/validate_backlink_report.py
@@ -234,6 +234,102 @@ def validate_health_score(scoring_factors: dict) -> list:
     return issues
 
 
+# Sources that can support a numeric backlink health score. Common Crawl is
+# deliberately absent: it provides rank/presence signals only, not the
+# referring-domain quality, anchor, or toxicity data a score implies.
+SCOREABLE_SOURCES = ("moz_data", "bing_data", "dataforseo_data")
+
+# Finding sources that mean "we did not measure this".
+UNMEASURED_SOURCES = ("not-assessed", "not_assessed")
+
+
+def _is_numeric_score(value) -> bool:
+    """True when value is a real number (bool excluded) or a numeric string."""
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value.strip())
+        except (TypeError, ValueError):
+            return False
+        return True
+    return False
+
+
+def _scoreable_sources_present(report_data: dict) -> list:
+    """Return the scoreable sources that actually carry data in this report."""
+    present = []
+    for key in SCOREABLE_SOURCES:
+        value = report_data.get(key)
+        if isinstance(value, dict):
+            if value and not value.get("error"):
+                present.append(key)
+        elif value:
+            present.append(key)
+    return present
+
+
+def validate_source_score_consistency(report_data: dict) -> list:
+    """Enforce: never emit a numeric score for data that was not measured.
+
+    Two failure modes, both observed in real audits despite the instruction
+    already existing in the skill:
+
+    1. Common Crawl is the only source available, but a numeric health score is
+       still produced.
+    2. A finding is marked `source: not-assessed` yet carries a score.
+    """
+    issues = []
+
+    scoring_factors = report_data.get("scoring_factors") or {}
+    score = scoring_factors.get("score") if isinstance(scoring_factors, dict) else None
+
+    scoreable = _scoreable_sources_present(report_data)
+    has_cc = bool(report_data.get("cc_data"))
+
+    if _is_numeric_score(score) and not scoreable:
+        detail = (
+            "Common Crawl was the only source available"
+            if has_cc else "no backlink data source was available"
+        )
+        issues.append({
+            "severity": "error",
+            "field": "health_score",
+            "message": (
+                f"Numeric score ({score}) produced when {detail}. Common Crawl "
+                "supplies rank/presence signals only and MUST NOT be scored. "
+                "Report 'Not Assessed' with no numeric value."
+            ),
+            "fix": "Set the score to null and report Not Assessed.",
+        })
+
+    findings = report_data.get("findings")
+    if isinstance(findings, list):
+        for i, finding in enumerate(findings):
+            if not isinstance(finding, dict):
+                continue
+            source = str(finding.get("source", "")).strip().lower()
+            if source not in UNMEASURED_SOURCES:
+                continue
+            for field in ("score", "value", "health_score"):
+                if _is_numeric_score(finding.get(field)):
+                    issues.append({
+                        "severity": "error",
+                        "field": f"findings[{i}].{field}",
+                        "message": (
+                            f"Finding '{finding.get('title', 'untitled')}' is "
+                            f"source: not-assessed but carries a numeric "
+                            f"{field} ({finding[field]}). A not-assessed finding "
+                            "MUST NOT be scored."
+                        ),
+                        "fix": f"Omit {field} or set it to null.",
+                    })
+
+    return issues
+
+
 def validate_report(report_data: dict) -> dict:
     """
     Run all validations on a backlink report.
@@ -266,6 +362,10 @@ def validate_report(report_data: dict) -> dict:
     if report_data.get("scoring_factors"):
         all_issues.extend(validate_health_score(report_data["scoring_factors"]))
 
+    # Always run: this gate must fire even when the agent supplies no
+    # scoring_factors block at all.
+    all_issues.extend(validate_source_score_consistency(report_data))
+
     # Classify
     errors = [i for i in all_issues if i["severity"] == "error"]
     warnings = [i for i in all_issues if i["severity"] == "warning"]
@@ -288,6 +388,7 @@ def validate_report(report_data: dict) -> dict:
             "checks_run": [
                 "schema_claims", "verification_results", "h1_claims",
                 "cc_claims", "reciprocal_links", "health_score",
+                "source_score_consistency",
             ],
         },
     }

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 ## Process
 
-1. **Render homepage**: use `claude-seo run render_page.py <url> --mode auto --json` to capture raw HTML, rendered HTML, extracted text, SPA status, and accessibility data when needed
+1. **Render homepage**: use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto --json` to capture raw HTML, rendered HTML, extracted text, SPA status, and accessibility data when needed
 2. **Detect business type**: analyze homepage signals per seo orchestrator
 3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt
 4. **Delegate to subagents** (if available, otherwise run inline sequentially):
@@ -27,11 +27,11 @@ metadata:
    - `seo-geo` -- AI crawler access, llms.txt, citability, brand mention signals
    - `seo-local` -- GBP signals, NAP consistency, reviews, local schema, industry-specific local factors (spawn when Local Service industry detected: brick-and-mortar, SAB, or hybrid business type)
    - `seo-maps` -- Geo-grid rank tracking, GBP audit, review intelligence, competitor radius mapping (spawn when Local Service detected AND DataForSEO MCP available)
-   - `seo-google` -- CWV field data (CrUX), URL indexation (GSC), organic traffic (GA4) (spawn when Google API credentials detected via `claude-seo run google_auth.py --check`)
-   - `seo-backlinks` -- Backlink profile data: DA/PA, referring domains, anchor text, toxic links (spawn when Moz or Bing API credentials detected via `claude-seo run backlinks_auth.py --check`, or always include Common Crawl domain-level metrics)
+   - `seo-google` -- CWV field data (CrUX), URL indexation (GSC), organic traffic (GA4) (spawn when Google API credentials detected via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check`)
+   - `seo-backlinks` -- Backlink profile data: DA/PA, referring domains, anchor text, toxic links (spawn when Moz or Bing API credentials detected via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check`, or always include Common Crawl domain-level metrics)
    - `seo-cluster` -- Semantic clustering analysis (spawn when content strategy signals detected: blog, pillar pages, topic clusters)
    - `seo-sxo` -- Search experience analysis: page-type mismatch, user stories, persona scoring (always include in full audits)
-   - `seo-drift` -- Drift analysis: compare against stored baseline (spawn when drift baseline exists for the URL via `claude-seo run drift_history.py <url>`)
+   - `seo-drift` -- Drift analysis: compare against stored baseline (spawn when drift baseline exists for the URL via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>`)
    - `seo-ecommerce` -- Product schema, marketplace intelligence (spawn when E-commerce industry detected)
 5. **Score** -- aggregate into SEO Health Score (0-100)
 6. **Persist audit artifacts** -- write all outputs under `{domain}-audit/`
@@ -55,11 +55,11 @@ Delay between requests: 1 second
 - `{domain}-audit/audit-data.json`: Structured audit envelope for report generation
 - `{domain}-audit/findings/*.md`: Per-category specialist findings (`technical.md`, `content.md`, `schema.md`, `performance.md`, `visual.md`, etc.)
 - `{domain}-audit/screenshots/`: Desktop + mobile captures (if Playwright available)
-- **PDF Report** (recommended): Generate a professional A4 PDF using `claude-seo run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/`. This produces a white-cover enterprise report with TOC, executive summary, charts (Lighthouse gauges, query bars, index donut), metric cards, threshold tables, prioritized recommendations with effort estimates, and implementation roadmap. Always offer PDF generation after completing an audit.
+- **PDF Report** (recommended): Generate a professional A4 PDF using `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/`. This produces a white-cover enterprise report with TOC, executive summary, charts (Lighthouse gauges, query bars, index donut), metric cards, threshold tables, prioritized recommendations with effort estimates, and implementation roadmap. Always offer PDF generation after completing an audit.
 
 ## Structured Audit Data Envelope
 
-Write `{domain}-audit/audit-data.json` with this shape so `claude-seo run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/` can generate a report even when Google API data is unavailable:
+Write `{domain}-audit/audit-data.json` with this shape so `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type full --data {domain}-audit/audit-data.json --domain <domain> --output-dir {domain}-audit/` can generate a report even when Google API data is unavailable:
 
 ```json
 {
@@ -170,7 +170,7 @@ If DataForSEO MCP tools are available, spawn the `seo-dataforseo` agent alongsid
 
 ## Google API Integration (Optional)
 
-If Google API credentials are configured (`claude-seo run google_auth.py --check`), spawn the `seo-google` agent to enrich the audit with real Google field data: CrUX Core Web Vitals (replaces lab-only estimates), GSC URL indexation status, search performance (clicks, impressions, CTR), and GA4 organic traffic trends. The Performance (CWV) category score benefits most from field data.
+If Google API credentials are configured (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check`), spawn the `seo-google` agent to enrich the audit with real Google field data: CrUX Core Web Vitals (replaces lab-only estimates), GSC URL indexation status, search performance (clicks, impressions, CTR), and GA4 organic traffic trends. The Performance (CWV) category score benefits most from field data.
 
 ## Error Handling
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Free: Common Crawl + verify always available. Optional: Moz API, Bing Webmaster (free signup). Premium: DataForSEO extension."
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -184,9 +184,40 @@ Calculate a 0-100 score. When mixing sources, apply confidence weighting:
   Show individual factor scores that ARE available with their source and confidence.
   Recommend: "Configure Moz API (free) for a scoreable profile. Run `/seo backlinks setup`"
 
-When only CC is available, do not produce a numeric score; report low-confidence rank/presence data only.
-A numeric score with fewer than 4 data sources is **misleading**, it implies poor health when
-the reality is we simply lack data.
+### MUST NOT: score what you did not measure
+
+**When Common Crawl is the only available source, you MUST NOT produce a numeric
+score of any kind** -- not a health score, not a per-factor score, not an
+"approximate" or "estimated" figure. Common Crawl supplies rank and presence
+signals only. Report low-confidence rank/presence data and the literal string
+`Not Assessed` in place of every number.
+
+**A finding written with `source: not-assessed` MUST NOT carry a numeric score.**
+
+A numeric score with fewer than 4 data sources is **misleading**: it implies poor
+health when the reality is that we simply lack data.
+
+### Validation gate (required, not optional)
+
+This rule has been stated in this skill before and was violated anyway, so it is
+now checkable. **Before writing any backlink output, run the validator:**
+
+```bash
+claude-seo run validate_backlink_report.py --report <report>.json --json
+```
+
+Pass the sources you actually collected (`cc_data`, `moz_data`, `bing_data`,
+`dataforseo_data`, `scoring_factors`, and your `findings` list). The
+`source_score_consistency` check fails the report with `status: FAIL` when:
+
+- a numeric score is present but no scoreable source (Moz, Bing, or DataForSEO)
+  supplied data -- i.e. the Common-Crawl-only case, and
+- any finding marked `source: not-assessed` carries a numeric `score`, `value`,
+  or `health_score`.
+
+**If the validator returns `status: FAIL`, do not present the report.** Fix the
+findings -- replace the offending numbers with `Not Assessed` -- and re-run until
+it passes.
 
 ## Output Format
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -18,12 +18,12 @@ metadata:
 Before analysis, detect available data sources:
 
 1. **DataForSEO MCP** (premium): Check if `dataforseo_backlinks_summary` tool is available
-2. **Moz API** (free signup): `claude-seo run backlinks_auth.py --check moz --json`
-3. **Bing Webmaster** (free signup): `claude-seo run backlinks_auth.py --check bing --json`
+2. **Moz API** (free signup): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check moz --json`
+3. **Bing Webmaster** (free signup): `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check bing --json`
 4. **Common Crawl** (always available): Domain-level graph with PageRank
 5. **Verification Crawler** (always available): Checks if known backlinks still exist
 
-Run `claude-seo run backlinks_auth.py --check --json` to detect all sources at once.
+Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check --json` to detect all sources at once.
 
 If no sources are configured beyond the always-available tier:
 - Still produce a report using Common Crawl domain metrics
@@ -48,9 +48,9 @@ Produce all 7 sections below. Each section lists data sources in preference orde
 
 **DataForSEO:** `dataforseo_backlinks_summary` → total backlinks, referring domains, domain rank, follow ratio, trend.
 
-**Moz API:** `claude-seo run moz_api.py metrics <url> --json` → Domain Authority, Page Authority, Spam Score, linking root domains, external links.
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json` → Domain Authority, Page Authority, Spam Score, linking root domains, external links.
 
-**Common Crawl:** `claude-seo run commoncrawl_graph.py <domain> --json` → PageRank, harmonic centrality, and low-confidence rank/presence data.
+**Common Crawl:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py <domain> --json` → PageRank, harmonic centrality, and low-confidence rank/presence data.
 
 **Scoring:**
 
@@ -65,9 +65,9 @@ Produce all 7 sections below. Each section lists data sources in preference orde
 
 **DataForSEO:** `dataforseo_backlinks_anchors`
 
-**Moz API:** `claude-seo run moz_api.py anchors <url> --json`
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py anchors <url> --json`
 
-**Bing Webmaster:** `claude-seo run bing_webmaster.py links <url> --json` (extract anchor text from link details)
+**Bing Webmaster:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py links <url> --json` (extract anchor text from link details)
 
 **Healthy distribution benchmarks:**
 
@@ -86,9 +86,9 @@ Flag if exact-match anchors exceed 15% as a review heuristic; it may indicate un
 
 **DataForSEO:** `dataforseo_backlinks_referring_domains`
 
-**Moz API:** `claude-seo run moz_api.py domains <url> --json` → domains with DA scores
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py domains <url> --json` → domains with DA scores
 
-**Common Crawl:** `claude-seo run commoncrawl_graph.py <domain> --json` → domain-level rank/presence data, no verified referring-domain counts
+**Common Crawl:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py <domain> --json` → domain-level rank/presence data, no verified referring-domain counts
 
 Analyze:
 - **TLD distribution**: .edu, .gov, .org = high authority. Excessive .xyz, .info = low quality
@@ -100,9 +100,9 @@ Analyze:
 
 **DataForSEO:** `dataforseo_backlinks_bulk_spam_score` + toxic patterns from reference
 
-**Moz API:** Raw vendor spam_score from `claude-seo run moz_api.py metrics <url> --json` (source-label the value; apply thresholds only if verified against current Moz docs)
+**Moz API:** Raw vendor spam_score from `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json` (source-label the value; apply thresholds only if verified against current Moz docs)
 
-**Verification Crawler:** `claude-seo run verify_backlinks.py --target <url> --links <file> --json` (verify suspicious links still exist)
+**Verification Crawler:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py --target <url> --links <file> --json` (verify suspicious links still exist)
 
 **High-risk indicators (flag immediately):**
 - Links from known PBN (Private Blog Network) domains
@@ -124,7 +124,7 @@ Load `../seo/references/backlink-quality.md` for the full 30 toxic patterns and 
 
 **DataForSEO:** `dataforseo_backlinks_backlinks` with target type "page"
 
-**Moz API:** `claude-seo run moz_api.py pages <domain> --json`
+**Moz API:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py pages <domain> --json`
 
 Find:
 - Which pages attract the most backlinks
@@ -136,11 +136,11 @@ Find:
 
 **DataForSEO:** `dataforseo_backlinks_referring_domains` for both domains, then compare
 
-**Bing Webmaster:** `claude-seo run bing_webmaster.py compare <url1> <url2> --json`
+**Bing Webmaster:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py compare <url1> <url2> --json`
 only when both properties are registered and accessible to the same Bing API
 account. For arbitrary competitors, use DataForSEO, Moz, or Common Crawl.
 
-**Moz API:** Compare DA/PA between domains via `claude-seo run moz_api.py metrics <url> --json` for each
+**Moz API:** Compare DA/PA between domains via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py metrics <url> --json` for each
 
 Output:
 - Domains linking to competitor but NOT to target = link building opportunities
@@ -152,7 +152,7 @@ Output:
 
 **DataForSEO only:** `dataforseo_backlinks_backlinks` with date filters for 30/60/90 day changes
 
-**Verification Crawler:** For known links, verify current status with `claude-seo run verify_backlinks.py --target <url> --links <file> --json`
+**Verification Crawler:** For known links, verify current status with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py --target <url> --links <file> --json`
 
 **Note:** Free sources cannot track new/lost links over time. If this section is requested without DataForSEO, inform the user: "Link velocity tracking requires the DataForSEO extension. Free sources provide point-in-time snapshots only."
 

--- a/skills/seo-backlinks/SKILL.md
+++ b/skills/seo-backlinks/SKILL.md
@@ -203,7 +203,7 @@ This rule has been stated in this skill before and was violated anyway, so it is
 now checkable. **Before writing any backlink output, run the validator:**
 
 ```bash
-claude-seo run validate_backlink_report.py --report <report>.json --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run validate_backlink_report.py --report <report>.json --json
 ```
 
 Pass the sources you actually collected (`cc_data`, `moz_data`, `bing_data`,

--- a/skills/seo-cluster/SKILL.md
+++ b/skills/seo-cluster/SKILL.md
@@ -14,7 +14,7 @@ license: MIT
 metadata:
   author: AgriciDaniel
   original_author: "Lutfiya Miller (Pro Hub Challenge Winner)"
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-cluster/SKILL.md
+++ b/skills/seo-cluster/SKILL.md
@@ -80,7 +80,7 @@ the full algorithm.
 - Skip pairs where both are long-tail variants of the same head term (assume same cluster)
 
 **DataForSEO integration:** If DataForSEO MCP is available, use `serp_organic_live_advanced`
-instead of WebSearch for SERP data. Run `claude-seo run dataforseo_costs.py check serp_organic_live_advanced --count N`
+instead of WebSearch for SERP data. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check serp_organic_live_advanced --count N`
 before each batch. If `"status": "needs_approval"`, show cost estimate and ask user.
 If `"status": "blocked"`, fall back to WebSearch.
 
@@ -312,7 +312,7 @@ After cluster planning or execution completes, offer:
 
 ## Security
 
-- All URLs fetched via `claude-seo run render_page.py <url> --mode auto` (SPA-aware SSRF protection via `url_safety`)
+- All URLs fetched via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto` (SPA-aware SSRF protection via `url_safety`)
 - No credentials stored or transmitted
 - Output files contain no PII or API keys
 - DataForSEO cost checks run before every API call

--- a/skills/seo-competitor-pages/SKILL.md
+++ b/skills/seo-competitor-pages/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[url or generate] [competitor]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-content/SKILL.md
+++ b/skills/seo-content/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-dataforseo/SKILL.md
+++ b/skills/seo-dataforseo/SKILL.md
@@ -48,7 +48,7 @@ DataForSEO charges per API call. Be efficient:
 
 **Before every DataForSEO MCP call**, run cost estimation:
 ```
-claude-seo run dataforseo_costs.py check <endpoint> [--count N]
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]
 ```
 
 - If `"status": "approved"` → proceed with the API call
@@ -57,7 +57,7 @@ claude-seo run dataforseo_costs.py check <endpoint> [--count N]
 
 **After each API call completes**, log the cost:
 ```
-claude-seo run dataforseo_costs.py log <endpoint> <actual_cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <actual_cost>
 ```
 
 **User commands for cost management:**

--- a/skills/seo-dataforseo/SKILL.md
+++ b/skills/seo-dataforseo/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 compatibility: "Requires DataForSEO MCP server"
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-dataforseo/references/cost-tiers.md
+++ b/skills/seo-dataforseo/references/cost-tiers.md
@@ -31,7 +31,7 @@
 | **Aggressive** | $50.00 | $2.00 | threshold | Agency bulk work |
 | **Unlimited** | $999.00 | -- | none | Trusted pipelines |
 
-Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
+Configure with: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py config --mode threshold --threshold 0.50 --daily-limit 10.00`
 
 ## Cost Reduction Tips
 
@@ -44,11 +44,11 @@ Configure with: `claude-seo run dataforseo_costs.py config --mode threshold --th
 ## Approval Flow
 
 Before any DataForSEO MCP call:
-1. Run `claude-seo run dataforseo_costs.py check <endpoint> [--count N]`
+1. Run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check <endpoint> [--count N]`
 2. If `status: "approved"` → proceed
 3. If `status: "needs_approval"` → show cost to user, ask to confirm
 4. If `status: "blocked"` → inform user daily limit would be exceeded
-5. After call completes, log: `claude-seo run dataforseo_costs.py log <endpoint> <cost>`
+5. After call completes, log: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log <endpoint> <cost>`
 
 ## Warn Endpoints
 

--- a/skills/seo-drift/SKILL.md
+++ b/skills/seo-drift/SKILL.md
@@ -12,7 +12,7 @@ license: MIT
 metadata:
   author: AgriciDaniel
   original_author: "Dan Colta (Pro Hub Challenge)"
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-drift/SKILL.md
+++ b/skills/seo-drift/SKILL.md
@@ -95,16 +95,16 @@ Captures the current state of a page and stores it.
 
 **Steps:**
 1. Validate URL (SSRF protection via `google_auth.validate_url()`)
-2. Fetch page via `claude-seo run fetch_page.py <URL>`
-3. Parse HTML via `claude-seo run parse_html.py <URL>`
-4. Optionally fetch CWV via `claude-seo run pagespeed_check.py <URL>` (use `--skip-cwv` to skip)
+2. Fetch page via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run fetch_page.py <URL>`
+3. Parse HTML via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py <URL>`
+4. Optionally fetch CWV via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <URL>` (use `--skip-cwv` to skip)
 5. Hash HTML body and schema content (SHA-256)
 6. Store snapshot in SQLite
 
 **Execution:**
 ```bash
-claude-seo run drift_baseline.py <url>
-claude-seo run drift_baseline.py <url> --skip-cwv
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_baseline.py <url>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_baseline.py <url> --skip-cwv
 ```
 
 **Output:** JSON with baseline ID, timestamp, URL, and summary of captured elements.
@@ -126,16 +126,16 @@ Fetches the current page state and diffs it against the most recent baseline.
 
 **Execution:**
 ```bash
-claude-seo run drift_compare.py <url>
-claude-seo run drift_compare.py <url> --baseline-id 5
-claude-seo run drift_compare.py <url> --skip-cwv
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url> --baseline-id 5
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_compare.py <url> --skip-cwv
 ```
 
 **Output:** JSON with all triggered rules, old/new values, severity, and actions.
 
 After comparison, offer to generate an HTML report:
 ```bash
-claude-seo run drift_report.py <comparison_json_file> --output drift-report.html
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_report.py <comparison_json_file> --output drift-report.html
 ```
 
 ---
@@ -146,8 +146,8 @@ Shows all baselines and comparisons for a URL.
 
 **Execution:**
 ```bash
-claude-seo run drift_history.py <url>
-claude-seo run drift_history.py <url> --limit 10
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url> --limit 10
 ```
 
 **Output:** JSON array of baselines (newest first) with timestamps and comparison summaries.
@@ -187,7 +187,7 @@ When drift is detected, recommend the appropriate specialized skill:
 
 ## Security
 
-- **All URL fetching** goes through `claude-seo run fetch_page.py`, which enforces SSRF protection
+- **All URL fetching** goes through `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run fetch_page.py`, which enforces SSRF protection
   (blocks private IPs, loopback, reserved ranges, GCP metadata endpoints)
 - **No curl, no subprocess HTTP calls** -- only the project's validated fetch pipeline
 - **All SQLite queries** use parameterized placeholders (`?`), never string interpolation

--- a/skills/seo-ecommerce/SKILL.md
+++ b/skills/seo-ecommerce/SKILL.md
@@ -14,7 +14,7 @@ compatibility: "Enhanced with DataForSEO Merchant API (optional)"
 metadata:
   author: AgriciDaniel
   original_author: "Matej Marjanovic (Pro Hub Challenge)"
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-ecommerce/SKILL.md
+++ b/skills/seo-ecommerce/SKILL.md
@@ -42,8 +42,8 @@ Fetch and parse any product page for on-page SEO quality.
 ### Workflow
 
 ```
-1. claude-seo run render_page.py <url> --mode auto → raw/rendered HTML
-2. claude-seo run parse_html.py --url <url>   → SEO elements
+1. "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto → raw/rendered HTML
+2. "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py --url <url>   → SEO elements
 3. Analyze product-specific signals (below)
 ```
 
@@ -107,7 +107,7 @@ Live competitive analysis from Google Shopping results.
 
 Before EVERY Merchant API call:
 ```bash
-claude-seo run dataforseo_costs.py check merchant_google_products_search
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check merchant_google_products_search
 ```
 
 - `"status": "approved"` -- proceed
@@ -116,20 +116,20 @@ claude-seo run dataforseo_costs.py check merchant_google_products_search
 
 After each call:
 ```bash
-claude-seo run dataforseo_costs.py log merchant_google_products_search <cost>
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py log merchant_google_products_search <cost>
 ```
 
 ### Workflow
 
 ```bash
 # Product search: who sells what at what price
-claude-seo run dataforseo_merchant.py search "<keyword>" --marketplace google
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py search "<keyword>" --marketplace google
 
 # Seller analysis: merchant ratings and dominance
-claude-seo run dataforseo_merchant.py sellers "<keyword>"
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py sellers "<keyword>"
 
 # Normalize results for analysis
-claude-seo run dataforseo_normalize.py results.json --module merchant
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_normalize.py results.json --module merchant
 ```
 
 ### Analysis Outputs
@@ -163,7 +163,7 @@ Cross-marketplace intelligence comparing Google Shopping and Amazon.
 ### Cost Guardrail (MANDATORY)
 
 ```bash
-claude-seo run dataforseo_costs.py check merchant_amazon_products_search
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_costs.py check merchant_amazon_products_search
 ```
 
 Amazon endpoints are in the `warn_endpoints` set -- always requires user approval.
@@ -172,10 +172,10 @@ Amazon endpoints are in the `warn_endpoints` set -- always requires user approva
 
 ```bash
 # Amazon product search
-claude-seo run dataforseo_merchant.py search "<keyword>" --marketplace amazon
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py search "<keyword>" --marketplace amazon
 
 # Cross-marketplace comparison
-claude-seo run dataforseo_merchant.py compare "<keyword>"
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_merchant.py compare "<keyword>"
 ```
 
 ### Cross-Marketplace Report
@@ -327,10 +327,10 @@ capability examples, and the relationship to AP2 (Agent Payments Protocol).
 
 ```bash
 # Discover and validate the UCP profile
-claude-seo run ucp_check.py https://store.example.com --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ucp_check.py https://store.example.com --json
 
 # With endpoint reachability probes (HEAD each declared capability)
-claude-seo run ucp_check.py https://store.example.com --probe-endpoints --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ucp_check.py https://store.example.com --probe-endpoints --json
 ```
 
 The script returns: profile presence, version, declared capabilities,

--- a/skills/seo-ecommerce/references/marketplace-endpoints.md
+++ b/skills/seo-ecommerce/references/marketplace-endpoints.md
@@ -110,7 +110,7 @@ When consuming responses, normalize:
 | Rating | Integer or float | Float rounded to 1 decimal |
 | Reviews | String or int | Integer |
 
-Use `claude-seo run dataforseo_normalize.py --module merchant` for automatic normalization.
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run dataforseo_normalize.py --module merchant` for automatic normalization.
 
 ## Cost Reference
 

--- a/skills/seo-flow/SKILL.md
+++ b/skills/seo-flow/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[stage] [url|topic]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-flow/SKILL.md
+++ b/skills/seo-flow/SKILL.md
@@ -82,7 +82,7 @@ Load prompt files on demand, only for the stage the user requests.
 2. Display the full index: all 41 prompts with stage, name, trigger conditions
 
 ### On `/seo flow sync`
-1. Run: `claude-seo run sync_flow.py`
+1. Run: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sync_flow.py`
 2. Display the JSON summary (files added, updated, unchanged)
 3. Show attribution notice after sync completes
 

--- a/skills/seo-geo/SKILL.md
+++ b/skills/seo-geo/SKILL.md
@@ -13,7 +13,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-google/SKILL.md
+++ b/skills/seo-google/SKILL.md
@@ -29,7 +29,7 @@ service account -- run `/seo google setup` for step-by-step instructions.
 
 Before executing any command, check credentials:
 ```bash
-claude-seo run google_auth.py --check --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check --json
 ```
 
 Config file: `~/.config/claude-seo/google-api.json`
@@ -89,7 +89,7 @@ Always communicate the detected tier before running commands.
 
 Combined Lighthouse lab data + CrUX field data.
 
-**Script:** `claude-seo run pagespeed_check.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json`
 **Reference:** `references/pagespeed-crux-api.md`
 **Default:** Both mobile + desktop strategies, all Lighthouse categories.
 
@@ -100,13 +100,13 @@ Chrome user metrics). CrUX tries URL-level first, falls back to origin-level.
 
 CrUX field data only (no Lighthouse run). Faster.
 
-**Script:** `claude-seo run pagespeed_check.py <url> --crux-only --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --crux-only --json`
 
 ### `/seo google crux-history <url>`
 
 25-week CrUX History trends. Shows whether CWV metrics are improving, stable, or degrading.
 
-**Script:** `claude-seo run crux_history.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py <url> --json`
 **Reference:** `references/pagespeed-crux-api.md`
 
 Output includes per-metric trend direction, percentage change, and weekly p75 values.
@@ -119,7 +119,7 @@ Output includes per-metric trend direction, percentage change, and weekly p75 va
 
 Search Analytics: clicks, impressions, CTR, position for last 28 days.
 
-**Script:** `claude-seo run gsc_query.py --property <property> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py --property <property> --json`
 **Reference:** `references/search-console-api.md`
 **Default:** 28 days, dimensions=query,page, type=web, limit=1000.
 
@@ -145,7 +145,7 @@ dimension rows, not the size of every pagination request.
 
 URL Inspection: real indexation status from Google.
 
-**Script:** `claude-seo run gsc_inspect.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py <url> --json`
 
 Returns: verdict (PASS/FAIL), coverage state, robots.txt status, indexing state,
 page fetch state, canonical selection, mobile usability, rich results.
@@ -154,7 +154,7 @@ page fetch state, canonical selection, mobile usability, rich results.
 
 Batch inspection from a file (one URL per line). Rate limited to 2,000/day per site.
 
-**Script:** `claude-seo run gsc_inspect.py --batch <file> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py --batch <file> --json`
 
 ### `/seo google sitemaps <property>`
 
@@ -162,7 +162,7 @@ List submitted sitemaps with status, errors, warnings. Sitemap contents report
 submitted counts only; URL Inspection API is the indexation truth for whether
 specific URLs are indexed.
 
-**Script:** `claude-seo run gsc_query.py sitemaps --property <property> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_query.py sitemaps --property <property> --json`
 
 ---
 
@@ -172,7 +172,7 @@ specific URLs are indexed.
 
 Notify Google of a URL update.
 
-**Script:** `claude-seo run indexing_notify.py <url> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexing_notify.py <url> --json`
 **Reference:** `references/indexing-api.md`
 
 The Indexing API is officially for JobPosting and BroadcastEvent/VideoObject pages.
@@ -182,7 +182,7 @@ Always inform the user of this restriction. Daily quota: 200 publish requests.
 
 Batch submit URLs from a file. Tracks quota usage.
 
-**Script:** `claude-seo run indexing_notify.py --batch <file> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run indexing_notify.py --batch <file> --json`
 
 ---
 
@@ -192,7 +192,7 @@ Batch submit URLs from a file. Tracks quota usage.
 
 Organic traffic report: daily sessions, users, pageviews, bounce rate, engagement.
 
-**Script:** `claude-seo run ga4_report.py --property <id> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --json`
 **Reference:** `references/ga4-data-api.md`
 **Default:** 28 days, filtered to Organic Search channel group.
 
@@ -202,7 +202,7 @@ Organic traffic report: daily sessions, users, pageviews, bounce rate, engagemen
 
 Top organic landing pages ranked by sessions.
 
-**Script:** `claude-seo run ga4_report.py --property <id> --report top-pages --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run ga4_report.py --property <id> --report top-pages --json`
 
 ---
 
@@ -214,7 +214,7 @@ Some third-party studies report a 0.737 correlation between YouTube mentions and
 
 Search YouTube for videos. Returns title, channel, views, likes, duration.
 
-**Script:** `claude-seo run youtube_search.py search "<query>" --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run youtube_search.py search "<query>" --json`
 **Reference:** `references/youtube-api.md`
 **Quota:** 100 units per search (10,000 units/day free).
 
@@ -222,7 +222,7 @@ Search YouTube for videos. Returns title, channel, views, likes, duration.
 
 Detailed video info + tags + top 10 comments.
 
-**Script:** `claude-seo run youtube_search.py video <video_id> --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run youtube_search.py video <video_id> --json`
 **Quota:** 2 units (video details + comments).
 
 ---
@@ -235,7 +235,7 @@ Google NLP entity/sentiment output for internal content-quality checks. Do not t
 
 Full NLP analysis: entities, sentiment, content classification.
 
-**Script:** `claude-seo run nlp_analyze.py --url <url> --json` or `--text "..."`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run nlp_analyze.py --url <url> --json` or `--text "..."`
 **Reference:** `references/nlp-api.md`
 **Free tier:** 5,000 units/month. Requires billing enabled on GCP project.
 
@@ -243,7 +243,7 @@ Full NLP analysis: entities, sentiment, content classification.
 
 Entity extraction only (faster, less quota).
 
-**Script:** `claude-seo run nlp_analyze.py --url <url> --features entities --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run nlp_analyze.py --url <url> --features entities --json`
 
 ---
 
@@ -255,7 +255,7 @@ Gold-standard keyword volume data. Requires Google Ads account.
 
 Generate keyword ideas from seed terms.
 
-**Script:** `claude-seo run keyword_planner.py ideas "<seed>" --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run keyword_planner.py ideas "<seed>" --json`
 **Reference:** `references/keyword-planner-api.md`
 **Requires:** Ads developer token + customer ID in config (Tier 3).
 
@@ -263,7 +263,7 @@ Generate keyword ideas from seed terms.
 
 Search volume for specific keywords (comma-separated).
 
-**Script:** `claude-seo run keyword_planner.py volume "<kw1>,<kw2>" --json`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run keyword_planner.py volume "<kw1>,<kw2>" --json`
 
 ---
 
@@ -296,7 +296,7 @@ After any analysis command, offer to generate a PDF/HTML report.
 
 Generate a professional PDF report with charts and analytics.
 
-**Script:** `claude-seo run google_report.py --type <type> --data <json> --domain <domain> --format pdf`
+**Script:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type <type> --data <json> --domain <domain> --format pdf`
 
 | Type | Input | Output |
 |------|-------|--------|
@@ -307,8 +307,8 @@ Generate a professional PDF report with charts and analytics.
 
 **Workflow:**
 1. Run data collection commands (pagespeed, gsc, inspect-batch, etc.)
-2. Save JSON output to file: `claude-seo run pagespeed_check.py <url> --json > data.json`
-3. Generate report: `claude-seo run google_report.py --type cwv-audit --data data.json --domain <domain>`
+2. Save JSON output to file: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json > data.json`
+3. Generate report: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py --type cwv-audit --data data.json --domain <domain>`
 
 **Convention:** After completing analysis, suggest: "Generate a report? Use `/seo google report <type>`"
 

--- a/skills/seo-google/SKILL.md
+++ b/skills/seo-google/SKILL.md
@@ -12,7 +12,7 @@ argument-hint: "[command] [url|property]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-google/references/auth-setup.md
+++ b/skills/seo-google/references/auth-setup.md
@@ -106,7 +106,7 @@ Save to `~/.config/claude-seo/google-api.json`:
 ## Step 8: Verify Setup
 
 ```bash
-claude-seo run google_auth.py --check
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check
 ```
 
 Expected output at Tier 2 (full):

--- a/skills/seo-hreflang/SKILL.md
+++ b/skills/seo-hreflang/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-hreflang/references/machine-translation-qa.md
+++ b/skills/seo-hreflang/references/machine-translation-qa.md
@@ -42,7 +42,7 @@ content abuse.
 - For per-page hreflang validation, stay inside `seo-hreflang`.
 - For broader scaled-content scoring (entropy of translated pages,
   AI-pattern detection in body), defer to `seo-content` via
-  `claude-seo run content_quality.py`.
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run content_quality.py`.
 - For "is this translated by Google's own auto-translate widget"
   detection, look for the `.goog-te-banner-frame` iframe. There is **no
   per-mechanism exemption**: in June 2025 Google removed the

--- a/skills/seo-image-gen/SKILL.md
+++ b/skills/seo-image-gen/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 compatibility: "Requires nanobanana MCP server"
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-images/SKILL.md
+++ b/skills/seo-images/SKILL.md
@@ -12,7 +12,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-images/SKILL.md
+++ b/skills/seo-images/SKILL.md
@@ -106,7 +106,7 @@ Third-party reporting and Wikipedia describe a Rust-based JPEG XL decoder as shi
 
 #### Detected lazy-loader methods (`lazy_method` field)
 
-`claude-seo run parse_html.py` classifies each image's lazy-loading mechanism via the
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py` classifies each image's lazy-loading mechanism via the
 `lazy_method` field on every image entry. Five values:
 
 | `lazy_method` | Signal detected | Common stack |
@@ -321,13 +321,13 @@ https://support.google.com/merchants/answer/14743464
 
 ```bash
 # Audit a directory for the IPTC label (counts: missing, ai, captured, etc.)
-claude-seo run iptc_ai_label.py audit ./images/ --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run iptc_ai_label.py audit ./images/ --json
 
 # Audit a single image
-claude-seo run iptc_ai_label.py audit ./hero.webp --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run iptc_ai_label.py audit ./hero.webp --json
 
 # Inject the AI label into an image
-claude-seo run iptc_ai_label.py inject ./ai-hero.webp \
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run iptc_ai_label.py inject ./ai-hero.webp \
     --source-type trainedAlgorithmicMedia
 
 # Other vocabulary values:

--- a/skills/seo-local/SKILL.md
+++ b/skills/seo-local/SKILL.md
@@ -13,7 +13,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-maps/SKILL.md
+++ b/skills/seo-maps/SKILL.md
@@ -14,7 +14,7 @@ license: MIT
 compatibility: "DataForSEO MCP for Tier 1+, Google Maps API for Tier 2"
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-page/SKILL.md
+++ b/skills/seo-page/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-plan/SKILL.md
+++ b/skills/seo-plan/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[business-type]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-programmatic/SKILL.md
+++ b/skills/seo-programmatic/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[url or plan]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-schema/SKILL.md
+++ b/skills/seo-schema/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-sitemap/SKILL.md
+++ b/skills/seo-sitemap/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: "[url or generate]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-sitemap/SKILL.md
+++ b/skills/seo-sitemap/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 Discover candidates before reporting a sitemap missing:
 
 ```bash
-claude-seo run sitemap_discovery.py <url> --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <url> --json
 ```
 
 The helper reads every bounded `Sitemap:` declaration in robots.txt, validates

--- a/skills/seo-sxo/SKILL.md
+++ b/skills/seo-sxo/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 metadata:
   author: AgriciDaniel
   original_author: "Florian Schmitz (Pro Hub Challenge)"
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-sxo/SKILL.md
+++ b/skills/seo-sxo/SKILL.md
@@ -43,8 +43,8 @@ well-optimized it is.
 
 ### Step 1: Target Acquisition
 
-1. Fetch the target URL via `claude-seo run render_page.py <URL> --mode auto` (SPA-aware and SSRF-safe)
-2. Parse with `claude-seo run parse_html.py <URL>` to extract: title, H1, meta description,
+1. Fetch the target URL via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto` (SPA-aware and SSRF-safe)
+2. Parse with `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run parse_html.py <URL>` to extract: title, H1, meta description,
    headings hierarchy, word count, schema markup, CTAs, media elements
 3. If no keyword provided, extract primary keyword from title tag + H1 overlap
 4. Validate keyword is non-empty before proceeding
@@ -244,7 +244,7 @@ The SXO score is **separate** from the main SEO Health Score.
 ## Quality Checklist
 
 Before delivering results, verify:
-- [ ] Target URL was fetched via `claude-seo run render_page.py <URL> --mode auto` (not raw curl/fetch)
+- [ ] Target URL was fetched via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto` (not raw curl/fetch)
 - [ ] Page type classification uses taxonomy from references
 - [ ] At least 5 SERP results were analyzed
 - [ ] User stories cite specific SERP signals as evidence

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -136,7 +136,20 @@ Allow: /
 - Check if content visible in initial HTML vs requires JS
 - Identify client-side rendered (CSR) vs server-side rendered (SSR)
 - Flag SPA frameworks (React, Vue, Angular) that may cause indexing issues
-- Verify dynamic rendering setup if applicable
+- If dynamic rendering is detected, flag it as technical debt rather than a valid setup.
+  Google documents it as "a workaround and not a recommended solution" because of the added
+  complexity and resource cost.
+  See https://developers.google.com/search/docs/crawling-indexing/javascript/dynamic-rendering
+
+**Recommended rendering strategy:**
+
+| Strategy | Use Case |
+|----------|----------|
+| **SSR** | Public SEO content, dynamic pages |
+| **SSG** | Static content, blogs, docs |
+| **CSR** | Authenticated / behind-login content only |
+
+**Preferred frameworks:** Next.js, Astro, React Router v7 (Remix), SvelteKit
 
 #### JavaScript SEO: Canonical & Indexing Guidance (December 2025)
 

--- a/skills/seo-technical/SKILL.md
+++ b/skills/seo-technical/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 
 ### 1. Crawlability
 - robots.txt: exists, valid, not blocking important resources
-- XML sitemap: run `claude-seo run sitemap_discovery.py <url> --json`; require a
+- XML sitemap: run `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run sitemap_discovery.py <url> --json`; require a
   valid entry in `found`, and report stale or unsafe robots.txt declarations
   separately from working fallback locations
 - Noindex tags: intentional vs accidental
@@ -189,7 +189,7 @@ It is also available through Lighthouse CLI with
 
 ```bash
 # Render with Playwright + capture accessibility tree, then score
-claude-seo run agent_ux_check.py https://example.com --json
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run agent_ux_check.py https://example.com --json
 ```
 
 The scanner outputs an Agent-UX score (0-100) plus itemized issues:
@@ -201,7 +201,7 @@ The scanner outputs an Agent-UX score (0-100) plus itemized issues:
 The accessibility-tree snapshot uses Chromium's
 `Accessibility.getFullAXTree` CDP command through Playwright. To capture the
 tree without scoring, use
-`claude-seo run render_page.py <url> --a11y-tree --json`.
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --a11y-tree --json`.
 
 Surface findings as **opportunities**, not failures; don't gate audits on a
 sub-100 Agent-UX score. WebMCP origin-trial/sign-up status needs verification,
@@ -235,7 +235,7 @@ If DataForSEO MCP tools are available, use `on_page_instant_pages` for real page
 
 ## Google API Integration (Optional)
 
-If Google API credentials are configured, use `claude-seo run pagespeed_check.py <url> --json` for real PSI + CrUX field data (replaces lab-only CWV estimates), `claude-seo run crux_history.py <url> --json` for 25-week CWV trends, and `claude-seo run gsc_inspect.py <url> --json` for real indexation status per URL.
+If Google API credentials are configured, use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py <url> --json` for real PSI + CrUX field data (replaces lab-only CWV estimates), `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run crux_history.py <url> --json` for 25-week CWV trends, and `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run gsc_inspect.py <url> --json` for real indexation status per URL.
 
 ## Error Handling
 

--- a/skills/seo-technical/references/agent-friendly-pages.md
+++ b/skills/seo-technical/references/agent-friendly-pages.md
@@ -165,9 +165,9 @@ Chrome DevTools and look for:
 - Any `<div>` with `onclick` and no `role` / `tabindex` → custom widget that
   agents won't see.
 
-`claude-seo run render_page.py <URL> --mode auto --a11y-tree --json` loads the
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <URL> --mode auto --a11y-tree --json` loads the
 page headlessly and captures Chromium's full accessibility tree through CDP.
-Use `claude-seo run agent_ux_check.py <URL> --json` for the bounded Agent-UX
+Use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run agent_ux_check.py <URL> --json` for the bounded Agent-UX
 heuristic and its explicit complete, partial, or unavailable score status.
 
 ## Last verified

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[command] [url]"
 license: MIT
 metadata:
   author: AgriciDaniel
-  version: "2.2.5"
+  version: "2.2.6"
   category: seo
 ---
 

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -14,10 +14,15 @@ metadata:
 
 **Invocation:** `/seo $1 $2` where `$1` is the command and `$2` is the URL or argument.
 
-**Runtime:** Run bundled Python tools through `claude-seo run <script.py>`. Plugin
-installs expose this command automatically. Repository users run
-`./bin/claude-seo`; manual installers rewrite the command to the isolated
-launcher path. Never invoke bundled scripts with a bare Python interpreter.
+**Runtime:** Run bundled Python tools through
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>`. That is the single
+canonical form used by every skill and agent. Claude Code expands
+`${CLAUDE_PLUGIN_ROOT}` to the installed plugin directory, so the launcher is
+found without any `PATH` entry; the repository ships no top-level `bin/`
+directory because hosted marketplaces reject one. Repository users run
+`./scripts/claude-seo`; manual installers rewrite the canonical form to
+`"$HOME/.claude/skills/seo/scripts/claude-seo"`. Never invoke bundled scripts
+with a bare Python interpreter.
 
 Comprehensive SEO analysis across all industries (SaaS, local services,
 e-commerce, publishers, agencies). Orchestrates 24 sub-skills (21 core + 1 framework
@@ -61,25 +66,28 @@ extension is also installable (see "Optional Extensions" below).
 ## Runtime Setup
 
 Run setup only when the user explicitly invokes `/seo setup` or explicitly asks
-to repair dependencies. Execute `claude-seo setup`, report core and Chromium
+to repair dependencies. Execute
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup`, report core and Chromium
 status separately, and do not fall back to global or user package installation.
-For diagnosis, execute `claude-seo doctor --json`; its output intentionally omits
-absolute paths and environment values. If any `claude-seo run` command reports
-that setup is required, suggest `/seo setup` and do not improvise a `pip install`.
+For diagnosis, execute
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor --json`; its output
+intentionally omits absolute paths and environment values. If any
+`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run` command reports that setup is
+required, suggest `/seo setup` and do not improvise a `pip install`.
 
 ## Orchestration Logic
 
 When the user invokes `/seo audit`, delegate to subagents in parallel:
 1. Detect business type (SaaS, local, ecommerce, publisher, agency, other)
 2. Spawn subagents: seo-technical, seo-content, seo-schema, seo-sitemap, seo-performance, seo-visual, seo-geo
-3. If Google API credentials detected (`claude-seo run google_auth.py --check`), also spawn seo-google agent
+3. If Google API credentials detected (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_auth.py --check`), also spawn seo-google agent
 4. If local business detected, also spawn seo-local agent
 5. If local business detected AND DataForSEO MCP available, also spawn seo-maps agent
-6. If backlink APIs detected (`claude-seo run backlinks_auth.py --check`), also spawn seo-backlinks agent
+6. If backlink APIs detected (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run backlinks_auth.py --check`), also spawn seo-backlinks agent
 7. If Firecrawl MCP available, use `firecrawl_map` to discover all site URLs before analysis
 8. If content strategy signals detected (blog, pillar pages, topic clusters), also spawn seo-cluster agent
 9. If e-commerce detected, also spawn seo-ecommerce agent
-10. If drift baseline exists for this URL (`claude-seo run drift_history.py <url>`), also spawn seo-drift agent
+10. If drift baseline exists for this URL (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run drift_history.py <url>`), also spawn seo-drift agent
 11. Always include seo-sxo in full audits (search experience applies to all sites)
 12. Collect results and generate unified report with SEO Health Score (0-100)
 13. **Synthesize via the 10-principle framework** (see "Synthesis Methodology" below), walk PERCEIVE → ANALYZE → VALIDATE → ACT before bucketing findings into Critical / High / Medium / Low
@@ -87,7 +95,7 @@ When the user invokes `/seo audit`, delegate to subagents in parallel:
 15. **Offer PDF report**: "Generate a professional PDF report? Use `/seo google report full`"
 
 For individual commands, load the relevant sub-skill directly.
-After any analysis command completes, offer to generate a PDF report via `claude-seo run google_report.py`.
+After any analysis command completes, offer to generate a PDF report via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py`.
 
 ## Synthesis Methodology
 

--- a/skills/seo/references/free-backlink-sources.md
+++ b/skills/seo/references/free-backlink-sources.md
@@ -30,8 +30,20 @@ When merging data from multiple sources, apply confidence weights to each metric
 weighted_score = Σ(source_score × confidence × factor_weight) / Σ(confidence × factor_weight)
 ```
 
-When only Common Crawl is available, cap the maximum health score at 70/100 and note
-"limited to domain-level metrics" in the report.
+**When only Common Crawl is available, do not produce a health score at all.**
+Not a capped one, not an "approximate" one. Common Crawl supplies domain-level
+rank and presence signals only -- it carries none of the referring-domain quality,
+anchor, or toxicity data a health score claims to summarise, so any number derived
+from it reads as "this profile is weak" when the truth is "we have no data."
+
+Report `Not Assessed` in place of the score, surface the rank/presence data that
+Common Crawl *does* support as low-confidence findings, and note "limited to
+domain-level metrics" in the report. The same applies to any finding written with
+`source: not-assessed`.
+
+This is enforced, not advisory: `claude-seo run validate_backlink_report.py` fails
+a report (`status: FAIL`) that carries a number in either case. See the
+`seo-backlinks` skill's "MUST NOT: score what you did not measure" section.
 
 ## Source Details
 

--- a/skills/seo/references/free-backlink-sources.md
+++ b/skills/seo/references/free-backlink-sources.md
@@ -53,7 +53,7 @@ a report (`status: FAIL`) that carries a number in either case. See the
 - **Signup:** https://moz.com/products/api (credit card required, not charged)
 - **Data:** Domain Authority (0-100), Page Authority, Spam Score (1-17%), link counts,
   referring domains, anchor text distribution
-- **Command:** `claude-seo run moz_api.py`
+- **Command:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run moz_api.py`
 - **Commands:** `metrics`, `domains`, `anchors`, `pages`
 - **Blind spots:** No link velocity, no toxic link patterns beyond Spam Score,
   3-day update lag, smaller index than Ahrefs/Semrush
@@ -66,7 +66,7 @@ a report (`status: FAIL`) that carries a number in either case. See the
   are accessible to the same API account
 - **Data:** Inbound-link source URL, target URL, anchor text, sampled link
   counts, and referring-domain comparison totals
-- **Command:** `claude-seo run bing_webmaster.py`
+- **Command:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run bing_webmaster.py`
 - **Commands:** `links`, `counts`, `compare` (comparison requires both
   properties to be registered to the same API account)
 - **Blind spots:** Only Bing-indexed pages (~15% of web), verified sites only,
@@ -77,7 +77,7 @@ a report (`status: FAIL`) that carries a number in either case. See the
 - **Releases:** Quarterly (e.g., cc-main-2025-18)
 - **No auth needed:** Public data, free to download
 - **Data:** Domain-level in-degree, PageRank, harmonic centrality, referring domains
-- **Command:** `claude-seo run commoncrawl_graph.py`
+- **Command:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run commoncrawl_graph.py`
 - **Cache:** `~/.cache/claude-seo/commoncrawl/` (90-day TTL)
 - **Blind spots:** No anchor text, no page-level data, monthly/quarterly freshness,
   domain-level only (e.g., "nytimes.com links to example.com" but not which page)
@@ -85,7 +85,7 @@ a report (`status: FAIL`) that carries a number in either case. See the
 ### Verification Crawler (Always Available)
 - **No auth needed:** Uses existing fetch_page.py + parse_html.py
 - **Data:** Binary verification (link exists/lost/moved), anchor text, rel attributes
-- **Command:** `claude-seo run verify_backlinks.py`
+- **Command:** `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run verify_backlinks.py`
 - **Input:** JSON file with `[{"source_url": "..."}]` entries
 - **Polite crawling:** 1-second delay between requests to same domain
 - **Best for:** Checking if known backlinks still exist, monitoring link health

--- a/skills/seo/references/free-backlink-sources.md
+++ b/skills/seo/references/free-backlink-sources.md
@@ -41,7 +41,7 @@ Common Crawl *does* support as low-confidence findings, and note "limited to
 domain-level metrics" in the report. The same applies to any finding written with
 `source: not-assessed`.
 
-This is enforced, not advisory: `claude-seo run validate_backlink_report.py` fails
+This is enforced, not advisory: `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run validate_backlink_report.py` fails
 a report (`status: FAIL`) that carries a number in either case. See the
 `seo-backlinks` skill's "MUST NOT: score what you did not measure" section.
 

--- a/skills/seo/references/thinking-framework.md
+++ b/skills/seo/references/thinking-framework.md
@@ -25,12 +25,12 @@ not a recommendation.
 
 Collect signals without interpreting them. For a website audit this means:
 
-- Raw HTML + rendered HTML (via `claude-seo run render_page.py`)
+- Raw HTML + rendered HTML (via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py`)
 - Schema.org markup actually present (via `seo-schema`)
 - SERP visibility for the site's published topics (via `seo-dataforseo` /
   Google APIs when available)
 - Backlink + brand-mention landscape (via `seo-backlinks`)
-- Core Web Vitals field data from CrUX (via `claude-seo run pagespeed_check.py`)
+- Core Web Vitals field data from CrUX (via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run pagespeed_check.py`)
 - AI-search citation patterns (via `seo-geo`)
 - Competitor pages on the target's primary keywords
 
@@ -185,7 +185,7 @@ Stop strategizing. Produce the artifact:
   measurable outcomes.
 - Generated schema JSON-LD ready to paste into the site.
 - A content brief with target keywords, outline, and internal links.
-- A PDF via `claude-seo run google_report.py` when the user asks for one.
+- A PDF via `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run google_report.py` when the user asks for one.
 - The smallest implementation of the highest-leverage recommendation,
   not the full plan.
 

--- a/tests/test_audit_instructions.py
+++ b/tests/test_audit_instructions.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def test_seo_audit_starts_with_render_page_auto() -> None:
     text = (REPO_ROOT / "skills" / "seo-audit" / "SKILL.md").read_text(encoding="utf-8")
     process = text[text.index("## Process"):text.index("## Crawl Configuration")]
-    assert "claude-seo run render_page.py" in process
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py' in process
     assert "python3 scripts/render_page.py" not in process
     assert "--mode auto" in process
     assert "scripts/fetch_page.py` to retrieve HTML" not in process

--- a/tests/test_backlink_score_gate.py
+++ b/tests/test_backlink_score_gate.py
@@ -6,6 +6,7 @@ anyway. These tests pin it to something checkable.
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -108,3 +109,36 @@ def test_source_score_consistency_runs_without_a_scoring_factors_block() -> None
 
     assert result["status"] == "FAIL"
     assert "source_score_consistency" in result["metadata"]["checks_run"]
+
+
+# ─── Repo-wide: no competing instruction to score unmeasured data ───────────
+
+FREE_SOURCES_REF = REPO_ROOT / "skills" / "seo" / "references" / "free-backlink-sources.md"
+
+
+def test_shared_reference_does_not_contradict_the_no_score_rule() -> None:
+    """The reference used to say 'cap the maximum health score at 70/100'.
+
+    That instructed a number in exactly the Common-Crawl-only case the skill
+    forbids, and gave the more actionable of the two competing instructions --
+    the likely reason the rule was violated despite being written down.
+    """
+    text = FREE_SOURCES_REF.read_text(encoding="utf-8")
+    assert "cap the maximum health score" not in text
+    assert "70/100" not in text
+    assert "do not produce a health score at all" in text
+    assert "Not Assessed" in text
+
+
+def test_no_skill_or_reference_instructs_capping_a_score_for_missing_data() -> None:
+    """Guard the whole class, not just the one line that was found."""
+    pattern = re.compile(
+        r"cap\s+(?:the\s+)?(?:maximum\s+)?[a-z ]*score\s+(?:at|to)\s+\d+",
+        re.I,
+    )
+    offenders = []
+    for root in (REPO_ROOT / "skills", REPO_ROOT / "agents"):
+        for path in root.rglob("*.md"):
+            if pattern.search(path.read_text(encoding="utf-8")):
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+    assert not offenders, f"score-capping instruction reintroduced in: {offenders}"

--- a/tests/test_backlink_score_gate.py
+++ b/tests/test_backlink_score_gate.py
@@ -1,0 +1,110 @@
+"""Backlink scoring: never emit a number for data that was not measured.
+
+The rule already existed as prose in the skill and was violated in a real audit
+anyway. These tests pin it to something checkable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = str(REPO_ROOT / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import validate_backlink_report as vbr  # noqa: E402
+
+
+# ─── Backlink score gating ───────────────────────────────────────────────────
+
+BACKLINKS_SKILL = REPO_ROOT / "skills" / "seo-backlinks" / "SKILL.md"
+
+
+def test_backlinks_skill_states_must_not_and_names_the_validator() -> None:
+    text = BACKLINKS_SKILL.read_text(encoding="utf-8")
+    assert "MUST NOT" in text
+    assert "validate_backlink_report.py" in text
+    assert "status: FAIL" in text
+
+
+def test_common_crawl_only_numeric_score_fails_validation() -> None:
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1234, "in_degree": 57},
+        "scoring_factors": {"score": 42, "factors_with_data": 2, "total_factors": 7},
+    })
+
+    assert result["status"] == "FAIL"
+    messages = [i["message"] for i in result["data"]["issues"]]
+    assert any("Common Crawl was the only source available" in m for m in messages)
+
+
+def test_common_crawl_only_without_a_score_passes() -> None:
+    """Not Assessed is the correct output, and it must validate cleanly."""
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1234, "in_degree": 57},
+        "scoring_factors": {"score": None, "factors_with_data": 2, "total_factors": 7},
+        "findings": [
+            {"title": "Backlink profile", "source": "not-assessed", "score": None},
+        ],
+    })
+
+    errors = [i for i in result["data"]["issues"] if i["severity"] == "error"]
+    assert errors == []
+
+
+def test_not_assessed_finding_with_a_numeric_score_fails_validation() -> None:
+    result = vbr.validate_report({
+        "moz_data": {"domain_authority": 30},
+        "findings": [
+            {"title": "Referring domain quality", "source": "not-assessed", "score": 55},
+        ],
+    })
+
+    assert result["status"] == "FAIL"
+    messages = [i["message"] for i in result["data"]["issues"]]
+    assert any("MUST NOT be scored" in m for m in messages)
+
+
+def test_numeric_score_string_is_still_caught() -> None:
+    """A score serialised as a string is the same misleading number."""
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1},
+        "scoring_factors": {"score": "42"},
+    })
+    assert result["status"] == "FAIL"
+
+
+def test_score_is_allowed_once_a_scoreable_source_has_data() -> None:
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1},
+        "moz_data": {"domain_authority": 41},
+        "scoring_factors": {"score": 68, "factors_with_data": 5, "total_factors": 7},
+    })
+
+    errors = [i for i in result["data"]["issues"] if i["severity"] == "error"]
+    assert errors == []
+
+
+def test_errored_source_does_not_count_as_available() -> None:
+    """A Moz call that failed must not unlock scoring."""
+    result = vbr.validate_report({
+        "cc_data": {"rank": 1},
+        "moz_data": {"error": "401 unauthorized"},
+        "scoring_factors": {"score": 68},
+    })
+
+    assert result["status"] == "FAIL"
+
+
+def test_source_score_consistency_runs_without_a_scoring_factors_block() -> None:
+    """The gate must fire even when the agent omits scoring_factors entirely."""
+    result = vbr.validate_report({
+        "findings": [
+            {"title": "Anchor text", "source": "not-assessed", "health_score": 12},
+        ],
+    })
+
+    assert result["status"] == "FAIL"
+    assert "source_score_consistency" in result["metadata"]["checks_run"]

--- a/tests/test_backlink_score_gate.py
+++ b/tests/test_backlink_score_gate.py
@@ -17,7 +17,6 @@ if _SCRIPTS not in sys.path:
 
 import validate_backlink_report as vbr  # noqa: E402
 
-
 # ─── Backlink score gating ───────────────────────────────────────────────────
 
 BACKLINKS_SKILL = REPO_ROOT / "skills" / "seo-backlinks" / "SKILL.md"

--- a/tests/test_banana_cost_tracker.py
+++ b/tests/test_banana_cost_tracker.py
@@ -1,0 +1,217 @@
+"""
+Tests for extensions/banana/scripts/cost_tracker.py — cost-ledger integrity.
+
+Same defect class as tests/test_dataforseo_costs.py, and worse here: this
+ledger had no file locking at all, non-atomic writes, and running aggregates
+(total_cost, total_images, daily) that are incremented alongside each entry.
+A lost write dropped the entry AND its aggregate increments together, so the
+file stayed internally self-consistent while under-reporting spend. Internal
+consistency is therefore not evidence that nothing was lost.
+
+Every test runs against an isolated BANANA_HOME, never the real
+~/.banana/costs.json.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "extensions" / "banana" / "scripts" / "cost_tracker.py"
+
+MODEL = "gemini-3.1-flash-image-preview"
+COST_1K = 0.039
+
+
+def _seed_pricing(home: Path) -> None:
+    """Write the dated pricing config the tracker requires."""
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "pricing.json").write_text(json.dumps({
+        "checked_date": "2026-08-02",
+        "models": {MODEL: {"512": 0.020, "1K": COST_1K, "2K": 0.078, "4K": 0.156}},
+    }))
+
+
+def _run(home: Path, *argv: str) -> subprocess.CompletedProcess:
+    """Invoke the CLI in a subprocess with an isolated ledger."""
+    if not (home / "pricing.json").exists():
+        _seed_pricing(home)
+    env = dict(os.environ)
+    env["BANANA_HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _ledger(home: Path) -> dict:
+    return json.loads((home / "costs.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_logs_do_not_lose_entries(tmp_path) -> None:
+    """20 concurrent `log` calls must produce exactly 20 entries.
+
+    Fails on the pre-fix code, which had no locking whatsoever.
+    """
+    calls = 20
+
+    with ThreadPoolExecutor(max_workers=calls) as pool:
+        results = list(
+            pool.map(
+                lambda i: _run(
+                    tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                    "--prompt", f"call-{i}",
+                ),
+                range(calls),
+            )
+        )
+
+    failed = [r for r in results if r.returncode != 0]
+    assert not failed, f"{len(failed)} log calls failed: {failed[0].stderr}"
+
+    ledger = _ledger(tmp_path)
+    assert len(ledger["entries"]) == calls, (
+        f"lost {calls - len(ledger['entries'])} of {calls} concurrent writes"
+    )
+
+    prompts = sorted(e["prompt"] for e in ledger["entries"])
+    assert prompts == sorted(f"call-{i}" for i in range(calls)), "entries were clobbered"
+
+
+def test_concurrent_logs_keep_aggregates_correct(tmp_path) -> None:
+    """The running aggregates must match the entries after concurrent writes.
+
+    These are the numbers the user actually reads, and they were incremented
+    in the same lost write as the entry itself.
+    """
+    calls = 20
+
+    with ThreadPoolExecutor(max_workers=calls) as pool:
+        list(
+            pool.map(
+                lambda i: _run(
+                    tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                    "--prompt", f"call-{i}",
+                ),
+                range(calls),
+            )
+        )
+
+    ledger = _ledger(tmp_path)
+    assert ledger["total_images"] == calls
+    assert ledger["total_cost"] == pytest.approx(calls * COST_1K, abs=1e-4)
+    assert ledger["total_cost"] == pytest.approx(
+        sum(e["cost"] for e in ledger["entries"]), abs=1e-4
+    )
+
+    daily_count = sum(d["count"] for d in ledger["daily"].values())
+    daily_cost = sum(d["cost"] for d in ledger["daily"].values())
+    assert daily_count == calls
+    assert daily_cost == pytest.approx(calls * COST_1K, abs=1e-4)
+
+
+def test_concurrent_log_and_reset_keep_the_ledger_parseable(tmp_path) -> None:
+    """Interleaved writers must never leave a torn/unparseable ledger."""
+    _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K", "--prompt", "seed")
+
+    def job(i: int) -> subprocess.CompletedProcess:
+        if i % 5 == 4:
+            return _run(tmp_path, "reset", "--confirm")
+        return _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                    "--prompt", f"p{i}")
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        list(pool.map(job, range(10)))
+
+    ledger = _ledger(tmp_path)
+    assert isinstance(ledger["entries"], list)
+    assert _run(tmp_path, "summary").returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# durability
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_ledger_is_not_silently_zeroed(tmp_path) -> None:
+    """A truncated ledger must fail closed, not restart the budget at zero."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ledger = tmp_path / "costs.json"
+    ledger.write_text('{"entries": [{"ts": "2026-01-01T00:00:00", "cos')
+
+    result = _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                  "--prompt", "x")
+    assert result.returncode != 0, "corrupt ledger must not be silently accepted"
+    assert "not valid JSON" in result.stderr
+
+    # Left in place for inspection, not overwritten.
+    assert ledger.read_text().endswith('"cos')
+
+
+def test_reset_recovers_a_corrupt_ledger(tmp_path) -> None:
+    """reset must not depend on the existing file parsing.
+
+    It is the documented recovery path, so requiring a readable ledger first
+    would leave a corrupt ledger unrecoverable through the CLI.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "costs.json").write_text("{ this is not json")
+
+    assert _run(tmp_path, "reset", "--confirm").returncode == 0
+    assert _ledger(tmp_path) == {
+        "total_cost": 0.0, "total_images": 0, "entries": [], "daily": {},
+    }
+
+
+def test_ledger_write_is_atomic_no_temp_files_left(tmp_path) -> None:
+    """The tempfile used for the atomic replace must not accumulate."""
+    for i in range(5):
+        _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+             "--prompt", f"p{i}")
+
+    leftovers = list(tmp_path.glob(".costs.*.tmp"))
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+def test_missing_aggregate_fields_are_tolerated(tmp_path) -> None:
+    """An older ledger without the aggregate keys must still be loggable."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "costs.json").write_text('{"entries": []}')
+
+    assert _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K",
+                "--prompt", "x").returncode == 0
+    ledger = _ledger(tmp_path)
+    assert ledger["total_images"] == 1
+    assert ledger["total_cost"] == pytest.approx(COST_1K)
+
+
+# ---------------------------------------------------------------------------
+# portability guard
+# ---------------------------------------------------------------------------
+
+
+def test_locking_is_never_disabled_unconditionally() -> None:
+    """The tracker must never run the ledger unlocked on any platform."""
+    source = _SCRIPT.read_text()
+    assert "import fcntl" in source and "import msvcrt" in source
+    assert "Refusing to touch the cost ledger unlocked" in source
+
+
+def test_isolated_home_is_honoured(tmp_path) -> None:
+    """Tests must never write to the operator's real ~/.banana ledger."""
+    _run(tmp_path, "log", "--model", MODEL, "--resolution", "1K", "--prompt", "x")
+    assert (tmp_path / "costs.json").exists()

--- a/tests/test_banana_cost_tracker.py
+++ b/tests/test_banana_cost_tracker.py
@@ -1,5 +1,5 @@
 """
-Tests for extensions/banana/scripts/cost_tracker.py — cost-ledger integrity.
+Tests for extensions/banana/scripts/cost_tracker.py: cost-ledger integrity.
 
 Same defect class as tests/test_dataforseo_costs.py, and worse here: this
 ledger had no file locking at all, non-atomic writes, and running aggregates

--- a/tests/test_banana_install_layout.py
+++ b/tests/test_banana_install_layout.py
@@ -17,7 +17,9 @@ def _text(path: Path) -> str:
 
 def _runtime_extension_scripts(text: str) -> set[str]:
     return set(
-        re.findall(r"claude-seo run --extension banana ([A-Za-z0-9_]+\.py)", text)
+        re.findall(
+            r"claude-seo[\"']? run --extension banana ([A-Za-z0-9_]+\.py)", text
+        )
     )
 
 
@@ -49,7 +51,8 @@ def test_standalone_installer_copies_scripts_beside_skill_file():
     installer = _text(EXTENSION / "install.sh")
     assert 'mkdir -p "${SKILL_DIR}/scripts" "${SKILL_DIR}/references"' in installer
     assert 'cp "${SOURCE_DIR}/scripts/"*.py "${SKILL_DIR}/scripts/"' in installer
-    assert '"$HOME/.claude/skills/seo/bin/claude-seo" run' in installer
+    assert '"$HOME/.claude/skills/seo/scripts/claude-seo" run' in installer
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run' in installer
 
 
 def test_top_level_installer_keeps_extension_scripts_under_core_extension_tree():

--- a/tests/test_commoncrawl_graph.py
+++ b/tests/test_commoncrawl_graph.py
@@ -1,0 +1,87 @@
+"""
+Tests for scripts/commoncrawl_graph.py.
+
+Focus: cache-path construction. `--release` reached `_get_cache_path`
+completely unsanitised and the result is opened for writing in `_save_cache`,
+so `--release ../../../../tmp/x` wrote outside the cache directory. The same
+value is also interpolated into a download URL by `_graph_file_url`, so it is
+rejected at the CLI boundary rather than silently rewritten -- otherwise the
+cache key would disagree with what was actually fetched.
+
+No network: only the pure path/validation helpers are exercised.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import commoncrawl_graph as ccg  # noqa: E402
+
+
+def _inside_cache_dir(path: str) -> bool:
+    root = os.path.realpath(ccg.get_cache_dir())
+    resolved = os.path.realpath(path)
+    return resolved == root or resolved.startswith(root + os.sep)
+
+
+# ---------------------------------------------------------------------------
+# path traversal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "domain,release",
+    [
+        ("example.com", "../../../../tmp/pwned"),
+        ("example.com", ".."),
+        ("../../../../tmp/evil", "cc-main-2026-jan-feb-mar"),
+        ("../..", ".."),
+        ("example.com/../../etc", "cc-main-2026-jan-feb-mar"),
+    ],
+)
+def test_cache_path_never_escapes_the_cache_dir(domain, release):
+    assert _inside_cache_dir(ccg._get_cache_path(domain, release, "combined"))
+
+
+def test_cache_path_preserves_legitimate_values():
+    """Sanitising must not mangle real inputs, or every cache miss forever."""
+    path = ccg._get_cache_path("example.com", "cc-main-2026-jan-feb-mar", "combined")
+    assert os.path.basename(path) == "example.com-cc-main-2026-jan-feb-mar-combined.json"
+    assert _inside_cache_dir(path)
+
+
+def test_safe_cache_component_collapses_dot_runs_and_separators():
+    assert ".." not in ccg._safe_cache_component("../../etc/passwd")
+    assert "/" not in ccg._safe_cache_component("a/b/c")
+    assert os.sep not in ccg._safe_cache_component("a\\b")
+    # Never returns empty, which would produce a path like "-release-type.json".
+    assert ccg._safe_cache_component("...") != ""
+    assert ccg._safe_cache_component("") != ""
+
+
+# ---------------------------------------------------------------------------
+# release validation (also guards the URL built by _graph_file_url)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "release",
+    ["cc-main-2026-jan-feb-mar", "cc-main-2024-oct-nov-dec", "CC-MAIN-2024-33", "a_b.c-1"],
+)
+def test_release_pattern_accepts_real_release_ids(release):
+    assert ccg._RELEASE_RE.match(release)
+
+
+@pytest.mark.parametrize(
+    "release",
+    ["../../../../tmp/pwned", "..", "a/../b", "a..b", "with space", "", "a/b", "x\ty"],
+)
+def test_release_pattern_rejects_traversal_and_junk(release):
+    assert not ccg._RELEASE_RE.match(release)

--- a/tests/test_consistency_check.py
+++ b/tests/test_consistency_check.py
@@ -15,6 +15,11 @@ from pathlib import Path
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPT = os.path.join(REPO, "scripts", "consistency_check.py")
+_SCRIPTS = os.path.join(REPO, "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import consistency_check  # noqa: E402
 
 
 def run_checker():
@@ -44,3 +49,41 @@ def test_user_facing_markdown_has_no_raw_core_script_paths():
             for match in pattern.finditer(path.read_text(encoding="utf-8")):
                 offenders.append(f"{path.relative_to(root)}: scripts/{match.group(1)}")
     assert offenders == [], "raw bundled script paths:\n" + "\n".join(offenders)
+
+
+def _locked_paths() -> list:
+    lock = Path(REPO) / consistency_check.LOCK_PATH
+    return [line.split()[1] for line in lock.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.startswith("#")]
+
+
+def _copy_with_crlf(dst: Path, rels: list) -> None:
+    """Mirror ``rels`` under ``dst`` the way core.autocrlf=true checks them out."""
+    for rel in rels:
+        data = (Path(REPO) / rel).read_bytes().replace(b"\r\n", b"\n")
+        target = dst / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data.replace(b"\n", b"\r\n"))
+
+
+def test_flow_lock_accepts_crlf_checkout(tmp_path, monkeypatch):
+    """Git for Windows defaults to core.autocrlf=true, so the locked prompt
+    files check out with CRLF while the lock was written from LF content.
+    Hashing must fold CRLF, or a stock Windows clone reports every locked
+    file as tampered."""
+    locked = _locked_paths()
+    _copy_with_crlf(tmp_path, [consistency_check.LOCK_PATH, *locked])
+    monkeypatch.setattr(consistency_check, "REPO", str(tmp_path))
+    assert consistency_check.check_flow_lock(locked) == []
+
+
+def test_flow_lock_still_detects_content_change(tmp_path, monkeypatch):
+    """Folding CRLF must not weaken the lock: any other change is caught."""
+    locked = _locked_paths()
+    _copy_with_crlf(tmp_path, [consistency_check.LOCK_PATH, *locked])
+    with open(tmp_path / locked[0], "ab") as fh:
+        fh.write(b"tampered\r\n")
+    monkeypatch.setattr(consistency_check, "REPO", str(tmp_path))
+    assert consistency_check.check_flow_lock(locked) == [
+        f"flow lock: hash mismatch {locked[0]}"
+    ]

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -273,6 +273,7 @@ def test_seo_updates_schema_and_order_are_enforced() -> None:
 
     assert dates == sorted(dates), "updates[] must be chronological"
     assert len(names) == len(set(names)), "update names must be unique"
+    assert set(seo_updates.KNOWN_KINDS) == allowed_kinds, "CLI --kind choices drifted from the schema"
     assert all(entry["kind"] in allowed_kinds for entry in updates)
     assert all(entry.get("notes", "").strip() for entry in updates)
     assert all(date.fromisoformat(value) for value in dates)
@@ -317,3 +318,16 @@ def test_seo_updates_filter_by_year() -> None:
     data = seo_updates._load()
     since_2025 = seo_updates._filter(data["updates"], since="2025")
     assert all(u["date"] >= "2025-01-01" for u in since_2025)
+
+
+def test_seo_updates_cli_accepts_every_known_kind() -> None:
+    """`--kind documentation` used to be rejected by argparse while the ledger used it."""
+    import subprocess, sys
+    script = REPO_ROOT / "scripts" / "seo_updates.py" if "REPO_ROOT" in globals() else Path(__file__).resolve().parents[1] / "scripts" / "seo_updates.py"
+    for kind in seo_updates.KNOWN_KINDS:
+        result = subprocess.run(
+            [sys.executable, str(script), "--kind", kind, "--json", "--limit", "1"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, f"--kind {kind} failed: {result.stderr}"
+        json.loads(result.stdout)

--- a/tests/test_content_quality.py
+++ b/tests/test_content_quality.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from datetime import date
 from pathlib import Path
@@ -322,8 +323,7 @@ def test_seo_updates_filter_by_year() -> None:
 
 def test_seo_updates_cli_accepts_every_known_kind() -> None:
     """`--kind documentation` used to be rejected by argparse while the ledger used it."""
-    import subprocess, sys
-    script = REPO_ROOT / "scripts" / "seo_updates.py" if "REPO_ROOT" in globals() else Path(__file__).resolve().parents[1] / "scripts" / "seo_updates.py"
+    script = Path(__file__).resolve().parents[1] / "scripts" / "seo_updates.py"
     for kind in seo_updates.KNOWN_KINDS:
         result = subprocess.run(
             [sys.executable, str(script), "--kind", kind, "--json", "--limit", "1"],

--- a/tests/test_dataforseo_costs.py
+++ b/tests/test_dataforseo_costs.py
@@ -1,0 +1,171 @@
+"""
+Tests for scripts/dataforseo_costs.py — spend-ledger integrity.
+
+Regression cover for the lost-update race: the ledger used to take its file
+lock twice, once to read and once to write, and drop it in between, so two
+concurrent `log` calls both read the same ledger and the second overwrote the
+first. A budget ledger that quietly under-reports spend is the one thing it
+must not do.
+
+Every test runs against an isolated CLAUDE_SEO_CONFIG_DIR, never the real
+~/.config/claude-seo/ ledger.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO / "scripts" / "dataforseo_costs.py"
+
+
+def _run(config_dir: Path, *argv: str) -> subprocess.CompletedProcess:
+    """Invoke the CLI in a subprocess with an isolated ledger."""
+    env = dict(os.environ)
+    env["CLAUDE_SEO_CONFIG_DIR"] = str(config_dir)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _entries(config_dir: Path) -> list[dict]:
+    return json.loads((config_dir / "dataforseo-ledger.json").read_text())["entries"]
+
+
+# ---------------------------------------------------------------------------
+# concurrency — the reported bug
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_logs_do_not_lose_entries(tmp_path) -> None:
+    """20 concurrent `log` calls must produce exactly 20 entries.
+
+    Fails on the pre-fix code, which loses entries whenever two processes
+    interleave their read-modify-write.
+    """
+    calls = 20
+    unit_cost = 0.01
+
+    with ThreadPoolExecutor(max_workers=calls) as pool:
+        results = list(
+            pool.map(
+                lambda i: _run(
+                    tmp_path, "log", "serp_organic_live_advanced", str(unit_cost),
+                    "--note", f"call-{i}",
+                ),
+                range(calls),
+            )
+        )
+
+    failed = [r for r in results if r.returncode != 0]
+    assert not failed, f"{len(failed)} log calls failed: {failed[0].stderr}"
+
+    entries = _entries(tmp_path)
+    assert len(entries) == calls, (
+        f"lost {calls - len(entries)} of {calls} concurrent writes"
+    )
+
+    notes = sorted(e["note"] for e in entries)
+    assert notes == sorted(f"call-{i}" for i in range(calls)), "entries were clobbered"
+
+    total = sum(e["cost"] for e in entries)
+    assert total == pytest.approx(calls * unit_cost), "recorded spend under-reports"
+
+
+def test_concurrent_log_and_reset_keep_the_ledger_parseable(tmp_path) -> None:
+    """Interleaved writers must never leave a torn/unparseable ledger."""
+    _run(tmp_path, "log", "serp_organic_live_advanced", "0.01")
+
+    def job(i: int) -> subprocess.CompletedProcess:
+        if i % 5 == 4:
+            return _run(tmp_path, "reset", "--confirm")
+        return _run(tmp_path, "log", "serp_organic_live_advanced", "0.01")
+
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        list(pool.map(job, range(10)))
+
+    # The ledger must still be valid JSON with an entries list. Which entries
+    # survive depends on reset ordering; that the file parses is the invariant.
+    entries = _entries(tmp_path)
+    assert isinstance(entries, list)
+
+    result = json.loads(_run(tmp_path, "today").stdout)
+    assert result["status"] == "today"
+
+
+# ---------------------------------------------------------------------------
+# durability
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_ledger_is_not_silently_zeroed(tmp_path) -> None:
+    """A truncated ledger must fail closed, not restart the budget at zero.
+
+    The old code caught JSONDecodeError and returned {"entries": []}, so the
+    next write persisted an empty ledger and the entire spend history vanished.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    ledger = tmp_path / "dataforseo-ledger.json"
+    ledger.write_text('{"entries": [{"timestamp": "2026-01-01T00:00:00", "cos')
+
+    result = _run(tmp_path, "log", "serp_organic_live_advanced", "0.01")
+    assert result.returncode != 0, "corrupt ledger must not be silently accepted"
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "error"
+    assert "not valid JSON" in payload["message"]
+
+    # The damaged file is left in place for inspection, not overwritten.
+    assert ledger.read_text().endswith('"cos')
+
+
+def test_today_totals_survive_a_write(tmp_path) -> None:
+    """Basic round trip: logged spend is reflected in `today`."""
+    _run(tmp_path, "log", "on_page_lighthouse", "0.02")
+    _run(tmp_path, "log", "on_page_lighthouse", "0.03")
+
+    payload = json.loads(_run(tmp_path, "today").stdout)
+    assert payload["total_usd"] == pytest.approx(0.05)
+    assert payload["calls"] == 2
+
+
+def test_ledger_write_is_atomic_no_temp_files_left(tmp_path) -> None:
+    """The tempfile used for the atomic replace must not accumulate."""
+    for _ in range(5):
+        _run(tmp_path, "log", "on_page_lighthouse", "0.02")
+
+    leftovers = list(tmp_path.glob(".dataforseo-ledger.*.tmp"))
+    assert leftovers == [], f"temp files left behind: {leftovers}"
+
+
+# ---------------------------------------------------------------------------
+# portability guard
+# ---------------------------------------------------------------------------
+
+
+def test_locking_is_never_disabled_unconditionally() -> None:
+    """Guard against the `fcntl = None` regression.
+
+    The module previously ran with no locking at all on Windows. It must now
+    fall back to msvcrt and, failing that, refuse to touch the ledger.
+    """
+    source = _SCRIPT.read_text()
+    assert "import msvcrt" in source, "no Windows locking fallback"
+    assert "Refusing to touch the spend ledger unlocked" in source, (
+        "module must fail closed when no locking primitive is available"
+    )
+
+
+def test_isolated_config_dir_is_honoured(tmp_path) -> None:
+    """Tests must never write to the operator's real ledger."""
+    _run(tmp_path, "log", "on_page_lighthouse", "0.02")
+    assert (tmp_path / "dataforseo-ledger.json").exists()

--- a/tests/test_dataforseo_costs.py
+++ b/tests/test_dataforseo_costs.py
@@ -1,5 +1,5 @@
 """
-Tests for scripts/dataforseo_costs.py — spend-ledger integrity.
+Tests for scripts/dataforseo_costs.py: spend-ledger integrity.
 
 Regression cover for the lost-update race: the ledger used to take its file
 lock twice, once to read and once to write, and drop it in between, so two
@@ -43,7 +43,7 @@ def _entries(config_dir: Path) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# concurrency — the reported bug
+# concurrency: the reported bug
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_domain_history.py
+++ b/tests/test_domain_history.py
@@ -1,0 +1,106 @@
+"""
+Tests for scripts/domain_history.py.
+
+Focus: the WHOIS referral chain in `_socket_whois`. It asks IANA for the
+authoritative WHOIS server and then connects to whatever host IANA names. WHOIS
+is plaintext on port 43, so anyone able to tamper with that response can inject
+a `refer:` line pointing at an internal address and turn the fallback into a
+port-43 probe of the operator's private network. The referral is now resolved
+and validated through url_safety before being dialled.
+
+No network: socket.create_connection is stubbed throughout.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import domain_history as dh  # noqa: E402
+
+
+class _FakeSock:
+    """Minimal stand-in for a connected socket that yields one payload."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._drained = False
+        self.sent = b""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def sendall(self, data: bytes) -> None:
+        self.sent += data
+
+    def recv(self, _n: int) -> bytes:
+        if self._drained:
+            return b""
+        self._drained = True
+        return self._payload
+
+
+def _stub_chain(monkeypatch, referral_line: bytes, referral_payload: bytes):
+    """Stub the IANA hop and the referral hop, recording every dial."""
+    attempts: list[tuple] = []
+
+    def fake_connection(address, timeout=None):
+        attempts.append(address)
+        if address[0] == "whois.iana.org":
+            return _FakeSock(referral_line)
+        return _FakeSock(referral_payload)
+
+    monkeypatch.setattr(dh.socket, "create_connection", fake_connection)
+    return attempts
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        b"refer: 169.254.169.254\n",   # cloud metadata endpoint
+        b"refer: 127.0.0.1\n",         # loopback
+        b"refer: 10.0.0.5\n",          # RFC1918
+        b"refer: localhost\n",
+    ],
+)
+def test_hostile_referral_is_never_dialled(monkeypatch, hostile):
+    attempts = _stub_chain(monkeypatch, hostile, b"SHOULD NOT BE REACHED\n")
+    result = dh._socket_whois("example.com")
+
+    dialled = [host for host, _port in attempts]
+    assert dialled == ["whois.iana.org"], f"followed a hostile referral: {dialled}"
+    assert "SHOULD NOT BE REACHED" not in (result or "")
+    # IANA's own answer is still returned -- a bad referral degrades the
+    # lookup, it does not blank it.
+    assert "refer:" in (result or "")
+
+
+def test_legitimate_referral_is_still_followed(monkeypatch):
+    """The guard must not break the normal path."""
+    attempts = _stub_chain(
+        monkeypatch,
+        b"refer: whois.verisign-grs.com\n",
+        b"Creation Date: 1995-08-14T04:00:00Z\n",
+    )
+    result = dh._socket_whois("example.com")
+
+    assert len(attempts) == 2, "referral hop did not happen"
+    assert "Creation Date" in (result or "")
+
+
+def test_direct_iana_answer_needs_no_referral(monkeypatch):
+    """.arpa and friends come back without a refer: line."""
+    attempts = _stub_chain(monkeypatch, b"domain: ARPA\nstatus: ACTIVE\n", b"unused")
+    result = dh._socket_whois("in-addr.arpa")
+
+    assert len(attempts) == 1
+    assert "ARPA" in (result or "")

--- a/tests/test_extension_installer_injection.py
+++ b/tests/test_extension_installer_injection.py
@@ -11,6 +11,7 @@ credential-bearing settings file atomically with ``0600`` perms.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -47,6 +48,9 @@ def test_installer_uses_safe_credential_pattern(rel: str, argc: int) -> None:
     assert "0o600" in text, f"{rel} not writing settings with 0600 perms"
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts 0o600 mode bits, which Windows does not represent"
+)
 @pytest.mark.parametrize("rel,argc", INSTALLERS.items())
 def test_installer_credential_injection_is_inert(tmp_path: Path, rel: str, argc: int) -> None:
     writer = _extract_writer((ROOT / rel).read_text(encoding="utf-8"))

--- a/tests/test_gsc_pagination.py
+++ b/tests/test_gsc_pagination.py
@@ -6,8 +6,16 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+# gsc_query calls sys.exit(1) at import time when google-api-python-client is
+# missing. Under pytest that SystemExit escapes collection as an INTERNALERROR
+# and aborts the whole session, so no test in tests/ runs. Skip this module
+# instead when the optional Google stack is absent.
+pytest.importorskip("googleapiclient")
 
 import gsc_query  # noqa: E402
 

--- a/tests/test_gsc_query.py
+++ b/tests/test_gsc_query.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPTS = REPO_ROOT / "scripts"
 if str(_SCRIPTS) not in sys.path:

--- a/tests/test_gsc_query.py
+++ b/tests/test_gsc_query.py
@@ -6,10 +6,19 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPTS = REPO_ROOT / "scripts"
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
+
+# gsc_query calls sys.exit(1) at import time when google-api-python-client is
+# missing. Under pytest that SystemExit escapes collection as an INTERNALERROR
+# and aborts the whole session, so no test in tests/ runs. Skip this module
+# instead when the optional Google stack is absent.
+pytest.importorskip("googleapiclient")
 
 import gsc_query  # noqa: E402
 

--- a/tests/test_gsc_totals_aggregate.py
+++ b/tests/test_gsc_totals_aggregate.py
@@ -9,8 +9,16 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+# gsc_query calls sys.exit(1) at import time when google-api-python-client is
+# missing. Under pytest that SystemExit escapes collection as an INTERNALERROR
+# and aborts the whole session, so no test in tests/ runs. Skip this module
+# instead when the optional Google stack is absent.
+pytest.importorskip("googleapiclient")
 
 import gsc_query  # noqa: E402
 

--- a/tests/test_hosted_plugin_layout.py
+++ b/tests/test_hosted_plugin_layout.py
@@ -15,10 +15,12 @@ installers rewrite that exact token to the absolute installed path.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
-import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 LAUNCHER = ROOT / "scripts" / "claude-seo"
@@ -67,7 +69,9 @@ def test_no_top_level_bin_directory() -> None:
 
 def test_launcher_lives_in_scripts_and_is_executable() -> None:
     assert LAUNCHER.is_file()
-    assert LAUNCHER.stat().st_mode & 0o111, "the launcher must stay executable"
+    if os.name == "posix":
+        # The executable bit is a POSIX mode bit; Windows checkouts have none.
+        assert LAUNCHER.stat().st_mode & 0o111, "the launcher must stay executable"
     text = LAUNCHER.read_text(encoding="utf-8")
     assert 'runtime="${launcher_dir}/runtime.py"' in text, (
         "the launcher must resolve runtime.py as a sibling"
@@ -112,15 +116,13 @@ def test_installers_reference_the_scripts_launcher() -> None:
     assert "bin/claude-seo" not in windows
 
 
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="the launcher is a bash script; Windows installs use install.ps1 and py -3, "
+    "which the manual installer smoke workflow exercises",
+)
 def test_launcher_runs_without_network_or_managed_runtime() -> None:
     """``doctor --help`` is handled by argparse before any venv is touched."""
-    if sys.platform == "win32":
-        import shutil
-
-        if shutil.which("bash") is None:
-            import pytest
-
-            pytest.skip("bash is unavailable on this runner")
     result = subprocess.run(
         ["bash", str(LAUNCHER), "doctor", "--help"],
         capture_output=True,

--- a/tests/test_hosted_plugin_layout.py
+++ b/tests/test_hosted_plugin_layout.py
@@ -1,0 +1,131 @@
+"""Layout contract for the claude.ai-hosted marketplace.
+
+Hosted marketplace sync rejects any plugin that ships a top-level ``bin/``
+directory (``marketplace_sync_bin_directory_not_allowed``). The launcher
+therefore lives in ``scripts/`` beside ``runtime.py``, and every skill, agent,
+and doc invokes it through the documented plugin-relative variable:
+
+    "${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script.py>
+
+Claude Code substitutes ``${CLAUDE_PLUGIN_ROOT}`` in skill body content and in
+``allowed-tools`` Bash rules, and exports it to hook processes. The quoting
+keeps the command correct when the plugin root contains spaces. Manual
+installers rewrite that exact token to the absolute installed path.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "scripts" / "claude-seo"
+CANONICAL = '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo"'
+MANUAL = '"$HOME/.claude/skills/seo/scripts/claude-seo"'
+
+# A bare invocation is ``claude-seo run`` with nothing in front of it. The
+# repository-relative form ``./scripts/claude-seo run`` and the canonical form
+# (which puts a closing quote between the name and the subcommand) do not match.
+BARE_INVOCATION = re.compile(r"(?<![A-Za-z0-9_/])claude-seo (?:run|setup|doctor)\b")
+
+# CHANGELOG.md records the historical bare form in released entries and must
+# keep reading as written.
+DOC_EXCLUSIONS = {"CHANGELOG.md"}
+
+
+def _tracked() -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return out.splitlines()
+
+
+def _instruction_docs() -> list[str]:
+    docs = []
+    for rel in _tracked():
+        if not rel.endswith(".md") or rel in DOC_EXCLUSIONS:
+            continue
+        if rel.startswith(("research/", ".github/", "tests/")):
+            continue
+        if rel.startswith(("skills/", "agents/", "docs/", "extensions/")) or "/" not in rel:
+            docs.append(rel)
+    return docs
+
+
+def test_no_top_level_bin_directory() -> None:
+    assert not (ROOT / "bin").exists(), (
+        "a top-level bin/ directory makes hosted marketplace sync fail with "
+        "marketplace_sync_bin_directory_not_allowed"
+    )
+    assert not any(rel == "bin" or rel.startswith("bin/") for rel in _tracked())
+
+
+def test_launcher_lives_in_scripts_and_is_executable() -> None:
+    assert LAUNCHER.is_file()
+    assert LAUNCHER.stat().st_mode & 0o111, "the launcher must stay executable"
+    text = LAUNCHER.read_text(encoding="utf-8")
+    assert 'runtime="${launcher_dir}/runtime.py"' in text, (
+        "the launcher must resolve runtime.py as a sibling"
+    )
+    assert "/../scripts/" not in text
+
+
+def test_no_instruction_file_keeps_a_bare_launcher_invocation() -> None:
+    offenders = []
+    for rel in _instruction_docs():
+        for match in BARE_INVOCATION.finditer((ROOT / rel).read_text(encoding="utf-8")):
+            offenders.append(f"{rel}: {match.group(0)}")
+    assert not offenders, "bare launcher invocations found: " + "; ".join(offenders)
+
+
+def test_instruction_files_use_the_canonical_plugin_root_form() -> None:
+    carriers = [
+        rel
+        for rel in _instruction_docs()
+        if CANONICAL in (ROOT / rel).read_text(encoding="utf-8")
+    ]
+    assert len(carriers) > 30, "the canonical launcher form should be used repo-wide"
+    assert "skills/seo/SKILL.md" in carriers
+    assert "agents/seo-technical.md" in carriers
+
+
+def test_installers_reference_the_scripts_launcher() -> None:
+    unix = (ROOT / "install.sh").read_text(encoding="utf-8")
+    assert 'cp "${TEMP_DIR}/claude-seo/scripts/claude-seo" "${SKILL_DIR}/scripts/claude-seo"' in unix
+    assert 'chmod +x "${SKILL_DIR}/scripts/claude-seo"' in unix
+    assert '"${SKILL_DIR}/scripts/claude-seo" setup' in unix
+    for subcommand in ("run", "setup", "doctor"):
+        assert f"s#{CANONICAL} {subcommand}#{MANUAL} {subcommand}#g" in unix
+    assert "bin/claude-seo" not in unix
+
+    windows = (ROOT / "install.ps1").read_text(encoding="utf-8")
+    assert "Join-Path $ScriptsPath 'claude-seo'" in windows
+    assert "Join-Path $SkillDir 'scripts'" in windows
+    for subcommand in ("run", "setup", "doctor"):
+        assert f"'{CANONICAL} {subcommand}'" in windows
+        assert f"'{MANUAL} {subcommand}'" in windows
+    assert "bin/claude-seo" not in windows
+
+
+def test_launcher_runs_without_network_or_managed_runtime() -> None:
+    """``doctor --help`` is handled by argparse before any venv is touched."""
+    if sys.platform == "win32":
+        import shutil
+
+        if shutil.which("bash") is None:
+            import pytest
+
+            pytest.skip("bash is unavailable on this runner")
+    result = subprocess.run(
+        ["bash", str(LAUNCHER), "doctor", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "usage: claude-seo doctor" in result.stdout

--- a/tests/test_pagespeed_null_category_score.py
+++ b/tests/test_pagespeed_null_category_score.py
@@ -1,0 +1,65 @@
+"""Lighthouse emits `score: null` for categories it could not evaluate
+(scoreDisplayMode "error" or "notApplicable"). `cat_data.get("score", 0)`
+only defaults on a *missing* key, so an explicit null reached the multiply
+and raised TypeError, losing the whole PSI run — including the categories
+that did score.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import pagespeed_check  # noqa: E402
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _psi_payload():
+    return {
+        "analysisUTCTimestamp": "2026-08-29T00:00:00.000Z",
+        "lighthouseResult": {
+            "categories": {
+                "performance": {"score": 0.91},
+                "accessibility": {"score": None},  # not evaluated
+                "seo": {"score": 0.5},
+            },
+            "audits": {},
+        },
+    }
+
+
+def test_null_category_score_does_not_crash_the_run():
+    with mock.patch.object(
+        pagespeed_check.requests, "get", return_value=_Response(_psi_payload())
+    ):
+        result = pagespeed_check.run_pagespeed("https://example.com")
+
+    assert result["error"] is None, result["error"]
+    assert result["lighthouse_scores"]["performance"] == 91
+    assert result["lighthouse_scores"]["seo"] == 50
+
+
+def test_unscored_category_is_omitted_not_reported_as_zero():
+    with mock.patch.object(
+        pagespeed_check.requests, "get", return_value=_Response(_psi_payload())
+    ):
+        result = pagespeed_check.run_pagespeed("https://example.com")
+
+    # A category Lighthouse refused to score is absent, not a 0/100 failure.
+    assert "accessibility" not in result["lighthouse_scores"], result["lighthouse_scores"]

--- a/tests/test_pagespeed_null_category_score.py
+++ b/tests/test_pagespeed_null_category_score.py
@@ -1,7 +1,7 @@
 """Lighthouse emits `score: null` for categories it could not evaluate
 (scoreDisplayMode "error" or "notApplicable"). `cat_data.get("score", 0)`
 only defaults on a *missing* key, so an explicit null reached the multiply
-and raised TypeError, losing the whole PSI run — including the categories
+and raised TypeError, losing the whole PSI run: including the categories
 that did score.
 """
 

--- a/tests/test_parasite_risk_and_extensions.py
+++ b/tests/test_parasite_risk_and_extensions.py
@@ -7,6 +7,7 @@ Tests for the v2 Checkpoint 5 deliverables:
 
 from __future__ import annotations
 
+import os
 import stat
 import sys
 from pathlib import Path
@@ -122,6 +123,12 @@ def test_extension_has_install_skill_and_docs(name: str, skill_dir: str) -> None
     )
 
 
+_POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix", reason="the executable bit is a POSIX mode bit; Windows has none"
+)
+
+
+@_POSIX_ONLY
 @pytest.mark.parametrize(
     "name", ["ahrefs", "seranking", "profound", "bing-webmaster", "unlighthouse"],
 )
@@ -131,6 +138,7 @@ def test_extension_install_script_is_executable(name: str) -> None:
     assert mode & stat.S_IXUSR, f"{name}/install.sh must be executable for chmod"
 
 
+@_POSIX_ONLY
 def test_every_extension_install_and_uninstall_is_executable() -> None:
     """All extensions ship executable install.sh + uninstall.sh — including v1 ones."""
     ext_root = _REPO_ROOT / "extensions"

--- a/tests/test_pyproject_metadata.py
+++ b/tests/test_pyproject_metadata.py
@@ -32,6 +32,6 @@ def test_requirements_accept_selected_security_compatibility_floors() -> None:
     assert re.search(r"^lxml>=6\.1\.1,<7\.0\.0", text, re.MULTILINE)
     assert re.search(r"^lxml_html_clean>=0\.4\.3,<1\.0\.0", text, re.MULTILINE)
     assert re.search(r"^urllib3>=2\.7\.0,<3\.0\.0", text, re.MULTILINE)
-    assert re.search(r"^numpy>=1\.26\.0,<3\.0\.0", text, re.MULTILINE)
+    assert re.search(r"^numpy>=2\.2\.6,<3\.0\.0", text, re.MULTILINE)
     assert re.search(r"^google-auth-httplib2>=0\.4\.0,<1\.0\.0", text, re.MULTILINE)
     assert re.search(r"^google-ads>=25\.0\.0,<40\.0\.0", text, re.MULTILINE)

--- a/tests/test_runtime_installers.py
+++ b/tests/test_runtime_installers.py
@@ -10,12 +10,12 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_unix_installer_delegates_to_runtime_without_global_pip() -> None:
     text = (ROOT / "install.sh").read_text(encoding="utf-8")
-    assert '"${SKILL_DIR}/bin/claude-seo" setup' in text
+    assert '"${SKILL_DIR}/scripts/claude-seo" setup' in text
     assert "pip install --user" not in text
     assert "python3 -m venv" not in text
-    assert "claude-seo run" in text
-    assert "claude-seo setup" in text
-    assert "claude-seo doctor" in text
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run' in text
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" setup' in text
+    assert '"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" doctor' in text
     assert '"${runtime_status}" -ne 0 ] && [ "${runtime_status}" -ne 10' in text
     assert 'find "${HOME}/.claude/skills"' not in text
 
@@ -36,11 +36,11 @@ def test_windows_installer_delegates_to_runtime_without_path_mutation() -> None:
     os.name != "posix", reason="the executable bit is a POSIX mode bit; Windows has none"
 )
 def test_launcher_is_executable() -> None:
-    assert (ROOT / "bin/claude-seo").stat().st_mode & 0o100
+    assert (ROOT / "scripts/claude-seo").stat().st_mode & 0o100
 
 
 def test_launcher_uses_safe_exec() -> None:
-    text = (ROOT / "bin/claude-seo").read_text(encoding="utf-8")
+    text = (ROOT / "scripts/claude-seo").read_text(encoding="utf-8")
     assert 'exec py -3 "${runtime}" "$@"' in text
     assert 'exec python3 "${runtime}" "$@"' in text
     assert 'exec python "${runtime}" "$@"' in text

--- a/tests/test_runtime_installers.py
+++ b/tests/test_runtime_installers.py
@@ -1,6 +1,9 @@
 """Static installer/runtime contract checks that do not mutate a real home."""
 
+import os
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -29,10 +32,15 @@ def test_windows_installer_delegates_to_runtime_without_path_mutation() -> None:
     assert "-Directory -Filter 'seo*'" not in text
 
 
-def test_launcher_is_executable_and_uses_safe_exec() -> None:
-    launcher = ROOT / "bin/claude-seo"
-    assert launcher.stat().st_mode & 0o100
-    text = launcher.read_text(encoding="utf-8")
+@pytest.mark.skipif(
+    os.name != "posix", reason="the executable bit is a POSIX mode bit; Windows has none"
+)
+def test_launcher_is_executable() -> None:
+    assert (ROOT / "bin/claude-seo").stat().st_mode & 0o100
+
+
+def test_launcher_uses_safe_exec() -> None:
+    text = (ROOT / "bin/claude-seo").read_text(encoding="utf-8")
     assert 'exec py -3 "${runtime}" "$@"' in text
     assert 'exec python3 "${runtime}" "$@"' in text
     assert 'exec python "${runtime}" "$@"' in text

--- a/tests/test_schema_hook_policy.py
+++ b/tests/test_schema_hook_policy.py
@@ -63,7 +63,10 @@ def test_graph_members_inherit_context_but_still_require_type(tmp_path: Path) ->
         "@context": "https://schema.org",
         "@graph": [{"name": "Missing type"}],
     }
-    result = _run_payload(tmp_path, payload, capture_output=True, text=True)
+    # The hook forces UTF-8 on its own stdout (_configure_utf8); decode with the
+    # same codec, not the locale default, which is cp1252 on Windows and cannot
+    # represent the emoji markers.
+    result = _run_payload(tmp_path, payload, capture_output=True, encoding="utf-8")
     assert result.returncode == 1
     assert "Missing @type" in result.stdout
     assert "Missing @context" not in result.stdout
@@ -82,7 +85,7 @@ def test_non_object_graph_members_are_reported_without_crashing(tmp_path: Path) 
         "@context": "https://schema.org",
         "@graph": ["not-a-node", 42],
     }
-    result = _run_payload(tmp_path, payload, capture_output=True, text=True)
+    result = _run_payload(tmp_path, payload, capture_output=True, encoding="utf-8")
     assert result.returncode == 1
     assert "@graph member 1 must be an object" in result.stdout
     assert "@graph member 2 must be an object" in result.stdout
@@ -93,7 +96,7 @@ def test_graph_must_be_a_list(tmp_path: Path) -> None:
         "@context": "https://schema.org",
         "@graph": {"@type": "Organization"},
     }
-    result = _run_payload(tmp_path, payload, capture_output=True, text=True)
+    result = _run_payload(tmp_path, payload, capture_output=True, encoding="utf-8")
     assert result.returncode == 1
     assert "@graph must be a list" in result.stdout
 

--- a/tests/test_sitemap_discovery.py
+++ b/tests/test_sitemap_discovery.py
@@ -6,8 +6,14 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
+
+# sitemap_discovery imports lxml at module scope. Without it the collection
+# error interrupts the whole pytest session, so skip this module instead.
+pytest.importorskip("lxml")
 
 import sitemap_discovery as discovery  # noqa: E402
 

--- a/tests/test_sync_flow.py
+++ b/tests/test_sync_flow.py
@@ -2,15 +2,27 @@
 
 import importlib.util as _ilu
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "sync_flow.py"
 REF_DIR = REPO_ROOT / "skills" / "seo-flow" / "references"
 
+# The dry run calls the live GitHub API. Unauthenticated parallel runs hit 429
+# and 403 rate limits, so these tests only run when explicitly enabled; CI sets
+# the flag together with GH_TOKEN.
+network = pytest.mark.skipif(
+    not os.environ.get("CLAUDE_SEO_NETWORK_TESTS"),
+    reason="live GitHub API call; set CLAUDE_SEO_NETWORK_TESTS=1 to run",
+)
 
+
+@network
 def test_dry_run_exits_zero():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--dry-run"],
@@ -19,6 +31,7 @@ def test_dry_run_exits_zero():
     assert result.returncode == 0, f"Dry run failed:\n{result.stderr}"
 
 
+@network
 def test_dry_run_produces_valid_json():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--dry-run"],
@@ -31,6 +44,7 @@ def test_dry_run_produces_valid_json():
     assert "unchanged" in data, "JSON missing 'unchanged' key"
 
 
+@network
 def test_dry_run_does_not_write_files():
     files_before = set(REF_DIR.rglob("*.md"))
     subprocess.run(

--- a/tests/test_technical_depth.py
+++ b/tests/test_technical_depth.py
@@ -14,8 +14,10 @@ deferred to manual smoke tests.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import patch
 
 _SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
@@ -170,3 +172,41 @@ def test_unlighthouse_reports_missing_node(monkeypatch) -> None:
     result = unlighthouse_run.run("https://example.com/")
     assert result["ok"] is False
     assert "npx" in result["error"].lower() or "node" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# preload_check exit status (issue #281): success is 0, gating is opt-in
+# ---------------------------------------------------------------------------
+
+_PLAIN_HTML = "<html><head></head><body><p>nothing to preload</p></body></html>"
+
+
+def _run_preload_main(monkeypatch, capsys, *argv: str) -> tuple[int, str]:
+    response = SimpleNamespace(url="https://example.com/", text=_PLAIN_HTML, headers={})
+    monkeypatch.setattr(preload_check, "safe_requests_get", lambda *a, **k: response)
+    monkeypatch.setattr(sys, "argv", ["preload_check.py", "https://example.com/", *argv])
+    code = preload_check.main()
+    return code, capsys.readouterr().out
+
+
+def test_preload_main_exits_zero_on_a_low_score(monkeypatch, capsys) -> None:
+    score = preload_check.analyse(_PLAIN_HTML, {})["score"]
+    assert score < 75  # the old hard-coded gate would have exited 1 here
+    code, out = _run_preload_main(monkeypatch, capsys, "--json")
+    assert code == 0
+    assert json.loads(out)["score"] == score
+
+
+def test_preload_main_fail_under_gates_on_the_score(monkeypatch, capsys) -> None:
+    score = preload_check.analyse(_PLAIN_HTML, {})["score"]
+    assert _run_preload_main(monkeypatch, capsys, "--fail-under", str(score + 1))[0] == 1
+    assert _run_preload_main(monkeypatch, capsys, "--fail-under", str(score))[0] == 0
+
+
+def test_preload_main_still_exits_two_on_url_safety_error(monkeypatch, capsys) -> None:
+    def refuse(*a, **k):
+        raise preload_check.URLSafetyError("blocked")
+
+    monkeypatch.setattr(preload_check, "safe_requests_get", refuse)
+    monkeypatch.setattr(sys, "argv", ["preload_check.py", "http://127.0.0.1/"])
+    assert preload_check.main() == 2

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -590,7 +590,9 @@ def test_save_oauth_token_ignores_fchmod_oserror(tmp_path, monkeypatch) -> None:
     def unsupported_fchmod(_fd, _mode):
         raise OSError("unsupported")
 
-    monkeypatch.setattr(google_auth.os, "fchmod", unsupported_fchmod)
+    # os.fchmod only exists on Windows from Python 3.13; install the stub
+    # either way so the OSError path is exercised on every platform.
+    monkeypatch.setattr(google_auth.os, "fchmod", unsupported_fchmod, raising=False)
     google_auth._save_oauth_token({"access_token": "portable"})
     assert json.loads(target.read_text(encoding="utf-8")) == {
         "access_token": "portable"

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -133,6 +133,13 @@ def test_validate_url_blocks_authority_confusion(url: str) -> None:
         ("172.16.0.1", False),
         ("127.0.0.1", False),
         ("169.254.169.254", False),  # AWS/GCP/Azure metadata
+        ("100.100.100.200", False),  # Alibaba Cloud metadata (RFC 6598 shared space)
+        ("100.64.0.0", False),  # RFC 6598 lower bound
+        ("100.127.255.255", False),  # RFC 6598 upper bound
+        ("100.128.0.1", True),  # first address past the /10 is public
+        ("::ffff:100.100.100.200", False),  # IPv4-mapped form of the above
+        ("::ffff:127.0.0.1", False),
+        ("::ffff:8.8.8.8", True),
         ("0.0.0.0", False),
         ("::1", False),
         ("fe80::1", False),  # IPv6 link-local
@@ -204,6 +211,8 @@ def test_validate_url_strict_accepts_ip_literal_public() -> None:
         "https://10.0.0.1/",
         "https://192.168.1.1/",
         "https://169.254.169.254/",
+        "http://100.100.100.200/latest/meta-data/",
+        "http://[::ffff:100.100.100.200]/latest/meta-data/",
         "https://0.0.0.0/",
     ],
 )

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -511,6 +511,9 @@ def test_route_handler_continues_when_both_ipv4_and_ipv6_public() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts POSIX mode bits, which Windows does not represent"
+)
 def test_save_oauth_token_writes_0o600(tmp_path, monkeypatch) -> None:
     """_save_oauth_token must produce a 0o600 file regardless of whether
     the path existed beforehand or what the umask is."""
@@ -528,6 +531,9 @@ def test_save_oauth_token_writes_0o600(tmp_path, monkeypatch) -> None:
         os.umask(old_umask)
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts POSIX mode bits, which Windows does not represent"
+)
 def test_save_oauth_token_remediates_legacy_0o644(tmp_path, monkeypatch) -> None:
     """A pre-existing 0o644 token (v1.9.x default) is locked down on save."""
     import google_auth  # noqa: WPS433
@@ -591,6 +597,9 @@ def test_save_oauth_token_ignores_fchmod_oserror(tmp_path, monkeypatch) -> None:
     }
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="asserts POSIX mode bits, which Windows does not represent"
+)
 def test_load_oauth_token_remediates_legacy_0o644(tmp_path, monkeypatch) -> None:
     """_load_oauth_token chmods the file before reading, so the next read
     by any other process sees 0o600 even without a re-save."""

--- a/tests/test_validate_backlink_report.py
+++ b/tests/test_validate_backlink_report.py
@@ -1,0 +1,95 @@
+"""Backlink report validation regressions."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import validate_backlink_report as vbr  # noqa: E402
+
+
+def test_unflattened_graph_schema_is_flagged_as_error() -> None:
+    issues = vbr.validate_schema_claims({"schema": [{"@graph": [{"@type": "Product"}]}]})
+
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "error"
+    assert "@graph" in issues[0]["message"]
+
+
+def test_deprecated_howto_schema_is_flagged_as_error() -> None:
+    issues = vbr.validate_schema_claims({"schema": [{"@type": "HowTo"}]})
+
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "error"
+    assert "HowTo" in issues[0]["message"]
+
+
+def test_schema_type_array_is_not_flagged() -> None:
+    issues = vbr.validate_schema_claims({"schema": [{"@type": ["Product", "ItemPage"]}]})
+
+    assert issues == []
+
+
+def test_verification_summary_mismatch_is_flagged_as_error() -> None:
+    verify_data = {
+        "data": {
+            "results": [{"status": "verified"}, {"status": "verified"}],
+            "summary": {"verified": 1},
+        }
+    }
+
+    issues = vbr.validate_verification_results(verify_data)
+
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "error"
+    assert "verified=1" in issues[0]["message"]
+
+
+def test_social_media_link_removed_with_200_is_flagged_as_error() -> None:
+    verify_data = {
+        "data": {
+            "results": [{
+                "source_url": "https://www.instagram.com/somepage",
+                "status": "link_removed",
+                "http_status": 200,
+            }],
+            "summary": {"link_removed": 1},
+        }
+    }
+
+    issues = vbr.validate_verification_results(verify_data)
+
+    assert any(i["severity"] == "error" and "unverifiable_js" in i["message"] for i in issues)
+
+
+def test_health_score_with_insufficient_data_is_flagged_as_error() -> None:
+    issues = vbr.validate_health_score({"total_factors": 7, "factors_with_data": 2, "score": 82})
+
+    assert len(issues) == 1
+    assert issues[0]["severity"] == "error"
+    assert "INSUFFICIENT DATA" in issues[0]["message"]
+
+
+def test_health_score_with_sufficient_data_is_not_flagged() -> None:
+    issues = vbr.validate_health_score({"total_factors": 7, "factors_with_data": 6, "score": 82})
+
+    assert issues == []
+
+
+def test_validate_report_status_is_fail_when_errors_present() -> None:
+    result = vbr.validate_report({"parsed_data": {"schema": [{"@type": "HowTo"}]}})
+
+    assert result["status"] == "FAIL"
+    assert result["data"]["errors"] == 1
+
+
+def test_validate_report_status_is_pass_when_no_issues() -> None:
+    result = vbr.validate_report({"parsed_data": {"schema": [{"@type": "Organization"}]}})
+
+    assert result["status"] == "PASS"
+    assert result["data"]["total_issues"] == 0

--- a/tests/test_validate_backlink_report.py
+++ b/tests/test_validate_backlink_report.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import sys
 
-
 _SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
 if _SCRIPTS not in sys.path:
     sys.path.insert(0, _SCRIPTS)


### PR DESCRIPTION
Release branch for v2.2.6, cut from main a1480c7. Each reviewed contributor PR landed as its own commit with authorship preserved; the full suite was green after every landing.

## Security
- Cache-path traversal in `commoncrawl_graph.py` (`--release`) and an unvalidated WHOIS referral in `domain_history.py`, from #243 commit 387f7e9.
- `url_safety` refuses RFC 6598 (100.64.0.0/10) and judges IPv4-mapped IPv6 by the embedded address (#294).
- WeasyPrint 70.0 (PYSEC-2026-3940), requests 2.34.2 (CVE-2026-25645), matplotlib 3.9.0 with numpy 2.2.6, plus the other Dependabot floors (#190, #191, #192, #193, #194). `pip-audit` passes and now runs in CI (#184).
- SECURITY.md only lists channels that exist; private vulnerability reporting is enabled (#289).

## Hosted install
- The launcher moves from `bin/claude-seo` to `scripts/claude-seo` and skills call it as `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run <script>`, per the plugin-marketplace docs. Manual installers rewrite that token to the absolute path. Fixes #298 and #199.

## Reliability
- Cost ledgers locked and atomic (#202), PSI null category scores (#274), preload_check exit codes (#296), CRLF-safe FLOW lock hashing (#292), full suite on Windows and macOS (#293), backlink no-score rule enforced (#260, #179), dynamic rendering guidance (#178), CI install failures surfaced (#183), importorskip for optional stacks (#182), `seo_updates --kind documentation`, network-gated sync_flow tests.

Review basis: a 2026-09-10 full review of all 46 open PRs and 17 issues at their exact heads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qjDbqj88SjLGY4MdQKGB8