### PR TITLE
feat(shopify): uncapped signed crawl of a Shopify store from .shopify-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ env/
 **/service_account*.json
 **/oauth-token.json
 **/.google-token.json
+**/.shopify-env
 
 # Node (if any)
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `extensions/shopify`: an uncapped, sitemap-complete crawl of a Shopify storefront
+  the user administers, signed with the store's Crawler Access signature
+  (`web-bot-auth`) read from a project-local `.shopify-env`. `shopify_env.py`
+  parses the file and answers `precheck`; `shopify_crawl.py` crawls through the
+  pinned `url_safety` session, sends the signature to its issuing host only, records
+  redirects without following them, and writes `summary.json`, `sample.json` and
+  `pages.jsonl` for the `seo-audit` pipeline. `seo-audit` falls back to its 500-page
+  link crawl whenever no valid signature exists.
+
 ## [2.3.0] - 2026-09-10
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the user administers, signed with the store's Crawler Access signature
   (`web-bot-auth`) read from a project-local `.shopify-env`. `shopify_env.py`
   parses the file and answers `precheck`; `shopify_crawl.py` crawls through the
-  pinned `url_safety` session, sends the signature to its issuing host only, records
-  redirects without following them, and writes `summary.json`, `sample.json` and
+  pinned `url_safety` session, sends the signature to its issuing origin only, records
+  redirects without following them, bounds the sitemap walk and every response body,
+  and writes `summary.json`, `sample.json` and
   `pages.jsonl` for the `seo-audit` pipeline. `seo-audit` falls back to its 500-page
   link crawl whenever no valid signature exists.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ claude-seo/
     profound/                    # Profound MCP install scripts
     seranking/                   # SE Ranking MCP install scripts
     unlighthouse/                # Unlighthouse install scripts
+    shopify/                     # Shopify Crawler Access crawl extension (no MCP)
   docs/                            # Extended documentation
 ```
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -25,6 +25,7 @@ Optional extensions make API calls to third-party services when you invoke their
 | **Profound** | Profound API (tryprofound.com) | Brands and domains you track | [Profound Privacy](https://tryprofound.com/privacy) |
 | **Bing Webmaster / IndexNow** | Bing Webmaster Tools API and IndexNow endpoints | Domains, submitted URLs, and key-verification URL data | [Microsoft Privacy](https://privacy.microsoft.com/) |
 | **Unlighthouse** | Local only — no third-party vendor | Runs Lighthouse locally against the target URL; only the target site is contacted (to crawl it). Nothing is sent to a third-party vendor. | N/A (runs locally) |
+| **Shopify Crawler Access** | Local only — no third-party vendor | Crawls the target Shopify storefront directly. The merchant's Crawler Access signature from `.shopify-env` is sent only to the storefront host it was issued for and is never written to the crawl artifacts or printed. Nothing is sent to a third-party vendor. | N/A (runs locally) |
 
 ## Backlink APIs
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ claude
 | `/seo profound [command]` | LLM citation tracking with time-series data (extension) |
 | `/seo bing [command] <url>` | Bing Webmaster Tools + IndexNow URL submission (extension) |
 | `/seo unlighthouse <url>` | Multi-page Lighthouse runner, runs locally (extension) |
+| `/seo shopify [crawl\|check] <url>` | Uncapped signed crawl of a Shopify store you administer via Crawler Access (extension) |
 
 ## Features
 
@@ -421,6 +422,16 @@ Five extensions added in Phase E:
 - **Unlighthouse:** MIT-licensed multi-page Lighthouse runner
 
 Setup walkthroughs live under `extensions/<name>/docs/`; integration notes: [docs/MCP-INTEGRATION.md](docs/MCP-INTEGRATION.md).
+
+### Shopify Crawler Access
+
+Shopify rate-limits storefront crawling and `seo-audit` caps its link crawl at 500
+pages. For a store you administer, mint a Crawler Access signature in the Shopify
+admin (Online Store > Preferences > Crawler access), put it in a project-local
+`.shopify-env`, and `/seo shopify <url>` crawls the complete sitemap with no page cap and
+no storefront rate limiting before handing the artifacts to the audit pipeline. No API
+keys; the credential stays in your project folder and is git-ignored.
+Setup: [extensions/shopify/docs/SHOPIFY-SETUP.md](extensions/shopify/docs/SHOPIFY-SETUP.md).
 
 ## Ecosystem
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -711,11 +711,23 @@ Multi-page Lighthouse audit via Unlighthouse (extension, MIT, no API quota). **P
 
 ---
 
+### `/seo shopify [crawl|check] <url>`
+
+Uncapped, sitemap-complete crawl of a Shopify store you administer, signed with the store's Crawler Access signature from a project-local `.shopify-env`, then the `seo-audit` pipeline on the crawl artifacts (extension, no API keys). Without a valid signature for the host, `seo-audit` runs unchanged. **Prerequisites:** a signature from the Shopify admin (Online Store > Preferences > Crawler access) in `.shopify-env` (`./extensions/shopify/install.sh`, see `extensions/shopify/docs/SHOPIFY-SETUP.md`).
+```
+/seo shopify https://shop.example              # precheck, signed crawl, full audit
+/seo shopify crawl https://shop.example        # crawl only, artifacts in ./crawl
+/seo shopify check https://shop.example        # is there a valid signature for this host?
+```
+
+---
+
 ## Quick Reference
 
 | Command | Use Case |
 |---------|----------|
 | `/seo audit <url>` | Full website audit with parallel subagents |
+| `/seo shopify <url>` | Uncapped signed crawl of a Shopify store you administer, then the audit (extension) |
 | `/seo page <url>` | Single page analysis |
 | `/seo technical <url>` | Technical SEO across 9 categories |
 | `/seo content <url>` | E-E-A-T and content quality |

--- a/extensions/shopify/.shopify-env.example
+++ b/extensions/shopify/.shopify-env.example
@@ -1,0 +1,23 @@
+# .shopify-env — copy into the folder you run audits from. Never commit it.
+#
+# Crawl settings before the first Domain= apply to every shop below.
+# Max-Pages=0 means no cap; that is also the default.
+Max-Pages   = 0
+Concurrency = 6
+Delay       = 0.2
+
+# One block per shop. A new Domain= line starts the next block.
+# Values come from the Shopify admin: Online Store > Preferences > Crawler access.
+# The signature is bound to exactly this host and expires after ~90 days.
+Domain          = shop.example
+Signature-Input = sig1=("@authority" "signature-agent");keyid="KEYID-FROM-ADMIN";nonce="NONCE-FROM-ADMIN";tag="web-bot-auth";created=1700000000;expires=1707776000
+Signature       = sig1=:SIGNATURE-VALUE-FROM-ADMIN==:
+# Signature-Agent is optional; "https://shopify.com" is the default and never changes.
+Signature-Agent = "https://shopify.com"
+
+# Per-shop overrides are allowed inside a block.
+Domain          = second-shop.example
+Signature-Input = sig1=("@authority" "signature-agent");keyid="...";tag="web-bot-auth";created=...;expires=...
+Signature       = sig1=:...:
+Concurrency     = 3
+Exclude         = /collections/.*\?

--- a/extensions/shopify/docs/SHOPIFY-SETUP.md
+++ b/extensions/shopify/docs/SHOPIFY-SETUP.md
@@ -1,0 +1,94 @@
+# Shopify Crawler Access extension setup
+
+## What this gives you
+
+1. **An uncapped, sitemap-complete crawl** of a Shopify storefront via
+   `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_crawl.py` instead of
+   the 500-page link-following crawl in `seo-audit`.
+2. **No storefront rate limiting** while crawling, because every request
+   carries the store's Crawler Access signature (RFC 9421 message signature,
+   tag `web-bot-auth`), read from a project-local `.shopify-env`.
+3. A `seo-shopify` skill that runs the precheck, the crawl, and then hands the
+   artifacts to the standard `seo-audit` pipeline.
+
+The signature is minted in the store's own admin, so this only works for stores
+you or your client administer. Everything else keeps crawling unsigned.
+
+## Install
+
+```bash
+./extensions/shopify/install.sh
+.\extensions\shopify\install.ps1
+```
+
+No API keys. The installer copies the `seo-shopify` skill next to the other
+skills; the scripts ship with claude-seo already.
+
+## 1. Issue the signature
+
+Shopify admin > **Online Store** > **Preferences** > **Crawler access** > create
+a signature. The admin shows three header values:
+
+```
+Signature-Agent: "https://shopify.com"
+Signature-Input: sig1=("@authority" "signature-agent");keyid="...";nonce="...";tag="web-bot-auth";created=...;expires=...
+Signature: sig1=:...:
+```
+
+Only `Signature-Agent` is constant. The signature covers `@authority`, so it is
+bound to exactly one host, and it expires after roughly 90 days.
+
+## 2. Write `.shopify-env`
+
+Create `.shopify-env` in the folder you run audits from (the file is also found
+up to five parent folders up, and `$SHOPIFY_ENV` points at an explicit path). One
+block per shop; a new `Domain=` line starts the next block. Keys before the first
+`Domain=` are crawl settings shared by every shop in the file.
+
+```
+Max-Pages   = 0
+Concurrency = 6
+
+Domain          = shop.example
+Signature-Input = sig1=("@authority" "signature-agent");keyid="...";tag="web-bot-auth";created=...;expires=...
+Signature       = sig1=:...:
+
+Domain          = second-shop.example
+Signature-Input = ...
+Signature       = ...
+Concurrency     = 3
+```
+
+`Signature-Agent` is optional and defaults to `"https://shopify.com"`. Header
+values are used byte-exact; do not strip their quotes. Recognised crawl keys:
+`Max-Pages` (0 = no cap, the default), `Concurrency`, `Delay`, `Timeout`,
+`Sample-Per-Template`, `Include`, `Exclude`, `Save-HTML`, `Ignore-Robots`. Inside
+a block they override the shared values for that shop only.
+
+A copy of this layout lives at `extensions/shopify/.shopify-env.example`.
+
+**Never commit it.** `.shopify-env` holds a client credential. It is in the
+repository's `.gitignore`; the scripts also warn when the file sits in a git
+work tree without being ignored.
+
+## 3. Check and crawl
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_env.py list
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_env.py check https://shop.example
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_crawl.py https://shop.example --out ./crawl
+```
+
+Or in Claude Code: `/seo shopify https://shop.example`.
+
+## Security notes
+
+- The crawler validates the root with `url_safety.validate_url_strict`, pins DNS
+  for the session, crawls the signed host only, and records redirects without
+  following them.
+- The signature is attached only to requests whose host equals the authority
+  it was issued for. Sitemap entries on other hosts are skipped.
+- On `429`, `430` or `503` the crawler backs off exponentially. If that happens
+  on a signed request, it exits with code 5 after finishing, because Shopify's
+  documented meaning of a rate-limit response to a signed request is that the
+  signature is not valid.

--- a/extensions/shopify/docs/SHOPIFY-SETUP.md
+++ b/extensions/shopify/docs/SHOPIFY-SETUP.md
@@ -40,8 +40,9 @@ bound to exactly one host, and it expires after roughly 90 days.
 
 ## 2. Write `.shopify-env`
 
-Create `.shopify-env` in the folder you run audits from (the file is also found
-up to five parent folders up, and `$SHOPIFY_ENV` points at an explicit path). One
+Create `.shopify-env` in the folder you run audits from; it is also found up to
+five parent folders up. Alternatively `$SHOPIFY_ENV` names a file anywhere on disk,
+for credentials shared across several audit folders. One
 block per shop; a new `Domain=` line starts the next block. Keys before the first
 `Domain=` are crawl settings shared by every shop in the file.
 
@@ -86,8 +87,15 @@ Or in Claude Code: `/seo shopify https://shop.example`.
 - The crawler validates the root with `url_safety.validate_url_strict`, pins DNS
   for the session, crawls the signed host only, and records redirects without
   following them.
-- The signature is attached only to requests whose host equals the authority
-  it was issued for. Sitemap entries on other hosts are skipped.
+- The signature is attached only to requests whose scheme and host equal the
+  origin it was issued for; an `http://` entry for an `https://` store is skipped
+  rather than signed in cleartext. Sitemap entries on other hosts are skipped.
+- No command prints the signature values; `list` and `check` report key id and
+  expiry only.
+- The sitemap walk stops at 5 index levels, 500 sitemaps or 250,000 URLs, and
+  every body is read up to a byte limit (1 MiB robots.txt, 50 MiB sitemap, 10 MiB
+  page). A crawl that hit one of those caps reports `discovery_capped` in
+  `summary.json`.
 - On `429`, `430` or `503` the crawler backs off exponentially. If that happens
   on a signed request, it exits with code 5 after finishing, because Shopify's
   documented meaning of a rate-limit response to a signed request is that the

--- a/extensions/shopify/install.ps1
+++ b/extensions/shopify/install.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+$SkillDir = Join-Path $HOME ".claude/skills"
+if (-not (Test-Path (Join-Path $SkillDir "seo"))) { throw "claude-seo not installed" }
+$SourceDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillTarget = Join-Path $SkillDir "seo-shopify"
+New-Item -ItemType Directory -Path $SkillTarget -Force | Out-Null
+Copy-Item (Join-Path $SourceDir "skills/seo-shopify/SKILL.md") `
+          (Join-Path $SkillTarget "SKILL.md") -Force
+Write-Host "Installed skill: $SkillTarget"
+Write-Host "Next: issue a Crawler Access signature in the Shopify admin and write it to .shopify-env"
+Write-Host "      in your audit folder (template: $SourceDir\.shopify-env.example)."
+Write-Host "Done."

--- a/extensions/shopify/install.sh
+++ b/extensions/shopify/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Claude SEO — Shopify Crawler Access extension installer.
+#
+# Copies the seo-shopify skill next to the other skills. The scripts it uses
+# (shopify_env.py, shopify_crawl.py) ship with claude-seo already. No API keys:
+# the crawl credential is minted in the merchant's Shopify admin and lives in a
+# project-local .shopify-env (see docs/SHOPIFY-SETUP.md).
+set -euo pipefail
+
+main() {
+    SKILL_DIR="${HOME}/.claude/skills"
+
+    echo "════════════════════════════════════════"
+    echo "║   Claude SEO — Shopify Crawler Access ║"
+    echo "════════════════════════════════════════"
+
+    [ ! -d "${SKILL_DIR}/seo" ] && { echo "✗ claude-seo base not installed."; exit 1; }
+
+    SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)"
+
+    mkdir -p "${SKILL_DIR}/seo-shopify"
+    cp "${SOURCE_DIR}/skills/seo-shopify/SKILL.md" "${SKILL_DIR}/seo-shopify/SKILL.md"
+    echo "✓ Installed skill: ${SKILL_DIR}/seo-shopify"
+    echo "Next: issue a Crawler Access signature in the Shopify admin and write it to"
+    echo "      .shopify-env in your audit folder (template: ${SOURCE_DIR}/.shopify-env.example)."
+    echo "Done. Try: /seo shopify https://shop.example"
+}
+main "$@"

--- a/extensions/shopify/skills/seo-shopify/SKILL.md
+++ b/extensions/shopify/skills/seo-shopify/SKILL.md
@@ -2,7 +2,7 @@
 name: seo-shopify
 description: "Uncapped, sitemap-complete crawl of a Shopify storefront using the merchant's Crawler Access signature from a project-local .shopify-env, feeding the standard seo-audit pipeline. Use when the user says 'Shopify audit', 'crawl the whole store', 'Crawler access', 'signature-agent', 'web-bot-auth', 'rate limited while crawling', or audits a host listed in .shopify-env."
 metadata:
-  version: "2.2.6"
+  version: "2.3.0"
 compatibility: "Requires a Shopify store the user administers (the signature is minted in the store's admin) and a .shopify-env file in the folder the audit runs from. Without it, seo-audit runs unchanged."
 ---
 
@@ -80,7 +80,9 @@ Large stores: the crawl is resumable (`--resume`). If it was interrupted, resume
 instead of auditing a partial crawl.
 
 Defaults: no page limit; concurrency 6 and a 0.2 s delay when signed, 2 and 1 s
-unsigned; robots.txt respected; redirects recorded, not followed. Precedence is
+unsigned; robots.txt respected; redirects recorded, not followed; bodies read up to
+10 MiB per page and the sitemap walk bounded at 5 levels, 500 sitemaps and 250,000
+URLs (`discovery_capped` in `summary.json` names the cap that was hit). Precedence is
 command line > domain block > global keys > these defaults. Useful flags:
 `--include`/`--exclude` (regex), `--save-html`, `--sample-per-template N`,
 `--no-signature` to measure the unsigned baseline.

--- a/extensions/shopify/skills/seo-shopify/SKILL.md
+++ b/extensions/shopify/skills/seo-shopify/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: seo-shopify
+description: "Uncapped, sitemap-complete crawl of a Shopify storefront using the merchant's Crawler Access signature from a project-local .shopify-env, feeding the standard seo-audit pipeline. Use when the user says 'Shopify audit', 'crawl the whole store', 'Crawler access', 'signature-agent', 'web-bot-auth', 'rate limited while crawling', or audits a host listed in .shopify-env."
+metadata:
+  version: "2.2.6"
+compatibility: "Requires a Shopify store the user administers (the signature is minted in the store's admin) and a .shopify-env file in the folder the audit runs from. Without it, seo-audit runs unchanged."
+---
+
+# seo-shopify
+
+Shopify rate-limits storefront crawling, and `seo-audit` caps its link-following
+crawl at 500 pages. A merchant can mint a **Crawler Access** signature in their
+admin (Online Store > Preferences > Crawler access). A crawler that replays the
+three resulting headers is treated as an authenticated crawler and is not rate
+limited, and Shopify publishes a complete nested sitemap for every store. Together
+that makes an uncapped, sitemap-complete crawl possible without guessing at a cap.
+
+This skill adds that crawl. It replaces **step 3 only** of `seo-audit` (the crawl).
+Business-type detection, subagent delegation, scoring and reports stay as
+`seo-audit` defines them.
+
+## Hard limits (state these before promising a crawl)
+
+- Only for stores the user administers. The signature exists only inside the
+  merchant's admin; competitor and prospect stores crawl unsigned, capped, via
+  plain `seo-audit`.
+- One signature per host. `shop.example`, `www.shop.example` and
+  `shop.myshopify.com` are different authorities; crawl the host the signature was
+  issued for. The crawler never sends it to any other host.
+- Signatures expire after roughly 90 days and cannot be extended. The merchant
+  issues a new one.
+- Checkout is excluded from signature access by Shopify.
+
+## Routing
+
+| Command | Effect |
+|---|---|
+| `/seo shopify <url>` | Precheck, signed uncapped crawl, then the `seo-audit` pipeline on the artifacts |
+| `/seo shopify crawl <url>` | Crawl only, artifacts in `./crawl` |
+| `/seo shopify check <url>` | Report whether `.shopify-env` holds a valid signature for the host |
+
+## Step 1: decide the mode
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_env.py precheck <url>
+```
+
+Always exits 0 and always prints JSON. Read `mode`:
+
+- `"signed"`: continue with step 2.
+- `"fallback"`: run the plain `seo-audit` skill, completely unchanged, cap and
+  link-following crawl included. Tell the user in one sentence why (the `detail`
+  field says it) and get on with the audit. A capped audit is a normal result.
+
+Fallback reasons: `no_env_file`, `no_signature`, `signature_expired`,
+`env_unreadable`. Before accepting `no_signature`, remember the signature is bound
+to one host: if the store serves on the other of apex/www, re-run the precheck
+against that host.
+
+## Step 2: crawl
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_crawl.py <url> --out ./crawl
+```
+
+No `--max-pages`. The crawl covers the complete sitemap; a cap applies only when
+`.shopify-env` or the command line sets one, and the summary then carries
+`"truncated": true`. Report the real number of pages crawled, never a rounded cap.
+
+Exit codes:
+
+- `0`: crawl complete, continue.
+- `5`: crawl complete and artifacts usable, but the storefront rate limited a
+  signed request. Shopify treats that as an invalid signature. Continue the audit
+  on the artifacts and flag in the report that the signature should be reissued.
+- `1`: nothing crawled (no sitemap reachable, password-protected store, wrong
+  host, or the URL failed `url_safety`). Fall back to plain `seo-audit` and say why.
+
+Large stores: the crawl is resumable (`--resume`). If it was interrupted, resume it
+instead of auditing a partial crawl.
+
+Defaults: no page limit; concurrency 6 and a 0.2 s delay when signed, 2 and 1 s
+unsigned; robots.txt respected; redirects recorded, not followed. Precedence is
+command line > domain block > global keys > these defaults. Useful flags:
+`--include`/`--exclude` (regex), `--save-html`, `--sample-per-template N`,
+`--no-signature` to measure the unsigned baseline.
+
+## Step 3: audit on the crawl artifacts
+
+Follow `seo-audit` from its step 4 onwards. The crawl is done; nobody crawls again.
+Business type is settled: a Shopify storefront is E-commerce, so `seo-ecommerce` is
+in scope.
+
+What each subagent gets:
+
+- `crawl/summary.json`: aggregate counts across all crawled pages. The evidence
+  base for anything quantitative: status distribution, per-template counts,
+  missing and duplicate titles, meta description lengths, missing canonicals,
+  noindex, h1 problems, thin pages, images without alt, schema coverage, latency
+  percentiles.
+- `crawl/sample.json`: a stratified sample, N pages per template type, for the
+  agents that need real page content (`seo-content`, `seo-schema`, `seo-sxo`,
+  `seo-ecommerce`).
+- `crawl/pages.jsonl`: never passed to a subagent. It is the raw record set and
+  will not fit in a context window on any store worth crawling uncapped. Query it
+  with a script when a specific number is missing from `summary.json`.
+
+Say in each subagent prompt that the pages were already fetched, so they analyze
+the artifacts instead of re-fetching the site. Agents that need live requests
+(`seo-performance`, `seo-visual`, `seo-google`) make their handful of unsigned
+requests as usual.
+
+## Step 4: score and report
+
+Unchanged from `seo-audit`: same weights, same `FULL-AUDIT-REPORT.md` and
+`ACTION-PLAN.md`. Two additions to the executive summary, because they change how
+the numbers read: the pages crawled and that the crawl was signed and complete,
+and any truncation with what was left out.
+
+## Setup
+
+See `extensions/shopify/docs/SHOPIFY-SETUP.md` for issuing the signature and the
+`.shopify-env` format. `.shopify-env` holds a client credential: keep it out of git.

--- a/extensions/shopify/uninstall.sh
+++ b/extensions/shopify/uninstall.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SKILL_DIR="${HOME}/.claude/skills/seo-shopify"
+[ -d "${SKILL_DIR}" ] && rm -rf "${SKILL_DIR}" && echo "✓ Removed ${SKILL_DIR}"
+echo "Done. (Nothing to remove from settings.json; the credential lives in your project's .shopify-env.)"

--- a/scripts/runtime.py
+++ b/scripts/runtime.py
@@ -43,6 +43,7 @@ ALLOWED_CORE_SCRIPTS = frozenset(
         "parasite_risk.py", "parse_html.py", "preload_check.py", "render_page.py",
         "portability_check.py", "consistency_check.py",
         "schema_ecommerce_validate.py", "schema_generate.py", "seo_updates.py",
+        "shopify_crawl.py", "shopify_env.py",
         "sitemap_discovery.py", "sync_flow.py", "ucp_check.py", "unlighthouse_run.py",
         "url_safety.py", "validate_backlink_report.py", "verify_backlinks.py",
         "youtube_search.py",

--- a/scripts/shopify_crawl.py
+++ b/scripts/shopify_crawl.py
@@ -7,11 +7,13 @@ set comes from sitemap.xml instead of link following and no page cap is
 needed. When `.shopify-env` (see shopify_env.py) holds a Crawler Access
 signature for the target host, its three headers are attached to every
 request and the storefront lifts its rate limit. The signature is sent to
-that one host only.
+that one origin only.
 
 Every request goes through url_safety: the root is validated with
-validate_url_strict, the session is DNS-pinned, and redirects are recorded
-but never followed.
+validate_url_strict, DNS is pinned for the crawl, only URLs on the root's
+scheme and host are fetched, response bodies are read up to a byte limit,
+and redirects are recorded but never followed. The sitemap walk is bounded
+in depth, sitemap count and URL count.
 
 Outputs in --out:
     pages.jsonl   one record per URL (machine input; never hand this to a model)
@@ -40,6 +42,7 @@ import time
 from collections import Counter, defaultdict
 from html import unescape
 from pathlib import Path
+from typing import Callable
 from urllib.parse import urlparse
 from urllib.robotparser import RobotFileParser
 
@@ -64,6 +67,16 @@ BASE_HEADERS = {
     "Accept-Encoding": "gzip, deflate",
 }
 RATE_LIMIT_STATUSES = (429, 430, 503)
+
+# Bounds on what one crawl will read. Shopify's own sitemap index nests two
+# levels deep; the depth cap leaves room for a store that puts a proxy in
+# front of it without letting a hostile chain run forever.
+MAX_SITEMAP_DEPTH = 5
+MAX_SITEMAPS = 500
+MAX_DISCOVERED_URLS = 250_000
+MAX_ROBOTS_BYTES = 1024 * 1024
+MAX_SITEMAP_BYTES = 50 * 1024 * 1024
+MAX_PAGE_BYTES = 10 * 1024 * 1024
 
 # Shopify storefront URL shapes, in match order. Everything else is "page".
 TEMPLATE_PATTERNS = [
@@ -114,6 +127,19 @@ class RateLimitGovernor:
             time.sleep(self.delay)
 
 
+class Origin:
+    """The one scheme and host this crawl talks to."""
+
+    def __init__(self, scheme: str, authority: str):
+        self.scheme = scheme
+        self.authority = authority.lower()
+        self.root = f"{scheme}://{self.authority}"
+
+    def owns(self, url: str) -> bool:
+        parsed = urlparse(url)
+        return parsed.scheme == self.scheme and parsed.netloc.lower() == self.authority
+
+
 def classify(url: str) -> str:
     for name, pattern in TEMPLATE_PATTERNS:
         if pattern.search(url):
@@ -121,17 +147,46 @@ def classify(url: str) -> str:
     return "page"
 
 
-def headers_for(url: str, authority: str, sig_headers: dict | None) -> dict:
-    """Base headers, plus the signature only for the host it was issued for."""
+def headers_for(url: str, origin: Origin, sig_headers: dict | None) -> dict:
+    """Base headers, plus the signature only for the origin it was issued for.
+
+    Scheme is part of the check: an http:// entry for an https:// store would
+    otherwise carry the signature in cleartext."""
     headers = dict(BASE_HEADERS)
-    if sig_headers and urlparse(url).netloc.lower() == authority:
+    if sig_headers and origin.owns(url):
         headers.update(sig_headers)
     return headers
 
 
-def same_authority(url: str, authority: str) -> bool:
-    parsed = urlparse(url)
-    return parsed.scheme in ("http", "https") and parsed.netloc.lower() == authority
+def read_bounded(response, max_bytes: int) -> tuple[bytes, bool]:
+    """Read a streamed response up to max_bytes after decompression.
+
+    Returns (content, too_large). Mirrors sitemap_discovery._bounded_fetch so
+    a multi-megabyte body never lands in memory in full, times the crawl's
+    concurrency."""
+    chunks: list[bytes] = []
+    size = 0
+    too_large = False
+    try:
+        for chunk in response.iter_content(chunk_size=65536):
+            if not chunk:
+                continue
+            size += len(chunk)
+            if size > max_bytes:
+                too_large = True
+                break
+            chunks.append(chunk)
+    finally:
+        response.close()
+    return b"".join(chunks), too_large
+
+
+def decode_body(content: bytes, response) -> str:
+    encoding = response.encoding or "utf-8"
+    try:
+        return content.decode(encoding, errors="replace")
+    except LookupError:
+        return content.decode("utf-8", errors="replace")
 
 
 def sitemap_locs(content: bytes) -> tuple[str, list[str]]:
@@ -157,64 +212,86 @@ def sitemap_locs(content: bytes) -> tuple[str, list[str]]:
     return kind, locs
 
 
-def fetch_sitemap_urls(session, root: str, authority: str, governor: RateLimitGovernor,
+def fetch_sitemap_urls(session, origin: Origin, governor: RateLimitGovernor,
                        sig_headers: dict | None = None, target: int = 0,
-                       robots_text: str | None = None, log=print) -> list[str]:
-    """Walk sitemap.xml and sitemap indexes recursively, same authority only.
+                       robots_text: str | None = None, log=print) -> tuple[list[str], dict]:
+    """Walk sitemap.xml and sitemap indexes recursively, same origin only.
 
     `target` > 0 stops the walk once that many URLs are collected so a capped
-    crawl does not open every child sitemap of a large store.
+    crawl does not open every child sitemap of a large store. Independently
+    of `target`, the walk stops at MAX_SITEMAP_DEPTH, MAX_SITEMAPS and
+    MAX_DISCOVERED_URLS. Returns (urls, stats).
     """
     seen_maps: set[str] = set()
-    queue: list[str] = []
+    queue: list[tuple[str, int]] = []
     urls: list[str] = []
-    skipped_foreign = 0
+    stats = {"sitemaps_fetched": 0, "skipped_foreign": 0, "discovery_capped": None}
 
     if robots_text:
-        queue += re.findall(r"(?im)^\s*sitemap:\s*(\S+)", robots_text)
-    queue.append(f"{root}/sitemap.xml")
+        queue += [(loc, 1) for loc in re.findall(r"(?im)^\s*sitemap:\s*(\S+)", robots_text)]
+    queue.append((f"{origin.root}/sitemap.xml", 1))
 
     while queue:
         if target and len(urls) >= target:
             log(f"  stopping sitemap walk at {len(urls)} URLs ({len(queue)} sitemaps not opened)")
             break
-        current = queue.pop(0)
+        if stats["sitemaps_fetched"] >= MAX_SITEMAPS:
+            stats["discovery_capped"] = f"more than {MAX_SITEMAPS} sitemaps"
+            break
+        if len(urls) >= MAX_DISCOVERED_URLS:
+            stats["discovery_capped"] = f"more than {MAX_DISCOVERED_URLS} URLs"
+            break
+        current, depth = queue.pop(0)
         if current in seen_maps:
             continue
-        seen_maps.add(current)
-        if not same_authority(current, authority):
-            skipped_foreign += 1
+        if not origin.owns(current):
+            stats["skipped_foreign"] += 1
             continue
+        if depth > MAX_SITEMAP_DEPTH:
+            stats["discovery_capped"] = f"sitemap index nested deeper than {MAX_SITEMAP_DEPTH}"
+            break
+        seen_maps.add(current)
         try:
-            response = session.get(current, timeout=30, allow_redirects=False,
-                                   headers=headers_for(current, authority, sig_headers))
+            response = session.get(current, timeout=30, allow_redirects=False, stream=True,
+                                   headers=headers_for(current, origin, sig_headers))
         except requests.RequestException as exc:
             log(f"  sitemap failed {current}: {exc}")
             continue
+        stats["sitemaps_fetched"] += 1
         if response.status_code in RATE_LIMIT_STATUSES:
-            queue.append(current)
+            response.close()
+            queue.append((current, depth))
             seen_maps.discard(current)
             time.sleep(governor.penalize())
             continue
-        if response.status_code != 200 or not response.content.strip():
+        if response.status_code != 200:
+            response.close()
+            continue
+        content, too_large = read_bounded(response, MAX_SITEMAP_BYTES)
+        if too_large:
+            log(f"  sitemap skipped, larger than {MAX_SITEMAP_BYTES} bytes: {current}")
+            continue
+        if not content.strip():
             continue
         try:
-            kind, locs = sitemap_locs(response.content)
+            kind, locs = sitemap_locs(content)
         except (etree.XMLSyntaxError, ValueError):
             continue
         if kind == "sitemapindex":
-            queue += locs
+            queue += [(loc, depth + 1) for loc in locs]
         else:
             for loc in locs:
-                if same_authority(loc, authority):
+                if origin.owns(loc):
                     urls.append(loc)
                 else:
-                    skipped_foreign += 1
+                    stats["skipped_foreign"] += 1
         log(f"  {current}: {len(locs)} entries ({kind})")
 
-    if skipped_foreign:
-        log(f"  skipped {skipped_foreign} sitemap entries outside {authority}")
-    return list(dict.fromkeys(urls))
+    if stats["skipped_foreign"]:
+        log(f"  skipped {stats['skipped_foreign']} sitemap entries outside {origin.root}")
+    if stats["discovery_capped"]:
+        log(f"  discovery stopped: {stats['discovery_capped']}")
+    return list(dict.fromkeys(urls)), stats
 
 
 TAG_RE = re.compile(r"<(script|style|noscript|template)[^>]*>.*?</\1>", re.S | re.I)
@@ -270,15 +347,18 @@ def analyze_html(html: str) -> dict:
     }
 
 
-def crawl_one(session, url: str, authority: str, sig_headers: dict | None,
-              governor: RateLimitGovernor, timeout: int, save_html_dir: Path | None) -> dict:
-    headers = headers_for(url, authority, sig_headers)
+def crawl_one(session_for: Callable[[], requests.Session], url: str, origin: Origin,
+              sig_headers: dict | None, governor: RateLimitGovernor, timeout: int,
+              save_html_dir: Path | None) -> dict:
+    session = session_for()
+    headers = headers_for(url, origin, sig_headers)
     record: dict = {"url": url, "template": classify(url), "signed": bool(sig_headers)}
     for attempt in range(4):
         governor.wait()
         started = time.time()
         try:
-            response = session.get(url, headers=headers, timeout=timeout, allow_redirects=False)
+            response = session.get(url, headers=headers, timeout=timeout,
+                                   allow_redirects=False, stream=True)
         except requests.RequestException as exc:
             record["error"] = str(exc)
             time.sleep(1 + attempt)
@@ -290,6 +370,7 @@ def crawl_one(session, url: str, authority: str, sig_headers: dict | None,
             record["redirect_to"] = response.headers.get("Location")
 
         if response.status_code in RATE_LIMIT_STATUSES:
+            response.close()
             record["rate_limited"] = True
             time.sleep(governor.penalize())
             continue
@@ -300,10 +381,18 @@ def crawl_one(session, url: str, authority: str, sig_headers: dict | None,
         record["content_type"] = content_type
         record["html"] = response.status_code == 200 and "html" in content_type
         if record["html"]:
-            record.update(analyze_html(response.text))
+            content, too_large = read_bounded(response, MAX_PAGE_BYTES)
+            if too_large:
+                record["html"] = False
+                record["too_large"] = True
+                return record
+            text = decode_body(content, response)
+            record.update(analyze_html(text))
             if save_html_dir:
                 name = re.sub(r"[^A-Za-z0-9]+", "_", urlparse(url).path)[:120] or "index"
-                (save_html_dir / f"{name}.html").write_text(response.text, encoding="utf-8")
+                (save_html_dir / f"{name}.html").write_text(text, encoding="utf-8")
+        else:
+            response.close()
         return record
 
     record["failed"] = True
@@ -334,6 +423,7 @@ def summarize(records: list[dict]) -> dict:
         "html_documents": len(html_pages),
         "non_html_resources": len(ok) - len(html_pages),
         "redirects": sum(1 for r in records if r.get("redirect_to")),
+        "too_large": sum(1 for r in records if r.get("too_large")),
         "content_types": {str(k): v for k, v in Counter(r.get("content_type") for r in ok).most_common()},
         "status_distribution": {str(k): v for k, v in statuses.most_common()},
         "template_distribution": dict(by_template.most_common()),
@@ -390,6 +480,32 @@ def resolve_settings(args: argparse.Namespace, env: dict, entry: dict | None, si
             setattr(args, field, value)
 
 
+class ThreadSessions:
+    """One requests.Session per worker thread. Sessions are not documented as
+    thread-safe; DNS pinning is process-wide, so every session stays pinned."""
+
+    def __init__(self):
+        self._local = threading.local()
+        self._all: list[requests.Session] = []
+        self._lock = threading.Lock()
+
+    def get(self) -> requests.Session:
+        session = getattr(self._local, "session", None)
+        if session is None:
+            session = requests.Session()
+            session.headers.update(BASE_HEADERS)
+            self._local.session = session
+            with self._lock:
+                self._all.append(session)
+        return session
+
+    def close(self) -> None:
+        with self._lock:
+            for session in self._all:
+                session.close()
+            self._all.clear()
+
+
 def _log(message: str) -> None:
     print(message, file=sys.stderr)
 
@@ -421,8 +537,8 @@ def main(argv: list[str] | None = None) -> int:
         _log(f"Error: {exc}")
         return 1
     parsed = urlparse(norm_url)
-    root = f"{parsed.scheme}://{parsed.netloc}"
-    authority = parsed.netloc.lower()
+    origin = Origin(parsed.scheme, parsed.netloc)
+    authority = origin.authority
 
     env = shopify_env.load()
     if env["path"]:
@@ -457,21 +573,27 @@ def main(argv: list[str] | None = None) -> int:
         html_dir.mkdir(exist_ok=True)
 
     governor = RateLimitGovernor(args.delay)
-    with safe_requests_session(root) as session:
+    sessions = ThreadSessions()
+    with safe_requests_session(origin.root) as session:
         session.headers.update(BASE_HEADERS)
 
         robots_text = None
         try:
-            robots_response = session.get(f"{root}/robots.txt", timeout=15, allow_redirects=False,
-                                          headers=headers_for(f"{root}/robots.txt", authority, sig_headers))
+            robots_url = f"{origin.root}/robots.txt"
+            robots_response = session.get(robots_url, timeout=15, allow_redirects=False, stream=True,
+                                          headers=headers_for(robots_url, origin, sig_headers))
             if robots_response.status_code == 200:
-                robots_text = robots_response.text
+                content, too_large = read_bounded(robots_response, MAX_ROBOTS_BYTES)
+                if not too_large:
+                    robots_text = content.decode("utf-8", errors="replace")
+            else:
+                robots_response.close()
         except requests.RequestException:
             pass
 
-        _log(f"Discovering URLs from sitemaps of {root} ...")
-        urls = fetch_sitemap_urls(session, root, authority, governor, sig_headers=sig_headers,
-                                  target=args.max_pages, robots_text=robots_text, log=_log)
+        _log(f"Discovering URLs from sitemaps of {origin.root} ...")
+        urls, discovery = fetch_sitemap_urls(session, origin, governor, sig_headers=sig_headers,
+                                             target=args.max_pages, robots_text=robots_text, log=_log)
         if not urls:
             _log("Error: no sitemap URLs found. Shopify storefronts always expose /sitemap.xml; "
                  "check the host, or whether the store is password-protected.")
@@ -513,21 +635,24 @@ def main(argv: list[str] | None = None) -> int:
         write_lock = threading.Lock()
         mode = "a" if (args.resume and pages_file.exists()) else "w"
 
-        with pages_file.open(mode, encoding="utf-8") as sink:
-            with futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
-                pending = {pool.submit(crawl_one, session, url, authority, sig_headers,
-                                       governor, args.timeout, html_dir): url for url in urls}
-                for index, future in enumerate(futures.as_completed(pending), 1):
-                    record = future.result()
-                    with write_lock:
-                        sink.write(json.dumps(record, ensure_ascii=False) + "\n")
-                        sink.flush()
-                    records.append(record)
-                    if index % progress_every == 0 or index == len(urls):
-                        elapsed = time.time() - started_at
-                        eta = elapsed / (index / len(urls)) - elapsed
-                        _log(f"  {index}/{len(urls)} ({index / len(urls):.0%}) ETA {eta / 60:.0f} min, "
-                             f"delay {governor.delay:.2f}s, {governor.hits} rate-limit hits")
+        try:
+            with pages_file.open(mode, encoding="utf-8") as sink:
+                with futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+                    pending = {pool.submit(crawl_one, sessions.get, url, origin, sig_headers,
+                                           governor, args.timeout, html_dir): url for url in urls}
+                    for index, future in enumerate(futures.as_completed(pending), 1):
+                        record = future.result()
+                        with write_lock:
+                            sink.write(json.dumps(record, ensure_ascii=False) + "\n")
+                            sink.flush()
+                        records.append(record)
+                        if index % progress_every == 0 or index == len(urls):
+                            elapsed = time.time() - started_at
+                            eta = elapsed / (index / len(urls)) - elapsed
+                            _log(f"  {index}/{len(urls)} ({index / len(urls):.0%}) ETA {eta / 60:.0f} min, "
+                                 f"delay {governor.delay:.2f}s, {governor.hits} rate-limit hits")
+        finally:
+            sessions.close()
 
     if args.resume and done:
         for line in pages_file.read_text(encoding="utf-8").splitlines():
@@ -542,7 +667,9 @@ def main(argv: list[str] | None = None) -> int:
     summary["authority"] = authority
     summary["signed"] = bool(sig_headers)
     summary["urls_discovered"] = discovered
-    summary["truncated"] = bool(args.max_pages) and discovered > summary["pages_crawled"]
+    summary["discovery_capped"] = discovery["discovery_capped"]
+    summary["truncated"] = bool(discovery["discovery_capped"]) or (
+        bool(args.max_pages) and discovered > summary["pages_crawled"])
     (out_dir / "summary.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
     (out_dir / "sample.json").write_text(
         json.dumps(stratified_sample(records, args.sample_per_template), indent=2, ensure_ascii=False),

--- a/scripts/shopify_crawl.py
+++ b/scripts/shopify_crawl.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+"""
+Sitemap-driven Shopify storefront crawler with Crawler Access signatures.
+
+Shopify publishes a complete nested sitemap for every storefront, so the URL
+set comes from sitemap.xml instead of link following and no page cap is
+needed. When `.shopify-env` (see shopify_env.py) holds a Crawler Access
+signature for the target host, its three headers are attached to every
+request and the storefront lifts its rate limit. The signature is sent to
+that one host only.
+
+Every request goes through url_safety: the root is validated with
+validate_url_strict, the session is DNS-pinned, and redirects are recorded
+but never followed.
+
+Outputs in --out:
+    pages.jsonl   one record per URL (machine input; never hand this to a model)
+    summary.json  aggregate counts, issue tallies, latency percentiles
+    sample.json   a stratified sample of pages per template type
+
+Usage:
+    python shopify_crawl.py https://shop.example --out ./crawl
+    python shopify_crawl.py https://shop.example --max-pages 2000 --concurrency 4
+    python shopify_crawl.py https://shop.example --resume --json
+
+Exit codes: 0 ok, 1 nothing crawled, 5 rate limited on a signed request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures as futures
+import json
+import os
+import random
+import re
+import sys
+import threading
+import time
+from collections import Counter, defaultdict
+from html import unescape
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+try:
+    import requests
+    from lxml import etree
+except ImportError:
+    print("Error: requests and lxml required. Install with: pip install requests lxml", file=sys.stderr)
+    sys.exit(1)
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+import shopify_env  # noqa: E402
+from url_safety import URLSafetyError, safe_requests_session, validate_url_strict  # noqa: E402
+
+USER_AGENT = "ClaudeSEO-ShopifyCrawler (+https://github.com/AgriciDaniel/claude-seo)"
+BASE_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.8,*;q=0.5",
+    "Accept-Encoding": "gzip, deflate",
+}
+RATE_LIMIT_STATUSES = (429, 430, 503)
+
+# Shopify storefront URL shapes, in match order. Everything else is "page".
+TEMPLATE_PATTERNS = [
+    ("product", re.compile(r"/products/")),
+    ("collection", re.compile(r"/collections/[^/?]+/?$")),
+    ("collection_filtered", re.compile(r"/collections/.+\?")),
+    ("blog_article", re.compile(r"/blogs/[^/]+/[^/]+")),
+    ("blog_index", re.compile(r"/blogs/[^/]+/?$")),
+    ("policy", re.compile(r"/policies/")),
+    ("account", re.compile(r"/account")),
+    ("home", re.compile(r"^https?://[^/]+/?$")),
+]
+
+BUILTIN_DEFAULTS = {
+    "max_pages": 0,
+    "timeout": 30,
+    "sample_per_template": 6,
+    "include": None,
+    "exclude": None,
+    "save_html": False,
+    "ignore_robots": False,
+}
+
+
+class RateLimitGovernor:
+    """Grow the per-request delay when the storefront pushes back and shrink
+    it again after successes. Concurrency stays fixed for the run."""
+
+    def __init__(self, delay: float):
+        self.lock = threading.Lock()
+        self.base_delay = delay
+        self.delay = delay
+        self.hits = 0
+
+    def penalize(self) -> float:
+        with self.lock:
+            self.hits += 1
+            self.delay = min(self.delay * 2 if self.delay else 1.0, 30.0)
+            return self.delay * (1 + random.random())
+
+    def reward(self) -> None:
+        with self.lock:
+            if self.delay > self.base_delay:
+                self.delay = max(self.base_delay, self.delay / 1.5)
+
+    def wait(self) -> None:
+        if self.delay:
+            time.sleep(self.delay)
+
+
+def classify(url: str) -> str:
+    for name, pattern in TEMPLATE_PATTERNS:
+        if pattern.search(url):
+            return name
+    return "page"
+
+
+def headers_for(url: str, authority: str, sig_headers: dict | None) -> dict:
+    """Base headers, plus the signature only for the host it was issued for."""
+    headers = dict(BASE_HEADERS)
+    if sig_headers and urlparse(url).netloc.lower() == authority:
+        headers.update(sig_headers)
+    return headers
+
+
+def same_authority(url: str, authority: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme in ("http", "https") and parsed.netloc.lower() == authority
+
+
+def sitemap_locs(content: bytes) -> tuple[str, list[str]]:
+    """Return (kind, locs) for a sitemap document; kind is 'sitemapindex' or 'urlset'.
+
+    Only <loc> directly under <url> or <sitemap> counts. Shopify product
+    sitemaps also carry <image:loc>; those are assets, not pages.
+    """
+    if b"<!DOCTYPE" in content[:512].upper():
+        raise ValueError("DOCTYPE is not allowed in sitemap XML")
+    parser = etree.XMLParser(resolve_entities=False, no_network=True, load_dtd=False,
+                             recover=False, huge_tree=False)
+    tree = etree.fromstring(content, parser=parser)
+    kind = etree.QName(tree).localname.lower()
+    locs = []
+    for entry in tree:
+        if not isinstance(entry.tag, str) or etree.QName(entry).localname not in ("url", "sitemap"):
+            continue
+        for child in entry:
+            if isinstance(child.tag, str) and etree.QName(child).localname == "loc" and child.text:
+                locs.append(child.text.strip())
+                break
+    return kind, locs
+
+
+def fetch_sitemap_urls(session, root: str, authority: str, governor: RateLimitGovernor,
+                       sig_headers: dict | None = None, target: int = 0,
+                       robots_text: str | None = None, log=print) -> list[str]:
+    """Walk sitemap.xml and sitemap indexes recursively, same authority only.
+
+    `target` > 0 stops the walk once that many URLs are collected so a capped
+    crawl does not open every child sitemap of a large store.
+    """
+    seen_maps: set[str] = set()
+    queue: list[str] = []
+    urls: list[str] = []
+    skipped_foreign = 0
+
+    if robots_text:
+        queue += re.findall(r"(?im)^\s*sitemap:\s*(\S+)", robots_text)
+    queue.append(f"{root}/sitemap.xml")
+
+    while queue:
+        if target and len(urls) >= target:
+            log(f"  stopping sitemap walk at {len(urls)} URLs ({len(queue)} sitemaps not opened)")
+            break
+        current = queue.pop(0)
+        if current in seen_maps:
+            continue
+        seen_maps.add(current)
+        if not same_authority(current, authority):
+            skipped_foreign += 1
+            continue
+        try:
+            response = session.get(current, timeout=30, allow_redirects=False,
+                                   headers=headers_for(current, authority, sig_headers))
+        except requests.RequestException as exc:
+            log(f"  sitemap failed {current}: {exc}")
+            continue
+        if response.status_code in RATE_LIMIT_STATUSES:
+            queue.append(current)
+            seen_maps.discard(current)
+            time.sleep(governor.penalize())
+            continue
+        if response.status_code != 200 or not response.content.strip():
+            continue
+        try:
+            kind, locs = sitemap_locs(response.content)
+        except (etree.XMLSyntaxError, ValueError):
+            continue
+        if kind == "sitemapindex":
+            queue += locs
+        else:
+            for loc in locs:
+                if same_authority(loc, authority):
+                    urls.append(loc)
+                else:
+                    skipped_foreign += 1
+        log(f"  {current}: {len(locs)} entries ({kind})")
+
+    if skipped_foreign:
+        log(f"  skipped {skipped_foreign} sitemap entries outside {authority}")
+    return list(dict.fromkeys(urls))
+
+
+TAG_RE = re.compile(r"<(script|style|noscript|template)[^>]*>.*?</\1>", re.S | re.I)
+STRIP_RE = re.compile(r"<[^>]+>")
+
+
+def analyze_html(html: str) -> dict:
+    """Regex-level extraction, dependency-free. Aggregate signals only; the
+    per-page subagents still do real DOM analysis on the sample."""
+    def collapse(value: str) -> str:
+        return re.sub(r"\s+", " ", unescape(value)).strip()
+
+    def first(pattern: str):
+        found = re.search(pattern, html, re.I | re.S)
+        return collapse(found.group(1)) if found else None
+
+    title = first(r"<title[^>]*>(.*?)</title>")
+    description = first(r'<meta[^>]+name=["\']description["\'][^>]+content=["\'](.*?)["\']')
+    if not description:
+        description = first(r'<meta[^>]+content=["\'](.*?)["\'][^>]+name=["\']description["\']')
+    canonical = first(r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\'](.*?)["\']')
+    robots_meta = first(r'<meta[^>]+name=["\']robots["\'][^>]+content=["\'](.*?)["\']')
+
+    h1s = re.findall(r"<h1[^>]*>(.*?)</h1>", html, re.I | re.S)
+    hreflang = re.findall(r'<link[^>]+rel=["\']alternate["\'][^>]+hreflang=["\']([^"\']+)', html, re.I)
+
+    schema_types: list[str] = []
+    for block in re.findall(r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+                            html, re.I | re.S):
+        schema_types += re.findall(r'"@type"\s*:\s*"([^"]+)"', block)
+
+    # Count images on the rendered page only; themes keep <img> inside script
+    # templates and <noscript> fallbacks too.
+    visible = TAG_RE.sub(" ", html)
+    images = re.findall(r"<img\b[^>]*>", visible, re.I)
+    without_alt = [img for img in images if not re.search(r"\balt\s*=", img, re.I)]
+    words = len(STRIP_RE.sub(" ", visible).split())
+
+    return {
+        "title": title,
+        "title_length": len(title) if title else 0,
+        "meta_description": description,
+        "meta_description_length": len(description) if description else 0,
+        "canonical": canonical,
+        "robots_meta": robots_meta,
+        "h1_count": len(h1s),
+        "h1_first": collapse(STRIP_RE.sub("", h1s[0]))[:200] if h1s else None,
+        "hreflang": sorted(set(hreflang)),
+        "schema_types": sorted(set(schema_types)),
+        "image_count": len(images),
+        "images_without_alt": len(without_alt),
+        "word_count": words,
+    }
+
+
+def crawl_one(session, url: str, authority: str, sig_headers: dict | None,
+              governor: RateLimitGovernor, timeout: int, save_html_dir: Path | None) -> dict:
+    headers = headers_for(url, authority, sig_headers)
+    record: dict = {"url": url, "template": classify(url), "signed": bool(sig_headers)}
+    for attempt in range(4):
+        governor.wait()
+        started = time.time()
+        try:
+            response = session.get(url, headers=headers, timeout=timeout, allow_redirects=False)
+        except requests.RequestException as exc:
+            record["error"] = str(exc)
+            time.sleep(1 + attempt)
+            continue
+
+        record["status"] = response.status_code
+        record["elapsed_ms"] = int((time.time() - started) * 1000)
+        if 300 <= response.status_code < 400:
+            record["redirect_to"] = response.headers.get("Location")
+
+        if response.status_code in RATE_LIMIT_STATUSES:
+            record["rate_limited"] = True
+            time.sleep(governor.penalize())
+            continue
+
+        governor.reward()
+        record.pop("error", None)
+        content_type = response.headers.get("Content-Type", "").split(";")[0].strip()
+        record["content_type"] = content_type
+        record["html"] = response.status_code == 200 and "html" in content_type
+        if record["html"]:
+            record.update(analyze_html(response.text))
+            if save_html_dir:
+                name = re.sub(r"[^A-Za-z0-9]+", "_", urlparse(url).path)[:120] or "index"
+                (save_html_dir / f"{name}.html").write_text(response.text, encoding="utf-8")
+        return record
+
+    record["failed"] = True
+    return record
+
+
+def summarize(records: list[dict]) -> dict:
+    by_template = Counter(r["template"] for r in records)
+    statuses = Counter(r.get("status") for r in records)
+    ok = [r for r in records if r.get("status") == 200]
+    # Sitemaps list agents.md, feeds and other non-HTML resources too; issue
+    # counts only make sense for HTML documents.
+    html_pages = [r for r in ok if r.get("html")]
+    titles = Counter(r.get("title") for r in html_pages if r.get("title"))
+
+    def count(predicate) -> int:
+        return sum(1 for r in html_pages if predicate(r))
+
+    schema_coverage: dict[str, int] = defaultdict(int)
+    for record in html_pages:
+        for schema_type in record.get("schema_types", []):
+            schema_coverage[schema_type] += 1
+
+    latencies = sorted(r["elapsed_ms"] for r in ok if r.get("elapsed_ms"))
+    return {
+        "pages_crawled": len(records),
+        "pages_ok": len(ok),
+        "html_documents": len(html_pages),
+        "non_html_resources": len(ok) - len(html_pages),
+        "redirects": sum(1 for r in records if r.get("redirect_to")),
+        "content_types": {str(k): v for k, v in Counter(r.get("content_type") for r in ok).most_common()},
+        "status_distribution": {str(k): v for k, v in statuses.most_common()},
+        "template_distribution": dict(by_template.most_common()),
+        "rate_limited_requests": sum(1 for r in records if r.get("rate_limited")),
+        "issues": {
+            "missing_title": count(lambda r: not r.get("title")),
+            "title_over_60": count(lambda r: r.get("title_length", 0) > 60),
+            "missing_meta_description": count(lambda r: not r.get("meta_description")),
+            "meta_description_out_of_range": count(
+                lambda r: r.get("meta_description")
+                and not 150 <= r.get("meta_description_length", 0) <= 160),
+            "duplicate_titles": sum(c for c in titles.values() if c > 1),
+            "missing_canonical": count(lambda r: not r.get("canonical")),
+            "noindex": count(lambda r: "noindex" in (r.get("robots_meta") or "")),
+            "h1_missing": count(lambda r: r.get("h1_count") == 0),
+            "h1_multiple": count(lambda r: r.get("h1_count", 0) > 1),
+            "thin_content_under_250_words": count(lambda r: r.get("word_count", 0) < 250),
+            "images_without_alt": sum(r.get("images_without_alt", 0) for r in html_pages),
+        },
+        "schema_coverage": dict(sorted(schema_coverage.items(), key=lambda kv: -kv[1])),
+        "latency_ms": {
+            "p50": latencies[len(latencies) // 2] if latencies else None,
+            "p95": latencies[int(len(latencies) * 0.95)] if latencies else None,
+        },
+        "duplicate_title_examples": [t for t, c in titles.most_common(10) if c > 1],
+    }
+
+
+def stratified_sample(records: list[dict], per_template: int) -> list[dict]:
+    buckets: dict[str, list[dict]] = defaultdict(list)
+    for record in records:
+        buckets[record["template"]].append(record)
+    sample: list[dict] = []
+    for items in buckets.values():
+        ok = [r for r in items if r.get("html")] or items
+        step = max(1, len(ok) // per_template)
+        sample += ok[::step][:per_template]
+    return sample
+
+
+def resolve_settings(args: argparse.Namespace, env: dict, entry: dict | None, signed: bool) -> None:
+    """CLI flag beats the domain block, which beats the global keys, which beat
+    the built-in defaults. Unset attributes on `args` are filled in place."""
+    builtin = dict(BUILTIN_DEFAULTS)
+    builtin["concurrency"] = 6 if signed else 2
+    builtin["delay"] = 0.2 if signed else 1.0
+    layers = [builtin, env.get("crawl", {}), (entry or {}).get("crawl", {})]
+    for field, fallback in builtin.items():
+        if getattr(args, field, None) is None:
+            value = fallback
+            for layer in layers:
+                if layer.get(field) is not None:
+                    value = layer[field]
+            setattr(args, field, value)
+
+
+def _log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sitemap-driven Shopify storefront crawler")
+    parser.add_argument("url", help="storefront root, e.g. https://shop.example")
+    parser.add_argument("--out", default="./crawl", help="output directory")
+    # Defaults stay None so .shopify-env can fill them; the command line still wins.
+    parser.add_argument("--max-pages", type=int, help="0 = no cap (default)")
+    parser.add_argument("--concurrency", type=int, help="default 6 signed, 2 unsigned")
+    parser.add_argument("--delay", type=float, help="base delay per request; grows on 429")
+    parser.add_argument("--timeout", type=int)
+    parser.add_argument("--sample-per-template", type=int)
+    parser.add_argument("--include", help="regex; crawl only matching URLs")
+    parser.add_argument("--exclude", help="regex; skip matching URLs")
+    parser.add_argument("--save-html", action="store_true", default=None)
+    parser.add_argument("--resume", action="store_true", help="skip URLs already in pages.jsonl")
+    parser.add_argument("--ignore-robots", action="store_true", default=None)
+    parser.add_argument("--no-signature", action="store_true",
+                        help="crawl unsigned even when a signature exists")
+    parser.add_argument("--json", action="store_true", help="print the full summary as JSON")
+    args = parser.parse_args(argv)
+
+    raw = args.url if "://" in args.url else f"https://{args.url}"
+    try:
+        norm_url, _ = validate_url_strict(raw)
+    except URLSafetyError as exc:
+        _log(f"Error: {exc}")
+        return 1
+    parsed = urlparse(norm_url)
+    root = f"{parsed.scheme}://{parsed.netloc}"
+    authority = parsed.netloc.lower()
+
+    env = shopify_env.load()
+    if env["path"]:
+        _log(f"Using crawl settings from {env['path']}")
+        warning = shopify_env.gitignore_warning(env["path"])
+        if warning:
+            _log(warning)
+        for problem in env["problems"]:
+            _log(f"  {problem}")
+
+    entry = env["authorities"].get(authority)
+    sig_headers = None
+    if args.no_signature:
+        entry = None
+    elif entry and shopify_env.days_left(entry.get("expires")) > 0:
+        sig_headers = shopify_env.signature_headers(entry)
+        _log(f"Crawler Access signature active for {authority} "
+             f"({shopify_env.days_left(entry['expires']):.0f} days left)")
+    elif entry:
+        _log(f"WARNING: signature for {authority} is expired; crawling unsigned at normal rate limits.")
+    else:
+        _log(f"No signature for {authority}; crawling unsigned.")
+
+    resolve_settings(args, env, entry, bool(sig_headers))
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pages_file = out_dir / "pages.jsonl"
+    html_dir = None
+    if args.save_html:
+        html_dir = out_dir / "html"
+        html_dir.mkdir(exist_ok=True)
+
+    governor = RateLimitGovernor(args.delay)
+    with safe_requests_session(root) as session:
+        session.headers.update(BASE_HEADERS)
+
+        robots_text = None
+        try:
+            robots_response = session.get(f"{root}/robots.txt", timeout=15, allow_redirects=False,
+                                          headers=headers_for(f"{root}/robots.txt", authority, sig_headers))
+            if robots_response.status_code == 200:
+                robots_text = robots_response.text
+        except requests.RequestException:
+            pass
+
+        _log(f"Discovering URLs from sitemaps of {root} ...")
+        urls = fetch_sitemap_urls(session, root, authority, governor, sig_headers=sig_headers,
+                                  target=args.max_pages, robots_text=robots_text, log=_log)
+        if not urls:
+            _log("Error: no sitemap URLs found. Shopify storefronts always expose /sitemap.xml; "
+                 "check the host, or whether the store is password-protected.")
+            return 1
+
+        if args.include:
+            pattern = re.compile(args.include)
+            urls = [u for u in urls if pattern.search(u)]
+        if args.exclude:
+            pattern = re.compile(args.exclude)
+            urls = [u for u in urls if not pattern.search(u)]
+
+        if not args.ignore_robots and robots_text:
+            robots = RobotFileParser()
+            robots.parse(robots_text.splitlines())
+            urls = [u for u in urls if robots.can_fetch(USER_AGENT, u)]
+
+        done: set[str] = set()
+        if args.resume and pages_file.exists():
+            for line in pages_file.read_text(encoding="utf-8").splitlines():
+                try:
+                    done.add(json.loads(line)["url"])
+                except (json.JSONDecodeError, KeyError):
+                    continue
+            urls = [u for u in urls if u not in done]
+            _log(f"Resuming: {len(done)} already crawled, {len(urls)} left")
+
+        discovered = len(urls) + len(done)
+        if args.max_pages and len(urls) > args.max_pages:
+            _log(f"Capping at --max-pages {args.max_pages} of {len(urls)} discovered URLs; "
+                 f"report this truncation in the audit.")
+            urls = urls[:args.max_pages]
+
+        _log(f"Crawling {len(urls)} URLs, concurrency {args.concurrency}, delay {args.delay}s"
+             + ("" if args.max_pages else " (no page cap)"))
+        progress_every = max(25, min(500, len(urls) // 50 or 25))
+        started_at = time.time()
+        records: list[dict] = []
+        write_lock = threading.Lock()
+        mode = "a" if (args.resume and pages_file.exists()) else "w"
+
+        with pages_file.open(mode, encoding="utf-8") as sink:
+            with futures.ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+                pending = {pool.submit(crawl_one, session, url, authority, sig_headers,
+                                       governor, args.timeout, html_dir): url for url in urls}
+                for index, future in enumerate(futures.as_completed(pending), 1):
+                    record = future.result()
+                    with write_lock:
+                        sink.write(json.dumps(record, ensure_ascii=False) + "\n")
+                        sink.flush()
+                    records.append(record)
+                    if index % progress_every == 0 or index == len(urls):
+                        elapsed = time.time() - started_at
+                        eta = elapsed / (index / len(urls)) - elapsed
+                        _log(f"  {index}/{len(urls)} ({index / len(urls):.0%}) ETA {eta / 60:.0f} min, "
+                             f"delay {governor.delay:.2f}s, {governor.hits} rate-limit hits")
+
+    if args.resume and done:
+        for line in pages_file.read_text(encoding="utf-8").splitlines():
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if record.get("url") in done:
+                records.append(record)
+
+    summary = summarize(records)
+    summary["authority"] = authority
+    summary["signed"] = bool(sig_headers)
+    summary["urls_discovered"] = discovered
+    summary["truncated"] = bool(args.max_pages) and discovered > summary["pages_crawled"]
+    (out_dir / "summary.json").write_text(json.dumps(summary, indent=2, ensure_ascii=False), encoding="utf-8")
+    (out_dir / "sample.json").write_text(
+        json.dumps(stratified_sample(records, args.sample_per_template), indent=2, ensure_ascii=False),
+        encoding="utf-8")
+
+    _log(f"Done. {summary['pages_crawled']} pages -> {out_dir}")
+    print(json.dumps(summary if args.json else summary["issues"], indent=2, ensure_ascii=False))
+
+    if governor.hits and sig_headers:
+        _log("WARNING: rate limited despite a signature. Shopify treats that as an invalid "
+             "signature; check its expiry and that the host matches the one it was issued for.")
+        return 5
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shopify_env.py
+++ b/scripts/shopify_env.py
@@ -20,14 +20,14 @@ settings shared by every shop in the file:
     Signature       = sig1=:...:
     Signature-Agent = "https://shopify.com"      # optional, this is the default
 
-Lookup order: $SHOPIFY_ENV, then `.shopify-env` in the current directory and
-up to five parents. The file holds client credentials; keep it out of git.
+Lookup order: the file named by $SHOPIFY_ENV (any path), then `.shopify-env`
+in the current directory and up to five parents. The file holds client
+credentials; keep it out of git. No command prints the signature values.
 
 Usage:
     python shopify_env.py list [--json]
     python shopify_env.py check <url> [--json]
     python shopify_env.py precheck <url>
-    python shopify_env.py headers <url>
 """
 
 from __future__ import annotations
@@ -364,16 +364,6 @@ def cmd_precheck(args) -> int:
     return 0
 
 
-def cmd_headers(args) -> int:
-    """Print the three headers as JSON, or an empty object when none apply."""
-    _, entry, _ = lookup(args.url)
-    if not entry or not days_left(entry.get("expires")) > 0:
-        print("{}")
-        return 3
-    print(json.dumps(signature_headers(entry)))
-    return 0
-
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -391,10 +381,6 @@ def main(argv: list[str] | None = None) -> int:
     pre = sub.add_parser("precheck", help="decide signed vs fallback for an audit (always JSON, exit 0)")
     pre.add_argument("url")
     pre.set_defaults(func=cmd_precheck)
-
-    hdr = sub.add_parser("headers", help="print the signature headers for a URL as JSON")
-    hdr.add_argument("url")
-    hdr.set_defaults(func=cmd_headers)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/scripts/shopify_env.py
+++ b/scripts/shopify_env.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Read Shopify Crawler Access signatures from a project-local `.shopify-env`.
+
+Shopify merchants mint a crawl credential in their admin under
+Online Store > Preferences > Crawler access. The admin prints three HTTP
+header values (RFC 9421 message signature, tag "web-bot-auth"). A crawler
+that replays them is not rate limited by the storefront. The signature is
+bound to one authority (host) and expires after roughly 90 days.
+
+The file lives in the folder an audit runs from, one block per shop. A new
+`Domain=` line starts a block; keys before the first `Domain=` are crawl
+settings shared by every shop in the file:
+
+    Max-Pages   = 0
+    Concurrency = 6
+
+    Domain          = shop.example
+    Signature-Input = sig1=("@authority" "signature-agent");keyid="...";tag="web-bot-auth";created=...;expires=...
+    Signature       = sig1=:...:
+    Signature-Agent = "https://shopify.com"      # optional, this is the default
+
+Lookup order: $SHOPIFY_ENV, then `.shopify-env` in the current directory and
+up to five parents. The file holds client credentials; keep it out of git.
+
+Usage:
+    python shopify_env.py list [--json]
+    python shopify_env.py check <url> [--json]
+    python shopify_env.py precheck <url>
+    python shopify_env.py headers <url>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+ENV_FILENAME = ".shopify-env"
+ENV_PATH_VAR = "SHOPIFY_ENV"
+DEFAULT_SIGNATURE_AGENT = '"https://shopify.com"'
+PARENT_LEVELS = 5
+REQUIRED_TAG = "web-bot-auth"
+EXPIRY_WARN_DAYS = 14
+
+# Header values are replayed byte-exact; never strip quotes from them.
+VERBATIM_KEYS = {"signature-input", "signature", "signature-agent"}
+
+
+def _flag(value: str) -> bool:
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+CRAWL_KEYS = {
+    "max-pages": ("max_pages", int),
+    "concurrency": ("concurrency", int),
+    "delay": ("delay", float),
+    "timeout": ("timeout", int),
+    "sample-per-template": ("sample_per_template", int),
+    "include": ("include", str),
+    "exclude": ("exclude", str),
+    "save-html": ("save_html", _flag),
+    "ignore-robots": ("ignore_robots", _flag),
+}
+
+
+def normalize_key(raw: str) -> str:
+    return raw.strip().lower().replace("_", "-")
+
+
+def normalize_authority(value: str) -> str:
+    """Accept a bare host or a full URL and return the lower-cased authority."""
+    value = value.strip().strip('"').strip("'")
+    if "://" in value:
+        return (urlparse(value).netloc or "").lower()
+    return value.split("/")[0].lower()
+
+
+def normalize_signature_agent(value: str) -> str:
+    """Shopify expects the value including its quotation marks."""
+    value = value.strip()
+    if not value:
+        return DEFAULT_SIGNATURE_AGENT
+    if not value.startswith('"'):
+        value = f'"{value.strip(chr(39))}"'
+    return value
+
+
+def parse_signature_input(raw: str) -> dict:
+    """Extract label, covered components, keyid, tag, created and expires."""
+    meta = {"label": None, "covered": [], "keyid": None, "tag": None,
+            "created": None, "expires": None}
+    label = re.match(r"\s*([A-Za-z0-9_-]+)\s*=", raw)
+    if label:
+        meta["label"] = label.group(1)
+    covered = re.search(r"=\s*\(([^)]*)\)", raw)
+    if covered:
+        meta["covered"] = re.findall(r'"([^"]+)"', covered.group(1))
+    for key in ("keyid", "tag"):
+        found = re.search(rf'{key}="([^"]*)"', raw)
+        if found:
+            meta[key] = found.group(1)
+    for key in ("created", "expires"):
+        found = re.search(rf"{key}=(\d+)", raw)
+        if found:
+            meta[key] = int(found.group(1))
+    return meta
+
+
+def validate_signature_input(meta: dict) -> list[str]:
+    problems = []
+    if meta["tag"] != REQUIRED_TAG:
+        problems.append(f'tag is {meta["tag"]!r}, expected "{REQUIRED_TAG}"')
+    if "@authority" not in meta["covered"]:
+        problems.append('covered components do not include "@authority"')
+    if not meta["keyid"]:
+        problems.append("no keyid in Signature-Input")
+    if not meta["expires"]:
+        problems.append("no expires in Signature-Input")
+    return problems
+
+
+def days_left(expires) -> float:
+    if not expires:
+        return float("nan")
+    return (expires - time.time()) / 86400.0
+
+
+def find_env_file(start: Path | None = None) -> Path | None:
+    explicit = os.environ.get(ENV_PATH_VAR)
+    if explicit:
+        path = Path(explicit)
+        return path if path.is_file() else None
+    current = (start or Path.cwd()).resolve()
+    for _ in range(PARENT_LEVELS + 1):
+        candidate = current / ENV_FILENAME
+        if candidate.is_file():
+            return candidate
+        if current.parent == current:
+            break
+        current = current.parent
+    return None
+
+
+def parse_env_file(path: Path) -> dict:
+    result: dict = {"path": str(path), "authorities": {}, "crawl": {}, "problems": []}
+    block: dict | None = None
+
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw.strip()
+        if not line or line[0] in "#;":
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            line = f"Domain={line[1:-1]}"
+        if "=" not in line:
+            result["problems"].append(f"line {lineno}: no '=' (ignored)")
+            continue
+
+        key, _, value = line.partition("=")
+        key = normalize_key(key)
+        value = value.strip() if key in VERBATIM_KEYS else value.strip().strip('"').strip("'")
+
+        if key == "domain":
+            authority = normalize_authority(value)
+            if not authority:
+                result["problems"].append(f"line {lineno}: empty Domain")
+                block = None
+                continue
+            block = {"authority": authority, "signature_agent": DEFAULT_SIGNATURE_AGENT,
+                     "source": f"{path.name}:{lineno}"}
+            result["authorities"][authority] = block
+            continue
+
+        if key in VERBATIM_KEYS:
+            if block is None:
+                result["problems"].append(f"line {lineno}: {key} before any Domain= line (ignored)")
+                continue
+            field = key.replace("-", "_")
+            block[field] = normalize_signature_agent(value) if key == "signature-agent" else value
+            continue
+
+        if key in CRAWL_KEYS:
+            field, caster = CRAWL_KEYS[key]
+            try:
+                cast = caster(value)
+            except (TypeError, ValueError):
+                result["problems"].append(f"line {lineno}: {key} is not usable (ignored)")
+                continue
+            target = block.setdefault("crawl", {}) if block else result["crawl"]
+            target[field] = cast
+            continue
+
+        result["problems"].append(f"line {lineno}: unknown key {key!r} (ignored)")
+
+    for authority, entry in list(result["authorities"].items()):
+        missing = [k for k in ("signature_input", "signature") if not entry.get(k)]
+        if missing:
+            result["problems"].append(
+                f"{authority}: missing {', '.join(m.replace('_', '-') for m in missing)} (domain skipped)")
+            result["authorities"].pop(authority)
+            continue
+        meta = parse_signature_input(entry["signature_input"])
+        entry.update({"keyid": meta["keyid"], "created": meta["created"], "expires": meta["expires"]})
+        for problem in validate_signature_input(meta):
+            result["problems"].append(f"{authority}: {problem}")
+
+    return result
+
+
+def load(start: Path | None = None) -> dict:
+    path = find_env_file(start)
+    if not path:
+        return {"path": None, "authorities": {}, "crawl": {}, "problems": []}
+    return parse_env_file(path)
+
+
+def lookup(url_or_host: str, start: Path | None = None) -> tuple[str, dict | None, dict]:
+    """Return (authority, entry or None, whole env) for one URL or host."""
+    authority = normalize_authority(url_or_host)
+    env = load(start)
+    return authority, env["authorities"].get(authority), env
+
+
+def signature_headers(entry: dict) -> dict:
+    return {
+        "Signature-Agent": entry.get("signature_agent", DEFAULT_SIGNATURE_AGENT),
+        "Signature-Input": entry["signature_input"],
+        "Signature": entry["signature"],
+    }
+
+
+def gitignore_warning(path) -> str:
+    """Warn when the env file sits in a git work tree without being ignored."""
+    if not path:
+        return ""
+    path = Path(path)
+    try:
+        inside = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=str(path.parent), capture_output=True, timeout=10)
+        ignored = subprocess.run(
+            ["git", "check-ignore", "-q", path.name],
+            cwd=str(path.parent), capture_output=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if inside.returncode != 0 or b"true" not in inside.stdout or ignored.returncode == 0:
+        return ""
+    return (f"WARNING: {path.name} holds crawl credentials and is not git-ignored in "
+            f"{path.parent}. Add '{ENV_FILENAME}' to .gitignore before committing.")
+
+
+def precheck(url: str, start: Path | None = None) -> dict:
+    """Decide whether an audit of `url` can run the signed, uncapped crawl.
+
+    Never raises: a broken env file must not abort an audit, it just means the
+    audit runs the plain link-following crawl.
+    """
+    result = {"mode": "fallback", "url": url, "authority": None, "reason": None,
+              "detail": None, "env_file": None}
+    try:
+        authority, entry, env = lookup(url, start)
+    except Exception as exc:  # noqa: BLE001 - any read problem means fallback
+        result["reason"] = "env_unreadable"
+        result["detail"] = f"{ENV_FILENAME} could not be read: {exc}"
+        return result
+    result["authority"] = authority
+    result["env_file"] = env["path"]
+    if not env["path"]:
+        result["reason"] = "no_env_file"
+        result["detail"] = f"No {ENV_FILENAME} in the working directory or its parents."
+        return result
+    if not entry:
+        result["reason"] = "no_signature"
+        result["detail"] = (f"{env['path']} has no block for {authority}. A signature is bound "
+                            f"to one host; if the store serves on the other of apex/www, "
+                            f"check that host.")
+        return result
+    left = days_left(entry.get("expires"))
+    if not left == left or left <= 0:  # NaN or expired
+        result["reason"] = "signature_expired"
+        result["detail"] = (f"The signature for {authority} is expired or has no expiry. Issue "
+                            f"a new one in the Shopify admin under Online Store > Preferences "
+                            f"> Crawler access.")
+        return result
+    result["mode"] = "signed"
+    result["reason"] = "signature_valid"
+    result["days_left"] = round(left)
+    result["detail"] = (f"Signature for {authority} is valid for {left:.0f} more days. "
+                        f"Crawl the complete sitemap with no page cap.")
+    return result
+
+
+def _describe(authority: str, entry: dict) -> str:
+    left = days_left(entry.get("expires"))
+    state = "expired" if not left == left or left <= 0 else (
+        "expiring" if left < EXPIRY_WARN_DAYS else "ok")
+    days = f"{left:6.0f}d" if left == left else "     ?"
+    return f"{authority:38s} {state:8s} {days}  {entry.get('source', '')}"
+
+
+def cmd_list(args) -> int:
+    env = load()
+    if args.json:
+        public = {
+            "path": env["path"],
+            "crawl": env["crawl"],
+            "problems": env["problems"],
+            "authorities": {
+                a: {"keyid": e.get("keyid"), "expires": e.get("expires"),
+                    "days_left": round(days_left(e.get("expires")))
+                    if e.get("expires") else None, "crawl": e.get("crawl", {}),
+                    "source": e.get("source")}
+                for a, e in env["authorities"].items()
+            },
+        }
+        print(json.dumps(public, indent=2))
+        return 0 if env["path"] else 3
+    if not env["path"]:
+        print(f"No {ENV_FILENAME} found in the current directory or its parents.")
+        return 3
+    print(f"Using {env['path']}")
+    warning = gitignore_warning(env["path"])
+    if warning:
+        print(warning, file=sys.stderr)
+    for authority, entry in sorted(env["authorities"].items()):
+        print(_describe(authority, entry))
+    if env["crawl"]:
+        print(f"crawl settings: {json.dumps(env['crawl'])}")
+    for problem in env["problems"]:
+        print(f"problem: {problem}", file=sys.stderr)
+    return 0
+
+
+def cmd_check(args) -> int:
+    authority, entry, env = lookup(args.url)
+    if not entry:
+        if args.json:
+            print(json.dumps({"authority": authority, "signed": False, "env_file": env["path"]}))
+        else:
+            print(f"No signature for {authority}")
+        return 3
+    left = days_left(entry.get("expires"))
+    valid = left == left and left > 0
+    if args.json:
+        print(json.dumps({"authority": authority, "signed": valid,
+                          "days_left": round(left) if left == left else None,
+                          "keyid": entry.get("keyid"), "env_file": env["path"]}))
+    elif valid:
+        print(f"{authority}: valid, {left:.0f} days left ({entry.get('source')})")
+    else:
+        print(f"{authority}: expired. Issue a new signature in the Shopify admin "
+              f"(Online Store > Preferences > Crawler access).")
+    return 0 if valid else 4
+
+
+def cmd_precheck(args) -> int:
+    print(json.dumps(precheck(args.url), indent=2))
+    return 0
+
+
+def cmd_headers(args) -> int:
+    """Print the three headers as JSON, or an empty object when none apply."""
+    _, entry, _ = lookup(args.url)
+    if not entry or not days_left(entry.get("expires")) > 0:
+        print("{}")
+        return 3
+    print(json.dumps(signature_headers(entry)))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    lst = sub.add_parser("list", help="list the signatures in the env file with their expiry")
+    lst.add_argument("--json", action="store_true")
+    lst.set_defaults(func=cmd_list)
+
+    chk = sub.add_parser("check", help="report whether a URL's host has a valid signature")
+    chk.add_argument("url")
+    chk.add_argument("--json", action="store_true")
+    chk.set_defaults(func=cmd_check)
+
+    pre = sub.add_parser("precheck", help="decide signed vs fallback for an audit (always JSON, exit 0)")
+    pre.add_argument("url")
+    pre.set_defaults(func=cmd_precheck)
+
+    hdr = sub.add_parser("headers", help="print the signature headers for a URL as JSON")
+    hdr.add_argument("url")
+    hdr.set_defaults(func=cmd_headers)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 1. **Render homepage**: use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto --json` to capture raw HTML, rendered HTML, extracted text, SPA status, and accessibility data when needed
 2. **Detect business type**: analyze homepage signals per seo orchestrator
-3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt
+3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt. For a Shopify storefront whose host has a Crawler Access signature in `.shopify-env` (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_env.py precheck <url>` reports `"mode": "signed"`), crawl with the `seo-shopify` extension instead: uncapped, sitemap-complete, and its `summary.json` and `sample.json` replace the link crawl as subagent input
 4. **Delegate to subagents** (if available, otherwise run inline sequentially):
    - `seo-technical` -- robots.txt, sitemaps, canonicals, Core Web Vitals, security headers
    - `seo-content` -- E-E-A-T, readability, thin content, AI citation readiness

--- a/skills/seo-audit/SKILL.md
+++ b/skills/seo-audit/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 
 1. **Render homepage**: use `"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run render_page.py <url> --mode auto --json` to capture raw HTML, rendered HTML, extracted text, SPA status, and accessibility data when needed
 2. **Detect business type**: analyze homepage signals per seo orchestrator
-3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt. For a Shopify storefront whose host has a Crawler Access signature in `.shopify-env` (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_env.py precheck <url>` reports `"mode": "signed"`), crawl with the `seo-shopify` extension instead: uncapped, sitemap-complete, and its `summary.json` and `sample.json` replace the link crawl as subagent input
+3. **Crawl site**: follow internal links up to 500 pages, respect robots.txt. For a Shopify storefront whose host has a Crawler Access signature in `.shopify-env` (`"${CLAUDE_PLUGIN_ROOT}/scripts/claude-seo" run shopify_env.py precheck <url>` reports `"mode": "signed"`), crawl with the seo-shopify extension (extensions/shopify) instead: uncapped, sitemap-complete, and its `summary.json` and `sample.json` replace the link crawl as subagent input
 4. **Delegate to subagents** (if available, otherwise run inline sequentially):
    - `seo-technical` -- robots.txt, sitemaps, canonicals, Core Web Vitals, security headers
    - `seo-content` -- E-E-A-T, readability, thin content, AI citation readiness

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -59,6 +59,7 @@ extension is also installable (see "Optional Extensions" below).
 | `/seo firecrawl [command] <url>` | Full-site crawling and site mapping (extension) |
 | `/seo dataforseo [command]` | Live SEO data via DataForSEO (extension) |
 | `/seo image-gen [use-case] <description>` | AI image generation for SEO assets (extension) |
+| `/seo shopify [crawl\|check] <url>` | Uncapped signed crawl of a Shopify store you administer, then the audit pipeline (extension) |
 | `/seo flow [stage] [url\|topic]` | FLOW framework: evidence-led prompts for Find, Leverage, Optimize, Win, or Local stages |
 | `/seo setup` | Explicitly create or refresh the isolated Python runtime and Chromium |
 | `/seo doctor` | Check runtime readiness without changing the system |
@@ -254,7 +255,7 @@ installer to activate (see each extension's `install.sh`/`install.ps1`):
 
 All optional extensions are reachable through `/seo` subcommands once
 installed: firecrawl, dataforseo, and image-gen, plus `/seo ahrefs`,
-`/seo bing`, `/seo profound`, `/seo seranking`, and `/seo unlighthouse`.
+`/seo bing`, `/seo profound`, `/seo seranking`, `/seo shopify`, and `/seo unlighthouse`.
 Each installs as its own sub-skill, so the model also auto-routes to their
 descriptions without the `/seo` prefix.
 

--- a/tests/test_parasite_risk_and_extensions.py
+++ b/tests/test_parasite_risk_and_extensions.py
@@ -106,6 +106,7 @@ def test_audit_page_counts_pattern_hits() -> None:
         ("profound", "seo-profound"),
         ("bing-webmaster", "seo-bing"),
         ("unlighthouse", "seo-unlighthouse"),
+        ("shopify", "seo-shopify"),
     ],
 )
 def test_extension_has_install_skill_and_docs(name: str, skill_dir: str) -> None:
@@ -131,7 +132,7 @@ _POSIX_ONLY = pytest.mark.skipif(
 
 @_POSIX_ONLY
 @pytest.mark.parametrize(
-    "name", ["ahrefs", "seranking", "profound", "bing-webmaster", "unlighthouse"],
+    "name", ["ahrefs", "seranking", "profound", "bing-webmaster", "unlighthouse", "shopify"],
 )
 def test_extension_install_script_is_executable(name: str) -> None:
     install = _REPO_ROOT / "extensions" / name / "install.sh"
@@ -166,6 +167,7 @@ def test_every_extension_install_and_uninstall_is_executable() -> None:
         ("profound", "seo-profound"),
         ("bing-webmaster", "seo-bing"),
         ("unlighthouse", "seo-unlighthouse"),
+        ("shopify", "seo-shopify"),
     ],
 )
 def test_extension_skillmd_has_required_frontmatter(

--- a/tests/test_shopify_crawl.py
+++ b/tests/test_shopify_crawl.py
@@ -1,4 +1,4 @@
-"""Shopify crawler: sitemap walk, host binding of the signature, HTML signals, summary."""
+"""Shopify crawler: sitemap walk, origin binding of the signature, bounded reads, HTML signals, summary."""
 
 from __future__ import annotations
 
@@ -22,26 +22,38 @@ crawl = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(crawl)
 
 SIG = {"Signature-Agent": '"https://shopify.com"', "Signature-Input": "sig1=(...)", "Signature": "sig1=:x:"}
+ORIGIN = crawl.Origin("https", "shop.example")
 
 
 class _Response:
     def __init__(self, status: int, content: bytes = b"", headers: dict | None = None):
         self.status_code = status
-        self.content = content
-        self.text = content.decode("utf-8", "replace")
+        self._content = content
         self.headers = headers or {}
+        self.encoding = "utf-8"
+        self.closed = False
+
+    def iter_content(self, chunk_size=65536):
+        for start in range(0, len(self._content), chunk_size):
+            yield self._content[start:start + chunk_size]
+
+    def close(self):
+        self.closed = True
 
 
 class _Session:
     """Serves canned responses and records which headers each URL received."""
 
-    def __init__(self, routes: dict[str, _Response]):
-        self.routes = routes
+    def __init__(self, routes: dict[str, _Response] | None = None, factory=None):
+        self.routes = routes or {}
+        self.factory = factory
         self.calls: list[tuple[str, dict]] = []
         self.headers: dict = {}
 
     def get(self, url, headers=None, **kwargs):
         self.calls.append((url, dict(headers or {})))
+        if self.factory:
+            return self.factory(url)
         return self.routes.get(url, _Response(404))
 
 
@@ -49,6 +61,7 @@ SITEMAP_INDEX = b"""<?xml version="1.0"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <sitemap><loc>https://shop.example/sitemap_products_1.xml</loc></sitemap>
   <sitemap><loc>https://cdn.other.example/sitemap_evil.xml</loc></sitemap>
+  <sitemap><loc>http://shop.example/sitemap_plain.xml</loc></sitemap>
 </sitemapindex>"""
 
 SITEMAP_PRODUCTS = b"""<?xml version="1.0"?>
@@ -61,25 +74,67 @@ SITEMAP_PRODUCTS = b"""<?xml version="1.0"?>
   <url><loc>https://shop.example/products/b</loc></url>
   <url><loc>https://shop.example/products/a</loc></url>
   <url><loc>https://elsewhere.example/products/c</loc></url>
+  <url><loc>http://shop.example/products/plain</loc></url>
 </urlset>"""
 
 
-def test_sitemap_walk_stays_on_the_signed_host_and_ignores_image_locs() -> None:
+def test_sitemap_walk_stays_on_the_signed_origin_and_ignores_image_locs() -> None:
     session = _Session({
         "https://shop.example/sitemap.xml": _Response(200, SITEMAP_INDEX),
         "https://shop.example/sitemap_products_1.xml": _Response(200, SITEMAP_PRODUCTS),
         "https://cdn.other.example/sitemap_evil.xml": _Response(200, SITEMAP_PRODUCTS),
+        "http://shop.example/sitemap_plain.xml": _Response(200, SITEMAP_PRODUCTS),
     })
     log: list[str] = []
-    urls = crawl.fetch_sitemap_urls(session, "https://shop.example", "shop.example",
-                                    crawl.RateLimitGovernor(0), sig_headers=SIG,
-                                    robots_text="Sitemap: https://shop.example/sitemap.xml\n",
-                                    log=log.append)
+    urls, stats = crawl.fetch_sitemap_urls(session, ORIGIN, crawl.RateLimitGovernor(0), sig_headers=SIG,
+                                           robots_text="Sitemap: https://shop.example/sitemap.xml\n",
+                                           log=log.append)
     assert urls == ["https://shop.example/products/a", "https://shop.example/products/b"]
     fetched = [url for url, _ in session.calls]
-    assert "https://cdn.other.example/sitemap_evil.xml" not in fetched
+    assert fetched == ["https://shop.example/sitemap.xml", "https://shop.example/sitemap_products_1.xml"]
     assert all(headers.get("Signature") == "sig1=:x:" for url, headers in session.calls)
-    assert any("skipped 2 sitemap entries outside shop.example" in line for line in log)
+    assert stats["skipped_foreign"] == 4
+    assert stats["discovery_capped"] is None
+
+
+def test_sitemap_walk_stops_on_a_deep_index_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    def chain(url: str) -> _Response:
+        level = int(url.rsplit("-", 1)[-1]) if "-" in url else 0
+        body = (f'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+                f'<sitemap><loc>https://shop.example/index-{level + 1}</loc></sitemap></sitemapindex>')
+        return _Response(200, body.encode())
+
+    session = _Session(factory=chain)
+    urls, stats = crawl.fetch_sitemap_urls(session, ORIGIN, crawl.RateLimitGovernor(0), log=lambda _m: None)
+    assert urls == []
+    assert stats["discovery_capped"].startswith("sitemap index nested deeper than")
+    assert stats["sitemaps_fetched"] == crawl.MAX_SITEMAP_DEPTH
+
+
+def test_sitemap_walk_stops_at_the_sitemap_count_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crawl, "MAX_SITEMAPS", 3)
+    many = "".join(f"<sitemap><loc>https://shop.example/child-{i}</loc></sitemap>" for i in range(10))
+
+    def fan_out(url: str) -> _Response:
+        if url.endswith("sitemap.xml"):
+            return _Response(200, f'<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{many}</sitemapindex>'.encode())
+        return _Response(200, f'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>{url}/p</loc></url></urlset>'.encode())
+
+    session = _Session(factory=fan_out)
+    urls, stats = crawl.fetch_sitemap_urls(session, ORIGIN, crawl.RateLimitGovernor(0), log=lambda _m: None)
+    assert stats["sitemaps_fetched"] == 3
+    assert stats["discovery_capped"] == "more than 3 sitemaps"
+    assert len(urls) == 2
+
+
+def test_oversized_sitemap_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crawl, "MAX_SITEMAP_BYTES", 100)
+    big = b'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' + b"<url><loc>https://shop.example/p</loc></url>" * 20 + b"</urlset>"
+    session = _Session({"https://shop.example/sitemap.xml": _Response(200, big)})
+    log: list[str] = []
+    urls, _ = crawl.fetch_sitemap_urls(session, ORIGIN, crawl.RateLimitGovernor(0), log=log.append)
+    assert urls == []
+    assert any("larger than 100 bytes" in line for line in log)
 
 
 def test_sitemap_with_doctype_is_rejected() -> None:
@@ -87,19 +142,21 @@ def test_sitemap_with_doctype_is_rejected() -> None:
         crawl.sitemap_locs(b'<!DOCTYPE x [<!ENTITY e "x">]><urlset><url><loc>&e;</loc></url></urlset>')
 
 
-def test_signature_is_only_attached_to_the_issuing_authority() -> None:
-    signed = crawl.headers_for("https://shop.example/products/a", "shop.example", SIG)
-    foreign = crawl.headers_for("https://www.shop.example/products/a", "shop.example", SIG)
+def test_signature_is_only_attached_to_the_issuing_origin() -> None:
+    signed = crawl.headers_for("https://shop.example/products/a", ORIGIN, SIG)
+    other_host = crawl.headers_for("https://www.shop.example/products/a", ORIGIN, SIG)
+    cleartext = crawl.headers_for("http://shop.example/products/a", ORIGIN, SIG)
     assert signed["Signature-Input"] == "sig1=(...)"
-    assert "Signature" not in foreign
-    assert foreign["User-Agent"] == crawl.USER_AGENT
+    assert "Signature" not in other_host
+    assert "Signature" not in cleartext
+    assert other_host["User-Agent"] == crawl.USER_AGENT
 
 
-def test_crawl_one_records_redirects_without_following(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_crawl_one_records_redirects_without_following() -> None:
     session = _Session({
         "https://shop.example/products/old": _Response(301, headers={"Location": "https://evil.example/"}),
     })
-    record = crawl.crawl_one(session, "https://shop.example/products/old", "shop.example", None,
+    record = crawl.crawl_one(lambda: session, "https://shop.example/products/old", ORIGIN, None,
                              crawl.RateLimitGovernor(0), timeout=5, save_html_dir=None)
     assert record["status"] == 301
     assert record["redirect_to"] == "https://evil.example/"
@@ -107,15 +164,64 @@ def test_crawl_one_records_redirects_without_following(monkeypatch: pytest.Monke
     assert [url for url, _ in session.calls] == ["https://shop.example/products/old"]
 
 
+def test_crawl_one_bounds_the_page_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crawl, "MAX_PAGE_BYTES", 1000)
+    response = _Response(200, b"<html><title>big</title>" + b"x" * 5000, headers={"Content-Type": "text/html"})
+    session = _Session({"https://shop.example/products/big": response})
+    record = crawl.crawl_one(lambda: session, "https://shop.example/products/big", ORIGIN, None,
+                             crawl.RateLimitGovernor(0), timeout=5, save_html_dir=None)
+    assert record["too_large"] is True
+    assert record["html"] is False
+    assert "title" not in record
+    assert response.closed
+
+
+def test_crawl_one_uses_the_worker_session_and_analyzes_html() -> None:
+    response = _Response(200, b"<html><title>Bottle</title><h1>x</h1></html>", headers={"Content-Type": "text/html; charset=utf-8"})
+    session = _Session({"https://shop.example/products/a": response})
+    calls = []
+
+    def session_for():
+        calls.append(1)
+        return session
+
+    record = crawl.crawl_one(session_for, "https://shop.example/products/a", ORIGIN, SIG,
+                             crawl.RateLimitGovernor(0), timeout=5, save_html_dir=None)
+    assert calls == [1]
+    assert record["title"] == "Bottle"
+    assert record["signed"] is True
+    assert response.closed
+
+
 def test_rate_limit_on_signed_request_is_recorded(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(crawl.time, "sleep", lambda _seconds: None)
     session = _Session({"https://shop.example/products/a": _Response(430)})
     governor = crawl.RateLimitGovernor(0)
-    record = crawl.crawl_one(session, "https://shop.example/products/a", "shop.example", SIG,
+    record = crawl.crawl_one(lambda: session, "https://shop.example/products/a", ORIGIN, SIG,
                              governor, timeout=5, save_html_dir=None)
     assert record["rate_limited"] is True
     assert record["failed"] is True
     assert governor.hits == 4
+
+
+def test_thread_sessions_are_per_thread() -> None:
+    import threading
+
+    sessions = crawl.ThreadSessions()
+    seen = []
+
+    def worker():
+        seen.append(id(sessions.get()))
+        seen.append(id(sessions.get()))
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert len(seen) == 6
+    assert len(set(seen)) == 3
+    sessions.close()
 
 
 def test_classify_templates() -> None:
@@ -165,18 +271,21 @@ def test_summary_counts_only_html_documents_and_flags_duplicates() -> None:
         {"url": "https://s.example/products/gone", "status": 404, "template": "product"},
         {"url": "https://s.example/products/moved", "status": 301, "template": "product",
          "redirect_to": "https://s.example/products/a"},
+        {"url": "https://s.example/products/huge", "status": 200, "html": False, "template": "product",
+         "elapsed_ms": 900, "content_type": "text/html", "too_large": True},
     ]
     summary = crawl.summarize(records)
-    assert summary["pages_crawled"] == 5
+    assert summary["pages_crawled"] == 6
     assert summary["html_documents"] == 2
-    assert summary["non_html_resources"] == 1
+    assert summary["non_html_resources"] == 2
     assert summary["redirects"] == 1
+    assert summary["too_large"] == 1
     assert summary["issues"]["missing_title"] == 0
     assert summary["issues"]["duplicate_titles"] == 2
     assert summary["issues"]["missing_meta_description"] == 2
     assert summary["issues"]["h1_missing"] == 2
     assert summary["duplicate_title_examples"] == ["Same"]
-    assert summary["status_distribution"] == {"200": 3, "404": 1, "301": 1}
+    assert summary["status_distribution"] == {"200": 4, "404": 1, "301": 1}
 
 
 def test_settings_precedence_cli_over_block_over_global_over_builtin() -> None:

--- a/tests/test_shopify_crawl.py
+++ b/tests/test_shopify_crawl.py
@@ -1,0 +1,203 @@
+"""Shopify crawler: sitemap walk, host binding of the signature, HTML signals, summary."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+pytest.importorskip("lxml")
+pytest.importorskip("requests")
+
+SPEC = importlib.util.spec_from_file_location("shopify_crawl", SCRIPTS / "shopify_crawl.py")
+assert SPEC and SPEC.loader
+crawl = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(crawl)
+
+SIG = {"Signature-Agent": '"https://shopify.com"', "Signature-Input": "sig1=(...)", "Signature": "sig1=:x:"}
+
+
+class _Response:
+    def __init__(self, status: int, content: bytes = b"", headers: dict | None = None):
+        self.status_code = status
+        self.content = content
+        self.text = content.decode("utf-8", "replace")
+        self.headers = headers or {}
+
+
+class _Session:
+    """Serves canned responses and records which headers each URL received."""
+
+    def __init__(self, routes: dict[str, _Response]):
+        self.routes = routes
+        self.calls: list[tuple[str, dict]] = []
+        self.headers: dict = {}
+
+    def get(self, url, headers=None, **kwargs):
+        self.calls.append((url, dict(headers or {})))
+        return self.routes.get(url, _Response(404))
+
+
+SITEMAP_INDEX = b"""<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://shop.example/sitemap_products_1.xml</loc></sitemap>
+  <sitemap><loc>https://cdn.other.example/sitemap_evil.xml</loc></sitemap>
+</sitemapindex>"""
+
+SITEMAP_PRODUCTS = b"""<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>https://shop.example/products/a</loc>
+    <image:image><image:loc>https://cdn.shopify.com/a.jpg</image:loc></image:image>
+  </url>
+  <url><loc>https://shop.example/products/b</loc></url>
+  <url><loc>https://shop.example/products/a</loc></url>
+  <url><loc>https://elsewhere.example/products/c</loc></url>
+</urlset>"""
+
+
+def test_sitemap_walk_stays_on_the_signed_host_and_ignores_image_locs() -> None:
+    session = _Session({
+        "https://shop.example/sitemap.xml": _Response(200, SITEMAP_INDEX),
+        "https://shop.example/sitemap_products_1.xml": _Response(200, SITEMAP_PRODUCTS),
+        "https://cdn.other.example/sitemap_evil.xml": _Response(200, SITEMAP_PRODUCTS),
+    })
+    log: list[str] = []
+    urls = crawl.fetch_sitemap_urls(session, "https://shop.example", "shop.example",
+                                    crawl.RateLimitGovernor(0), sig_headers=SIG,
+                                    robots_text="Sitemap: https://shop.example/sitemap.xml\n",
+                                    log=log.append)
+    assert urls == ["https://shop.example/products/a", "https://shop.example/products/b"]
+    fetched = [url for url, _ in session.calls]
+    assert "https://cdn.other.example/sitemap_evil.xml" not in fetched
+    assert all(headers.get("Signature") == "sig1=:x:" for url, headers in session.calls)
+    assert any("skipped 2 sitemap entries outside shop.example" in line for line in log)
+
+
+def test_sitemap_with_doctype_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        crawl.sitemap_locs(b'<!DOCTYPE x [<!ENTITY e "x">]><urlset><url><loc>&e;</loc></url></urlset>')
+
+
+def test_signature_is_only_attached_to_the_issuing_authority() -> None:
+    signed = crawl.headers_for("https://shop.example/products/a", "shop.example", SIG)
+    foreign = crawl.headers_for("https://www.shop.example/products/a", "shop.example", SIG)
+    assert signed["Signature-Input"] == "sig1=(...)"
+    assert "Signature" not in foreign
+    assert foreign["User-Agent"] == crawl.USER_AGENT
+
+
+def test_crawl_one_records_redirects_without_following(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _Session({
+        "https://shop.example/products/old": _Response(301, headers={"Location": "https://evil.example/"}),
+    })
+    record = crawl.crawl_one(session, "https://shop.example/products/old", "shop.example", None,
+                             crawl.RateLimitGovernor(0), timeout=5, save_html_dir=None)
+    assert record["status"] == 301
+    assert record["redirect_to"] == "https://evil.example/"
+    assert record["html"] is False
+    assert [url for url, _ in session.calls] == ["https://shop.example/products/old"]
+
+
+def test_rate_limit_on_signed_request_is_recorded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crawl.time, "sleep", lambda _seconds: None)
+    session = _Session({"https://shop.example/products/a": _Response(430)})
+    governor = crawl.RateLimitGovernor(0)
+    record = crawl.crawl_one(session, "https://shop.example/products/a", "shop.example", SIG,
+                             governor, timeout=5, save_html_dir=None)
+    assert record["rate_limited"] is True
+    assert record["failed"] is True
+    assert governor.hits == 4
+
+
+def test_classify_templates() -> None:
+    assert crawl.classify("https://s.example/") == "home"
+    assert crawl.classify("https://s.example/products/x") == "product"
+    assert crawl.classify("https://s.example/collections/all") == "collection"
+    assert crawl.classify("https://s.example/collections/all?filter=1") == "collection_filtered"
+    assert crawl.classify("https://s.example/blogs/news/post") == "blog_article"
+    assert crawl.classify("https://s.example/blogs/news") == "blog_index"
+    assert crawl.classify("https://s.example/policies/refund-policy") == "policy"
+    assert crawl.classify("https://s.example/pages/about") == "page"
+
+
+def test_analyze_html_extracts_signals_from_visible_markup() -> None:
+    html = """
+    <html><head><title> Blue   Bottle </title>
+    <meta name="description" content="A bottle.">
+    <link rel="canonical" href="https://s.example/products/bottle">
+    <link rel="alternate" hreflang="de" href="https://s.example/de/products/bottle">
+    <script type="application/ld+json">{"@type": "Product", "offers": {"@type": "Offer"}}</script>
+    </head><body><h1>Bottle</h1>
+    <img src="a.jpg" alt="bottle"><img src="b.jpg">
+    <script type="text/template"><img src="hidden.jpg"></script>
+    <noscript><img src="ns.jpg"></noscript>
+    <p>word word word</p></body></html>
+    """
+    signals = crawl.analyze_html(html)
+    assert signals["title"] == "Blue Bottle"
+    assert signals["meta_description_length"] == 9
+    assert signals["canonical"] == "https://s.example/products/bottle"
+    assert signals["hreflang"] == ["de"]
+    assert signals["schema_types"] == ["Offer", "Product"]
+    assert signals["h1_count"] == 1
+    assert signals["image_count"] == 2
+    assert signals["images_without_alt"] == 1
+
+
+def test_summary_counts_only_html_documents_and_flags_duplicates() -> None:
+    page = {"status": 200, "html": True, "template": "product", "elapsed_ms": 100,
+            "content_type": "text/html", "title": "Same", "title_length": 4,
+            "meta_description": None, "canonical": None, "h1_count": 0, "word_count": 10}
+    records = [
+        dict(page, url="https://s.example/products/a"),
+        dict(page, url="https://s.example/products/b"),
+        {"url": "https://s.example/agents.md", "status": 200, "html": False, "template": "page",
+         "elapsed_ms": 50, "content_type": "text/markdown"},
+        {"url": "https://s.example/products/gone", "status": 404, "template": "product"},
+        {"url": "https://s.example/products/moved", "status": 301, "template": "product",
+         "redirect_to": "https://s.example/products/a"},
+    ]
+    summary = crawl.summarize(records)
+    assert summary["pages_crawled"] == 5
+    assert summary["html_documents"] == 2
+    assert summary["non_html_resources"] == 1
+    assert summary["redirects"] == 1
+    assert summary["issues"]["missing_title"] == 0
+    assert summary["issues"]["duplicate_titles"] == 2
+    assert summary["issues"]["missing_meta_description"] == 2
+    assert summary["issues"]["h1_missing"] == 2
+    assert summary["duplicate_title_examples"] == ["Same"]
+    assert summary["status_distribution"] == {"200": 3, "404": 1, "301": 1}
+
+
+def test_settings_precedence_cli_over_block_over_global_over_builtin() -> None:
+    args = SimpleNamespace(max_pages=None, concurrency=4, delay=None, timeout=None,
+                           sample_per_template=None, include=None, exclude=None,
+                           save_html=None, ignore_robots=None)
+    env = {"crawl": {"max_pages": 100, "concurrency": 8, "delay": 0.5}}
+    entry = {"crawl": {"max_pages": 200}}
+    crawl.resolve_settings(args, env, entry, signed=True)
+    assert args.concurrency == 4
+    assert args.max_pages == 200
+    assert args.delay == 0.5
+    assert args.timeout == 30
+
+    unsigned = SimpleNamespace(max_pages=None, concurrency=None, delay=None, timeout=None,
+                               sample_per_template=None, include=None, exclude=None,
+                               save_html=None, ignore_robots=None)
+    crawl.resolve_settings(unsigned, {"crawl": {}}, None, signed=False)
+    assert (unsigned.concurrency, unsigned.delay, unsigned.max_pages) == (2, 1.0, 0)
+
+
+def test_main_refuses_unsafe_roots(capsys: pytest.CaptureFixture[str]) -> None:
+    assert crawl.main(["http://127.0.0.1/", "--out", "unused"]) == 1
+    assert "Error:" in capsys.readouterr().err

--- a/tests/test_shopify_env.py
+++ b/tests/test_shopify_env.py
@@ -133,7 +133,20 @@ def test_precheck_never_raises_on_an_unreadable_file(
     assert result["reason"] == "env_unreadable"
 
 
-def test_headers_cli_prints_the_three_headers_or_nothing(
+def test_signature_headers_are_the_three_verbatim_values(tmp_path: Path) -> None:
+    path = _write_env(tmp_path, f"""
+        Domain = shop.example
+        Signature-Input = {_signature_input(FUTURE)}
+        Signature = sig1=:ok:
+    """)
+    entry = shopify_env.parse_env_file(path)["authorities"]["shop.example"]
+    headers = shopify_env.signature_headers(entry)
+    assert set(headers) == {"Signature-Agent", "Signature-Input", "Signature"}
+    assert headers["Signature-Agent"] == '"https://shopify.com"'
+    assert headers["Signature"] == "sig1=:ok:"
+
+
+def test_no_cli_command_prints_signature_values(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.delenv(shopify_env.ENV_PATH_VAR, raising=False)
@@ -141,14 +154,15 @@ def test_headers_cli_prints_the_three_headers_or_nothing(
     _write_env(tmp_path, f"""
         Domain = shop.example
         Signature-Input = {_signature_input(FUTURE)}
-        Signature = sig1=:ok:
+        Signature = sig1=:SECRETVALUE:
     """)
-    assert shopify_env.main(["headers", "https://shop.example/collections/all"]) == 0
-    headers = json.loads(capsys.readouterr().out)
-    assert set(headers) == {"Signature-Agent", "Signature-Input", "Signature"}
-    assert headers["Signature-Agent"] == '"https://shopify.com"'
-    assert shopify_env.main(["headers", "https://other.example"]) == 3
-    assert capsys.readouterr().out.strip() == "{}"
+    for argv in (["list"], ["list", "--json"], ["check", "https://shop.example"],
+                 ["check", "https://shop.example", "--json"], ["precheck", "https://shop.example"]):
+        shopify_env.main(argv)
+        captured = capsys.readouterr()
+        assert "SECRETVALUE" not in captured.out + captured.err, argv
+    with pytest.raises(SystemExit):
+        shopify_env.main(["headers", "https://shop.example"])
 
 
 def test_list_json_never_prints_signature_values(

--- a/tests/test_shopify_env.py
+++ b/tests/test_shopify_env.py
@@ -1,0 +1,167 @@
+"""`.shopify-env` parsing, lookup precedence, and the audit precheck contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("shopify_env", ROOT / "scripts" / "shopify_env.py")
+assert SPEC and SPEC.loader
+shopify_env = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(shopify_env)
+
+FUTURE = int(time.time()) + 30 * 86400
+PAST = int(time.time()) - 86400
+
+
+def _signature_input(expires: int, tag: str = "web-bot-auth") -> str:
+    return (f'sig1=("@authority" "signature-agent");keyid="key-1";nonce="n";'
+            f'tag="{tag}";created=1700000000;expires={expires}')
+
+
+def _write_env(directory: Path, body: str) -> Path:
+    path = directory / shopify_env.ENV_FILENAME
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_blocks_globals_and_verbatim_header_values(tmp_path: Path) -> None:
+    path = _write_env(tmp_path, f"""
+        # shared settings
+        Max-Pages = 0
+        Concurrency = 6
+        Save-HTML = yes
+
+        Domain = Shop.Example
+        Signature-Input = {_signature_input(FUTURE)}
+        Signature = sig1=:AbC==:
+        Signature-Agent = https://shopify.com
+        Concurrency = 3
+
+        [second.example]
+        Signature-Input = {_signature_input(FUTURE)}
+        Signature = sig1=:XyZ==:
+    """)
+    env = shopify_env.parse_env_file(path)
+    assert env["problems"] == []
+    assert env["crawl"] == {"max_pages": 0, "concurrency": 6, "save_html": True}
+    shop = env["authorities"]["shop.example"]
+    assert shop["signature"] == "sig1=:AbC==:"
+    assert shop["signature_agent"] == '"https://shopify.com"'
+    assert shop["keyid"] == "key-1"
+    assert shop["expires"] == FUTURE
+    assert shop["crawl"] == {"concurrency": 3}
+    assert "second.example" in env["authorities"]
+
+
+def test_incomplete_blocks_are_skipped_with_a_problem(tmp_path: Path) -> None:
+    path = _write_env(tmp_path, f"""
+        Signature = sig1=:orphan:
+        Domain = shop.example
+        Signature-Input = {_signature_input(FUTURE)}
+        Domain = other.example
+        Signature-Input = {_signature_input(FUTURE, tag="wrong")}
+        Signature = sig1=:ok:
+        Unknown-Key = 1
+        no equals sign here
+    """)
+    env = shopify_env.parse_env_file(path)
+    assert "shop.example" not in env["authorities"]
+    assert "other.example" in env["authorities"]
+    joined = "\n".join(env["problems"])
+    assert "before any Domain=" in joined
+    assert "shop.example: missing signature" in joined
+    assert "other.example: tag is 'wrong'" in joined
+    assert "unknown key 'unknown-key'" in joined
+    assert "no '='" in joined
+
+
+def test_env_file_is_found_in_parents_and_via_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(shopify_env.ENV_PATH_VAR, raising=False)
+    path = _write_env(tmp_path, "Domain = shop.example\n")
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    assert shopify_env.find_env_file(nested) == path
+
+    explicit = tmp_path / "elsewhere.env"
+    explicit.write_text("Domain = shop.example\n", encoding="utf-8")
+    monkeypatch.setenv(shopify_env.ENV_PATH_VAR, str(explicit))
+    assert shopify_env.find_env_file(nested) == explicit
+    monkeypatch.setenv(shopify_env.ENV_PATH_VAR, str(tmp_path / "missing.env"))
+    assert shopify_env.find_env_file(nested) is None
+
+
+def test_precheck_modes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(shopify_env.ENV_PATH_VAR, raising=False)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert shopify_env.precheck("https://shop.example", empty)["reason"] == "no_env_file"
+
+    _write_env(tmp_path, f"""
+        Domain = shop.example
+        Signature-Input = {_signature_input(FUTURE)}
+        Signature = sig1=:ok:
+        Domain = old.example
+        Signature-Input = {_signature_input(PAST)}
+        Signature = sig1=:old:
+    """)
+    signed = shopify_env.precheck("https://shop.example/products/x", tmp_path)
+    assert signed["mode"] == "signed"
+    assert signed["authority"] == "shop.example"
+    assert 28 <= signed["days_left"] <= 30
+    assert shopify_env.precheck("https://www.shop.example", tmp_path)["reason"] == "no_signature"
+    assert shopify_env.precheck("https://old.example", tmp_path)["reason"] == "signature_expired"
+    for result in (signed, shopify_env.precheck("https://old.example", tmp_path)):
+        assert result["mode"] in ("signed", "fallback")
+
+
+def test_precheck_never_raises_on_an_unreadable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(shopify_env.ENV_PATH_VAR, raising=False)
+    path = _write_env(tmp_path, "Domain = shop.example\n")
+    path.write_bytes(b"\xff\xfe\x00broken")
+    result = shopify_env.precheck("https://shop.example", tmp_path)
+    assert result["mode"] == "fallback"
+    assert result["reason"] == "env_unreadable"
+
+
+def test_headers_cli_prints_the_three_headers_or_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv(shopify_env.ENV_PATH_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    _write_env(tmp_path, f"""
+        Domain = shop.example
+        Signature-Input = {_signature_input(FUTURE)}
+        Signature = sig1=:ok:
+    """)
+    assert shopify_env.main(["headers", "https://shop.example/collections/all"]) == 0
+    headers = json.loads(capsys.readouterr().out)
+    assert set(headers) == {"Signature-Agent", "Signature-Input", "Signature"}
+    assert headers["Signature-Agent"] == '"https://shopify.com"'
+    assert shopify_env.main(["headers", "https://other.example"]) == 3
+    assert capsys.readouterr().out.strip() == "{}"
+
+
+def test_list_json_never_prints_signature_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv(shopify_env.ENV_PATH_VAR, raising=False)
+    monkeypatch.chdir(tmp_path)
+    _write_env(tmp_path, f"""
+        Domain = shop.example
+        Signature-Input = {_signature_input(FUTURE)}
+        Signature = sig1=:SECRETVALUE:
+    """)
+    assert shopify_env.main(["list", "--json"]) == 0
+    out = capsys.readouterr().out
+    assert "SECRETVALUE" not in out
+    assert json.loads(out)["authorities"]["shop.example"]["keyid"] == "key-1"


### PR DESCRIPTION
`seo-audit` caps its link crawl at 500 pages and Shopify rate-limits storefront crawling, so large Shopify stores are audited from a sample. A merchant's Crawler Access signature lifts the rate limit and Shopify's complete sitemap removes the need for a cap. Closes #301.

`shopify_env.py` reads the signature and per-shop settings from a project-local `.shopify-env` and answers `precheck`; `shopify_crawl.py` crawls the sitemap through the pinned `url_safety` session, sends the signature to its issuing host only, records redirects without following them, and writes `summary.json`, `sample.json` and `pages.jsonl`. The `seo-shopify` extension skill feeds those into the unchanged `seo-audit` pipeline; without a valid signature nothing changes.

Verified in:
- Windows 11, Python 3.14.4, repo checkout — full suite 527 passed, 18 skipped; `consistency_check.py` 0 errors; unsigned smoke crawl of a public Shopify store with `--max-pages 8`: 111 URLs discovered from the sitemap index, 8 crawled, `truncated: true`, three artifacts written; `precheck` and `list` against the example env from a separate folder
- Windows 11, Python 3.11.16 (uv, pytest+requests+lxml only) — the new tests plus extension, consistency, hosted-layout, manifest and runtime tests: 72 passed, 8 skipped
- Fork CI on Nordalux/claude-seo @1e1edb2 — test suite, portability (windows-latest, macos-latest), dependency audit, syntax check, secret scan all green
- Signed crawl against a real signature — not exercised in this run; the header binding and exit-5 path are unit-tested

Verified and tested by hand. The description was drafted with AI assistance — I'd rather let the diff do the talking than a long write-up.
