### PR TITLE
fix(runtime): surface the failing setup stage's own output

### DIFF
--- a/scripts/runtime.py
+++ b/scripts/runtime.py
@@ -198,11 +198,22 @@ def _safe_env(status: dict[str, Any]) -> dict[str, str]:
     return env
 
 
+def _home_pattern(home: str) -> re.Pattern[str]:
+    # Child output quotes paths in repr form (doubled or quadrupled separators
+    # once nested) and Windows tools mix drive-letter case, so match the home
+    # directory by its segments rather than by the exact string.
+    parts = [re.escape(part) for part in re.split(r"[\\/]+", home) if part]
+    pattern = r"[\\/]+".join(parts)
+    if home[:1] in ("\\", "/"):
+        pattern = r"[\\/]+" + pattern
+    return re.compile(pattern, re.IGNORECASE)
+
+
 def _redact(text: str) -> str:
     try:
         home = str(Path.home())
         if home:
-            text = text.replace(home, "<home>")
+            text = _home_pattern(home).sub("<home>", text)
     except RuntimeError:
         pass
     for pattern, replacement in REDACTIONS:
@@ -210,12 +221,22 @@ def _redact(text: str) -> str:
     return text
 
 
+def _tail(text: str, limit: int = 30) -> str:
+    lines = [line.rstrip() for line in text.splitlines() if line.strip()]
+    return "\n".join(f"  {line}" for line in lines[-limit:])
+
+
 def _run_checked(
     argv: list[str], *, env: dict[str, str], stage: str
 ) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(argv, env=env, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if result.returncode:
-        raise RuntimeError(f"{stage} failed with exit code {result.returncode}")
+        # The child's own diagnostics (pip's OSError, a missing ensurepip,
+        # a proxy rejection) are the only thing that makes the failure
+        # actionable; the exit code alone is not.
+        detail = _tail(result.stderr or result.stdout)
+        message = f"{stage} failed with exit code {result.returncode}"
+        raise RuntimeError(f"{message}\n{detail}" if detail else message)
     return result
 
 
@@ -261,9 +282,21 @@ def command_setup(args: argparse.Namespace) -> int:
     had_previous = final_venv.exists()
     try:
         with SetupLock(data_dir / ".setup.lock"):
-            print("Creating isolated Claude SEO environment...")
-            _run_checked([sys.executable, "-m", "venv", str(staged)], env=env, stage="virtual environment creation")
+            print("Creating isolated Claude SEO environment...", flush=True)
+            # venv bootstraps pip itself but discards ensurepip's output, so a
+            # failing bootstrap would surface only as "ensurepip returned 1".
+            # Running it as its own stage keeps pip's diagnostics visible.
+            _run_checked(
+                [sys.executable, "-m", "venv", "--without-pip", str(staged)],
+                env=env,
+                stage="virtual environment creation",
+            )
             staged_python = _venv_python(staged)
+            _run_checked(
+                [str(staged_python), "-m", "ensurepip", "--upgrade", "--default-pip"],
+                env=env,
+                stage="pip bootstrap",
+            )
             _run_checked(
                 [str(staged_python), "-m", "pip", "install", "--disable-pip-version-check", "-r", str(root / "requirements.txt")],
                 env=env,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -223,3 +223,60 @@ def test_run_propagates_child_signal(tmp_path: Path, monkeypatch: pytest.MonkeyP
     )
     assert rc == 128 + signal.SIGTERM
     assert delivered == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_failed_stage_reports_child_diagnostics(monkeypatch: pytest.MonkeyPatch) -> None:
+    stderr = "\n".join(
+        [
+            "Looking in links: /tmp/tmp8b58vt29",
+            "ERROR: Could not install packages due to an OSError: [WinError 206] "
+            "Der Dateiname oder die Erweiterung ist zu lang",
+            "",
+        ]
+    )
+    monkeypatch.setattr(
+        runtime.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 1, "", stderr),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime._run_checked(["python", "-m", "venv", "x"], env={}, stage="virtual environment creation")
+    message = str(excinfo.value)
+    assert message.startswith("virtual environment creation failed with exit code 1")
+    assert "[WinError 206]" in message
+
+
+def test_failed_stage_falls_back_to_stdout_and_bounds_the_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    stdout = "\n".join(f"line {index}" for index in range(40))
+    monkeypatch.setattr(
+        runtime.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 2, stdout, ""),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        runtime._run_checked(["pip"], env={}, stage="dependency installation")
+    message = str(excinfo.value)
+    assert "line 39" in message
+    assert "line 10" in message
+    assert "line 9" not in message
+
+
+def test_successful_stage_returns_the_completed_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        runtime.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, "ok", "warning noise"),
+    )
+    assert runtime._run_checked(["pip"], env={}, stage="dependency installation").stdout == "ok"
+
+
+def test_redaction_covers_repr_quoted_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(runtime.Path, "home", classmethod(lambda cls: Path(r"C:\Users\someone")))
+    quoted = repr(r"C:\Users\someone\.claude\skills\seo\.venv.next-1\Scripts\python.exe")
+    nested = repr(f"sys.path = [{quoted}]")
+    redacted = runtime._redact(
+        f"Command '[{quoted}, '-c', {nested}]' returned non-zero exit status 1.\n"
+        "Looking in links: c:\\users\\someone\\AppData\\Local\\Temp\\tmp1"
+    )
+    assert "someone" not in redacted
+    assert redacted.count("<home>") == 3


### PR DESCRIPTION
`_run_checked` discarded the child's stderr, so a failed venv or pip stage reported only `failed with exit code 1`. `venv` additionally swallows `ensurepip`'s output, so a pip bootstrap failure was invisible one level deeper.

pip is now bootstrapped as its own stage, the last lines of the failing stage's output are appended to the error, and the home-directory redaction matches the repr-quoted and mixed-case forms that child tracebacks print.

Before/after on a checkout whose data dir exceeds MAX_PATH:

```
Claude SEO setup failed: virtual environment creation failed with exit code 1
---
Claude SEO setup failed: pip bootstrap failed with exit code 1
  ERROR: Could not install packages due to an OSError: [WinError 206] Der Dateiname oder die Erweiterung ist zu lang: '<home>\\...\\.venv.next-81952\\Lib\\site-packages\\pip-26.0.1.dist-info\\licenses\\src\\pip\\_vendor\\dependency_groups'
```

Verified in:
- Windows 11, Python 3.14.4, repo checkout — full suite 512 passed, 17 skipped; `install.sh` v2.2.6 into a fresh short-path HOME still completes and `doctor` reports ready
- Windows 11, Python 3.11.16 (uv, pytest+requests+lxml only) — test_runtime.py and test_runtime_installers.py 19 passed, 1 skipped
- Fork CI on Nordalux/claude-seo @1f953b4 — test suite, portability (windows-latest, macos-latest), dependency audit, syntax check, secret scan all green

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
